### PR TITLE
Response close leak

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ def commonAssemblySettings(module: String): immutable.Seq[Def.Setting[_]] = comm
   assemblyJarName := s"${name.value}.jar"
 )
 def commonSettings(module: String): immutable.Seq[Def.Setting[_]]  = {
-  val awsVersion: String = "1.11.315"
+  val awsVersion: String = "1.11.320"
   val specsVersion: String = "4.0.3"
   val log4j2Version: String = "2.10.0"
   val jacksonVersion: String = "2.9.5"

--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,7 @@ def commonSettings(module: String): immutable.Seq[Def.Setting[_]]  = {
     organization := "com.gu",
     description := "Validate Receipts",
     version := "1.0",
-    scalaVersion := "2.12.5",
+    scalaVersion := "2.12.6",
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding", "UTF-8",

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -192,7 +192,7 @@ Resources:
           Stack: !Ref Stack
           App: !Sub ${App}
       Description: Validates purchases
-      MemorySize: 320
+      MemorySize: 448
       Timeout: 45
       Events:
         PostApi:
@@ -218,7 +218,7 @@ Resources:
           Stack: !Ref Stack
           App: !Sub ${App}
       Description: Gets user purchases
-      MemorySize: 320
+      MemorySize: 448
       Timeout: 45
       Events:
         GetApi:

--- a/commonlambda/src/main/scala/com/gu/mobilepurchases/shared/cloudwatch/Cloudwatch.scala
+++ b/commonlambda/src/main/scala/com/gu/mobilepurchases/shared/cloudwatch/Cloudwatch.scala
@@ -3,7 +3,6 @@ package com.gu.mobilepurchases.shared.cloudwatch
 import java.time.{ Duration, Instant }
 import java.util
 import java.util.Date
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.{ ConcurrentLinkedQueue, TimeUnit }
 
 import com.amazonaws.handlers.AsyncHandler
@@ -36,7 +35,7 @@ sealed class Timer(metricName: String, cloudWatch: CloudWatchMetrics, start: Ins
 }
 
 class CloudWatchImpl(stage: String, lambdaname: String, cw: AmazonCloudWatchAsync) extends CloudWatch {
-  private val atomicLong: AtomicLong = new AtomicLong(0)
+
   private val logger: Logger = LogManager.getLogger(classOf[CloudWatchImpl])
   implicit private val ec: ExecutionContext = Parallelism.largeGlobalExecutionContext
   private val queue: ConcurrentLinkedQueue[MetricDatum] = new ConcurrentLinkedQueue[MetricDatum]()
@@ -60,7 +59,6 @@ class CloudWatchImpl(stage: String, lambdaname: String, cw: AmazonCloudWatchAsyn
       val value: AsyncHandler[PutMetricDataRequest, PutMetricDataResult] = new AsyncHandler[PutMetricDataRequest, PutMetricDataResult] {
         override def onError(exception: Exception): Unit = promise.failure(exception)
         override def onSuccess(request: PutMetricDataRequest, result: PutMetricDataResult): Unit = {
-
           promise.success(result)
         }
       }

--- a/commonlambda/src/main/scala/com/gu/mobilepurchases/shared/lambda/LambdaApiGateway.scala
+++ b/commonlambda/src/main/scala/com/gu/mobilepurchases/shared/lambda/LambdaApiGateway.scala
@@ -77,6 +77,7 @@ class LambdaApiGatewayImpl(function: (LambdaRequest => LambdaResponse)) extends 
   private val logger: Logger = LogManager.getLogger(classOf[LambdaApiGateway])
   def execute(input: InputStream, output: OutputStream): Unit = {
     try {
+
       mapper.writeValue(output, objectReadAndClose(input) match {
         case Right(apiGatewayLambdaRequest) =>
           if (apiGatewayLambdaRequest.isBase64Encoded) {

--- a/commonlambda/src/main/scala/com/gu/mobilepurchases/shared/lambda/LambdaApiGateway.scala
+++ b/commonlambda/src/main/scala/com/gu/mobilepurchases/shared/lambda/LambdaApiGateway.scala
@@ -84,9 +84,7 @@ class LambdaApiGatewayImpl(function: (LambdaRequest => LambdaResponse)) extends 
             ApiGatewayLambdaResponse(LambdaResponse(HttpStatusCodes.badRequest, Some("Binary content not supported"), Map("Content-Type" -> "text/plain")))
           } else {
             val lambdaRequest: LambdaRequest = LambdaRequest(apiGatewayLambdaRequest)
-            logger.info(lambdaRequest)
             val lambdaResponse: LambdaResponse = function(lambdaRequest)
-            logger.info(lambdaResponse)
             ApiGatewayLambdaResponse(lambdaResponse)
           }
         case Left(_) => ApiGatewayLambdaResponse(internalServerError)

--- a/commonlambda/src/main/scala/com/gu/mobilepurchases/shared/lambda/LambdaApiGateway.scala
+++ b/commonlambda/src/main/scala/com/gu/mobilepurchases/shared/lambda/LambdaApiGateway.scala
@@ -84,7 +84,9 @@ class LambdaApiGatewayImpl(function: (LambdaRequest => LambdaResponse)) extends 
             ApiGatewayLambdaResponse(LambdaResponse(HttpStatusCodes.badRequest, Some("Binary content not supported"), Map("Content-Type" -> "text/plain")))
           } else {
             val lambdaRequest: LambdaRequest = LambdaRequest(apiGatewayLambdaRequest)
+            logger.info(lambdaRequest)
             val lambdaResponse: LambdaResponse = function(lambdaRequest)
+            logger.info(lambdaResponse)
             ApiGatewayLambdaResponse(lambdaResponse)
           }
         case Left(_) => ApiGatewayLambdaResponse(internalServerError)

--- a/iosuserpurchases/src/main/scala/com/gu/mobilepurchases/userpurchases/purchases/UserPurchases.scala
+++ b/iosuserpurchases/src/main/scala/com/gu/mobilepurchases/userpurchases/purchases/UserPurchases.scala
@@ -20,7 +20,7 @@ class UserPurchasesImpl(
 
   override def findPurchases(userPurchasesRequest: UserPurchasesRequest): UserPurchasesResponse = {
     UserPurchasesResponse(userPurchasesRequest.userIds
-      .filter(_.startsWith("vendorUdid~"))
+      .filter((_: String).startsWith("vendorUdid~"))
       .map(userPurchasePersistence.read(_: String, userPurchasesRequest.appId))
       .flatMap {
         case Success(userPurchasesByUserIdAndAppId) => userPurchasesByUserIdAndAppId.map((_: UserPurchasesByUserIdAndAppId).purchases).getOrElse(Set())

--- a/userpurchasepersistence/src/test/scala/com/gu/mobilepurchases/userpurchases/persistence/UserPurchasePersistenceImplSpec.scala
+++ b/userpurchasepersistence/src/test/scala/com/gu/mobilepurchases/userpurchases/persistence/UserPurchasePersistenceImplSpec.scala
@@ -72,7 +72,6 @@ class UserPurchasePersistenceImplSpec extends Specification with Mockito {
     }
     "read failure" in {
       val mockClock: Clock = buildMockClock
-
       val userPurchasePersistenceTransformer = new UserPurchasePersistenceTransformer(mockClock)
       new UserPurchasePersistenceImpl(new ScanamaoUserPurchasesStringsByUserIdColonAppId {
         override def put(t: UserPurchasesStringsByUserIdColonAppId): Option[Either[DynamoReadError, UserPurchasesStringsByUserIdColonAppId]] = ???


### PR DESCRIPTION
Response close doesn't appear to have been the cause of the leak as it still appeared.
We might just be running out of memory as the various thread/connection pools get fully allocated (we've got a few if you consider how many aws clients we've got along with our own needs for okhttp).
Upgrading memory seems to work much better.