### PR TITLE
Fixing purchase parsing failure, which has no purchase data

### DIFF
--- a/iosuserpurchases/src/main/scala/com/gu/mobilepurchases/userpurchases/controller/UserPurchasesController.scala
+++ b/iosuserpurchases/src/main/scala/com/gu/mobilepurchases/userpurchases/controller/UserPurchasesController.scala
@@ -2,11 +2,12 @@ package com.gu.mobilepurchases.userpurchases.controller
 
 import java.nio.charset.StandardCharsets
 
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import com.gu.mobilepurchases.shared.cloudwatch.CloudWatchMetrics
 import com.gu.mobilepurchases.shared.external.HttpStatusCodes
 import com.gu.mobilepurchases.shared.external.HttpStatusCodes.okCode
 import com.gu.mobilepurchases.shared.external.Jackson.mapper
 import com.gu.mobilepurchases.shared.lambda.{ LambdaRequest, LambdaResponse }
-import com.gu.mobilepurchases.userpurchases.controller.UserPurchasesController.emptyPurchasesResponse
 import com.gu.mobilepurchases.userpurchases.purchases.{ UserPurchases, UserPurchasesRequest, UserPurchasesResponse }
 import org.apache.http.HttpHeaders
 import org.apache.http.entity.ContentType
@@ -17,11 +18,10 @@ import scala.util.{ Failure, Success, Try }
 object UserPurchasesController {
   val errorHeaders: Map[String, String] = Map(HttpHeaders.CONTENT_TYPE -> ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8).toString)
   val defaultHeaders: Map[String, String] = Map(HttpHeaders.CONTENT_TYPE -> ContentType.APPLICATION_JSON.toString)
-  val emptyPurchasesResponse: LambdaResponse = LambdaResponse(okCode, Some(mapper.writeValueAsString(UserPurchasesResponse(Set()))), defaultHeaders)
   private val serverError: LambdaResponse = LambdaResponse(HttpStatusCodes.internalServerError, Some("Failed to process request"), errorHeaders)
 }
 
-class UserPurchasesController(userPurchases: UserPurchases) extends Function[LambdaRequest, LambdaResponse] {
+class UserPurchasesController(userPurchases: UserPurchases, cloudWatchMetrics: CloudWatchMetrics) extends Function[LambdaRequest, LambdaResponse] {
   val logger = LogManager.getLogger(classOf[UserPurchasesController])
   override def apply(lambdaRequest: LambdaRequest): LambdaResponse = {
     val parameters: Map[String, String] = lambdaRequest.queryStringParameters
@@ -35,11 +35,15 @@ class UserPurchasesController(userPurchases: UserPurchases) extends Function[Lam
           Some(mapper.writeValueAsString(purchases)),
           UserPurchasesController.defaultHeaders
         ))
-        .getOrElse(emptyPurchasesResponse)
+        .getOrElse({
+          cloudWatchMetrics.queueMetric("failed", 1, StandardUnit.Count)
+          UserPurchasesController.serverError
+        })
     } match {
       case Success(response) => response
       case Failure(throwable) => {
         logger.warn("Error executing lambda", throwable)
+        cloudWatchMetrics.queueMetric("failed", 1, StandardUnit.Count)
         UserPurchasesController.serverError
       }
     }

--- a/iosuserpurchases/src/main/scala/com/gu/mobilepurchases/userpurchases/lambda/UserPurchasesLambda.scala
+++ b/iosuserpurchases/src/main/scala/com/gu/mobilepurchases/userpurchases/lambda/UserPurchasesLambda.scala
@@ -23,7 +23,7 @@ object UserPurchasesLambda {
   def userPurchasesController(userPurchaseConfig: UserPurchaseConfig, clock: Clock, cloudWatch: CloudWatchMetrics): UserPurchasesController = Logging.logOnThrown(() =>
     new UserPurchasesController(new UserPurchasesImpl(new UserPurchasePersistenceImpl(
       ScanamaoUserPurchasesStringsByUserIdColonAppIdImpl(
-        userPurchaseConfig), new UserPurchasePersistenceTransformer(clock), cloudWatch))), "Error instantiating UserPurchasesLambda", Some(classOf[UserPurchasesLambda]))
+        userPurchaseConfig), new UserPurchasePersistenceTransformer(clock), cloudWatch)), cloudWatch), "Error instantiating UserPurchasesLambda", Some(classOf[UserPurchasesLambda]))
 }
 
 class UserPurchasesLambda(userPurchaseConfig: UserPurchaseConfig, cloudWatch: CloudWatch, clock: Clock) extends AwsLambda(UserPurchasesLambda.userPurchasesController(userPurchaseConfig, clock, cloudWatch), cloudWatch = cloudWatch) {

--- a/iosuserpurchases/src/test/scala/com/gu/mobilepurchases/userpurchases/lambda/DelegateUserPurchasesLambdaSpec.scala
+++ b/iosuserpurchases/src/test/scala/com/gu/mobilepurchases/userpurchases/lambda/DelegateUserPurchasesLambdaSpec.scala
@@ -27,7 +27,7 @@ class DelegateUserPurchasesLambdaSpec extends Specification with Mockito {
           "userIds" -> "gnmUdid~gia:D39DE40D-CF02-4DFC-96F7-3BF6CA2C1A25,vendorUdid~DB19C9CB-5539-4BF8-B76A-44B9BEB36E22"))))
     "return lambda failure when both fail" in {
 
-      val userPurchasesController = new UserPurchasesController((userPurchasesRequest: UserPurchasesRequest) => throw new IllegalStateException("lambda failed"))
+      val userPurchasesController = new UserPurchasesController((userPurchasesRequest: UserPurchasesRequest) => throw new IllegalStateException("lambda failed"), cloudWatchImpl)
       val inputStream: InputStream = new ByteArrayInputStream(expectedApiGatewayRequest)
       val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
       val client: OkHttpClient = mock[OkHttpClient]
@@ -54,7 +54,7 @@ class DelegateUserPurchasesLambdaSpec extends Specification with Mockito {
     val expectedDelegateResponse: UserPurchasesResponse = UserPurchasesResponse(Set(UserPurchase("delegateProductId", "delegateWebOrderLineItemid", UserPurchaseInterval("delegateStart", "delegateEnd"))))
     "return lambda success when delegate fails" in {
 
-      val userPurchasesController = new UserPurchasesController((userPurchasesRequest: UserPurchasesRequest) => expectedLambdaResponse)
+      val userPurchasesController = new UserPurchasesController((userPurchasesRequest: UserPurchasesRequest) => expectedLambdaResponse, cloudWatchImpl)
       val inputStream: InputStream = new ByteArrayInputStream(expectedApiGatewayRequest)
       val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
       val client: OkHttpClient = mock[OkHttpClient]
@@ -81,7 +81,7 @@ class DelegateUserPurchasesLambdaSpec extends Specification with Mockito {
     }
     "return delegate when lambda fails" in {
 
-      val userPurchasesController = new UserPurchasesController((userPurchasesRequest: UserPurchasesRequest) => throw new IllegalStateException("lambda failed"))
+      val userPurchasesController = new UserPurchasesController((userPurchasesRequest: UserPurchasesRequest) => throw new IllegalStateException("lambda failed"), cloudWatchImpl)
       val inputStream: InputStream = new ByteArrayInputStream(expectedApiGatewayRequest)
       val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
       val client: OkHttpClient = mock[OkHttpClient]
@@ -110,7 +110,7 @@ class DelegateUserPurchasesLambdaSpec extends Specification with Mockito {
 
     "prefer delegate over lambda" in {
 
-      val userPurchasesController = new UserPurchasesController((userPurchasesRequest: UserPurchasesRequest) => expectedLambdaResponse)
+      val userPurchasesController = new UserPurchasesController((userPurchasesRequest: UserPurchasesRequest) => expectedLambdaResponse, cloudWatchImpl)
       val inputStream: InputStream = new ByteArrayInputStream(expectedApiGatewayRequest)
       val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
       val client: OkHttpClient = mock[OkHttpClient]

--- a/iosvalidatereceipts/src/main/scala/com/gu/mobilepurchases/lambda/ValidateReceiptLambda.scala
+++ b/iosvalidatereceipts/src/main/scala/com/gu/mobilepurchases/lambda/ValidateReceiptLambda.scala
@@ -30,7 +30,7 @@ object ValidateReceiptLambda {
           ScanamaoUserPurchasesStringsByUserIdColonAppIdImpl(UserPurchaseConfig(ssmConfig.app, ssmConfig.stage, ssmConfig.stack)),
           new UserPurchasePersistenceTransformer(clock), cloudWatch
         ), new UserPurchaseFilterExpiredImpl())
-      )),
+      ), cloudWatch),
     "Error initialising validate receipts controller",
     Some(classOf[ValidateReceiptLambda]))
 }

--- a/iosvalidatereceipts/src/main/scala/com/gu/mobilepurchases/model/ValidatedTransaction.scala
+++ b/iosvalidatereceipts/src/main/scala/com/gu/mobilepurchases/model/ValidatedTransaction.scala
@@ -14,7 +14,7 @@ object ValidatedTransaction {
     transactionId: String,
     validated: Boolean,
     finishTransaction: Boolean,
-    purchase: ValidatedTransactionPurchase,
+    purchase: Option[ValidatedTransactionPurchase],
     appStoreStatusResponse: Long
   ): ValidatedTransaction = {
     val validatedLong: Int = if (validated) 1 else 0
@@ -27,6 +27,6 @@ case class ValidatedTransaction(
     transactionId: String,
     validated: Long,
     finishTransaction: Long,
-    purchase: ValidatedTransactionPurchase,
+    purchase: Option[ValidatedTransactionPurchase],
     appStoreStatusResponse: Long
 )

--- a/iosvalidatereceipts/src/main/scala/com/gu/mobilepurchases/validate/ValidateReceiptsRoute.scala
+++ b/iosvalidatereceipts/src/main/scala/com/gu/mobilepurchases/validate/ValidateReceiptsRoute.scala
@@ -39,7 +39,7 @@ class ValidateReceiptsRouteImpl(
       .filterKeys(validatedTransactions.contains)
       .values
       .map((_: Set[ValidatedTransaction])
-        .maxBy((_: ValidatedTransaction).purchase.activeInterval.end))
+        .maxBy((_: ValidatedTransaction).purchase.map(_.activeInterval.end).getOrElse("")))
       .toSet
   }
 

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/ValidateToAppleSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/ValidateToAppleSpec.scala
@@ -45,10 +45,10 @@ class ValidateToAppleSpec extends Specification with Mockito {
           )
 
           Success(ValidateResponse(Set(
-            ValidatedTransaction("1000000390101769", 1, 1, ValidatedTransactionPurchase("uk.co.guardian.gla.1month", "1000000038562242",
-              ValidatedTransactionPurchaseActiveInterval("2018-04-26T11:53:01.000Z", "2018-04-26T11:58:01.000Z")), 21006),
-            ValidatedTransaction("1000000390101770", 1, 1, ValidatedTransactionPurchase("uk.co.guardian.gla.1month", "1000000038562242",
-              ValidatedTransactionPurchaseActiveInterval("2018-04-26T11:53:01.000Z", "2018-04-26T11:58:01.000Z")), 21006)
+            ValidatedTransaction("1000000390101769", 1, 1, Some(ValidatedTransactionPurchase("uk.co.guardian.gla.1month", "1000000038562242",
+              ValidatedTransactionPurchaseActiveInterval("2018-04-26T11:53:01.000Z", "2018-04-26T11:58:01.000Z"))), 21006),
+            ValidatedTransaction("1000000390101770", 1, 1, Some(ValidatedTransactionPurchase("uk.co.guardian.gla.1month", "1000000038562242",
+              ValidatedTransactionPurchaseActiveInterval("2018-04-26T11:53:01.000Z", "2018-04-26T11:58:01.000Z"))), 21006)
           )))
         }
       ), cloudWatch = new CloudWatchImpl("", "lambdaname", CloudWatchImplSpec.mockSuccessfullySendMetrics(_ => ()))) {}

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/ValidateToAppleSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/ValidateToAppleSpec.scala
@@ -30,6 +30,7 @@ object ValidateToAppleSpec {
 class ValidateToAppleSpec extends Specification with Mockito {
   "ValidateReceiptLambdaMockedApple" should {
     "controller works in an AwsLambda" in {
+      val cloudWatchImpl: CloudWatchImpl = new CloudWatchImpl("", "lambdaname", CloudWatchImplSpec.mockSuccessfullySendMetrics(_ => ()))
       val lambda: AwsLambda = new AwsLambda(new ValidateReceiptsController(
         (validateReceiptRequest: ValidateRequest) => {
           validateReceiptRequest must beEqualTo(ValidateRequest(
@@ -50,8 +51,8 @@ class ValidateToAppleSpec extends Specification with Mockito {
             ValidatedTransaction("1000000390101770", 1, 1, Some(ValidatedTransactionPurchase("uk.co.guardian.gla.1month", "1000000038562242",
               ValidatedTransactionPurchaseActiveInterval("2018-04-26T11:53:01.000Z", "2018-04-26T11:58:01.000Z"))), 21006)
           )))
-        }
-      ), cloudWatch = new CloudWatchImpl("", "lambdaname", CloudWatchImplSpec.mockSuccessfullySendMetrics(_ => ()))) {}
+        }, cloudWatchImpl
+      ), cloudWatch = cloudWatchImpl) {}
       val byteArrayOutputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
       lambda.handleRequest(
         new ByteArrayInputStream(mapper.writeValueAsBytes(

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/lambda/DelegatingValidateReceiptLambdaSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/lambda/DelegatingValidateReceiptLambdaSpec.scala
@@ -73,7 +73,7 @@ class DelegatingValidateReceiptLambdaSpec extends Specification with Mockito {
       new ValidateReceiptsTransformAppStoreResponseImpl(),
       fetchAppStoreResponsesImpl, new TransactionPersistenceImpl(
         userPurchasePersistenceImpl, new UserPurchaseFilterExpiredImpl(clock))
-    ))
+    ), cloudWatchImpl)
 
     "don't delegate when no delegate" in {
       val config: Config = ConfigFactory.empty()
@@ -145,7 +145,7 @@ class DelegatingValidateReceiptLambdaSpec extends Specification with Mockito {
       }
 
       new DelegatingValidateReceiptLambda(config, new ValidateReceiptsController(
-        (validateReceiptRequest: ValidateRequest) => Failure(new IllegalStateException())),
+        (validateReceiptRequest: ValidateRequest) => Failure(new IllegalStateException()), cloudWatchImpl),
         client,
         cloudWatchImpl
       ).handleRequest(new ByteArrayInputStream(expectedApiGatewayRequest), stream, null)

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/lambda/DelegatingValidateReceiptLambdaSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/lambda/DelegatingValidateReceiptLambdaSpec.scala
@@ -85,7 +85,9 @@ class DelegatingValidateReceiptLambdaSpec extends Specification with Mockito {
       val actualResponse: LambdaResponse = LambdaResponse(mapper.readValue[ApiGatewayLambdaResponse](stream.toByteArray))
 
       actualResponse.copy(maybeBody = None) must beEqualTo(LambdaResponse(200, None, Map("Content-Type" -> "application/json; charset=UTF-8")))
-      mapper.readValue[ValidateResponse](actualResponse.maybeBody.get) must beEqualTo(ValidateResponse(Set(ValidatedTransaction("20000034829192", 1, 1, ValidatedTransactionPurchase("uk.co.guardian.gce.plusobserver.1monthsub", "20000001746150", ValidatedTransactionPurchaseActiveInterval("2012-09-30T12:24:36.000Z", "2012-11-06T13:24:36.000Z")), 0))))
+      mapper.readValue[ValidateResponse](actualResponse.maybeBody.get) must beEqualTo(ValidateResponse(Set(
+        ValidatedTransaction("20000034829192", 1, 1,
+          Some(ValidatedTransactionPurchase("uk.co.guardian.gce.plusobserver.1monthsub", "20000001746150", ValidatedTransactionPurchaseActiveInterval("2012-09-30T12:24:36.000Z", "2012-11-06T13:24:36.000Z"))), 0))))
       there was no(client).newCall(Mockito.any[Request]())
     }
 
@@ -117,7 +119,7 @@ class DelegatingValidateReceiptLambdaSpec extends Specification with Mockito {
       val actualResponse: LambdaResponse = LambdaResponse(mapper.readValue[ApiGatewayLambdaResponse](stream.toByteArray))
       val expectedResponse: LambdaResponse = LambdaResponse(200, None, Map("Content-Type" -> "application/json; charset=UTF-8"))
       actualResponse.copy(maybeBody = None) must beEqualTo(expectedResponse)
-      mapper.readValue[ValidateResponse](actualResponse.maybeBody.get) must beEqualTo(ValidateResponse(Set(ValidatedTransaction("20000034829192", 1, 1, ValidatedTransactionPurchase("uk.co.guardian.gce.plusobserver.1monthsub", "20000001746150", ValidatedTransactionPurchaseActiveInterval("2012-09-30T12:24:36.000Z", "2012-11-06T13:24:36.000Z")), 0))))
+      mapper.readValue[ValidateResponse](actualResponse.maybeBody.get) must beEqualTo(ValidateResponse(Set(ValidatedTransaction("20000034829192", 1, 1, Some(ValidatedTransactionPurchase("uk.co.guardian.gce.plusobserver.1monthsub", "20000001746150", ValidatedTransactionPurchaseActiveInterval("2012-09-30T12:24:36.000Z", "2012-11-06T13:24:36.000Z"))), 0))))
       there was one(client).newCall(any[Request]())
     }
 
@@ -184,7 +186,7 @@ class DelegatingValidateReceiptLambdaSpec extends Specification with Mockito {
       val actualResponse: LambdaResponse = LambdaResponse(mapper.readValue[ApiGatewayLambdaResponse](stream.toByteArray))
       val expectedResponse: LambdaResponse = LambdaResponse(200, None, Map("Content-Type" -> "application/json; charset=UTF-8"))
       actualResponse.copy(maybeBody = None) must beEqualTo(expectedResponse)
-      mapper.readValue[ValidateResponse](actualResponse.maybeBody.get) must beEqualTo(ValidateResponse(Set(ValidatedTransaction("20000034829192", 1, 1, ValidatedTransactionPurchase("uk.co.guardian.gce.plusobserver.1monthsub", "20000001746150", ValidatedTransactionPurchaseActiveInterval("2012-09-30T12:24:36.000Z", "2012-11-06T13:24:36.000Z")), 0))))
+      mapper.readValue[ValidateResponse](actualResponse.maybeBody.get) must beEqualTo(ValidateResponse(Set(ValidatedTransaction("20000034829192", 1, 1, Some(ValidatedTransactionPurchase("uk.co.guardian.gce.plusobserver.1monthsub", "20000001746150", ValidatedTransactionPurchaseActiveInterval("2012-09-30T12:24:36.000Z", "2012-11-06T13:24:36.000Z"))), 0))))
       there was one(client).newCall(any[Request]())
     }
 

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/model/ValidatedTransactionSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/model/ValidatedTransactionSpec.scala
@@ -16,7 +16,7 @@ object ValidatedTransactionSpec {
     "",
     1,
     1,
-    ValidatedTransactionPurchase("", "", ValidatedTransactionPurchaseActiveInterval("", "")), 0
+    Some(ValidatedTransactionPurchase("", "", ValidatedTransactionPurchaseActiveInterval("", ""))), 0
   )
   val genValidatedTransaction: Gen[ValidatedTransaction] = for {
     transactionId <- genCommonAscii
@@ -33,7 +33,7 @@ object ValidatedTransactionSpec {
       } yield ValidatedTransactionPurchaseActiveInterval(start, end)
     } yield ValidatedTransactionPurchase(productId, webOrderLineItemId, activeInterval)
     appStoreStatusResponse <- Arbitrary.arbitrary[Long]
-  } yield ValidatedTransaction(transactionId, validated, finishTransaction, purchase, appStoreStatusResponse)
+  } yield ValidatedTransaction(transactionId, validated, finishTransaction, Some(purchase), appStoreStatusResponse)
   val genValidatedTransactions: Gen[Set[ValidatedTransaction]] = Gen.containerOf[Set, ValidatedTransaction](genValidatedTransaction)
 }
 

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/persistence/TransactionPersistenceImplSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/persistence/TransactionPersistenceImplSpec.scala
@@ -36,7 +36,7 @@ class TransactionPersistenceImplSpec extends Specification with ScalaCheck {
               val userIdWithAppId: UserIdWithAppId = validateRequestWithTransactions.userIdWithAppId
               userPurchasesByUserId must beEqualTo(UserPurchasesByUserIdAndAppId(userIdWithAppId.userId, userIdWithAppId.appId,
                 validateRequestWithTransactions.transactions.map((transaction: ValidatedTransaction) => {
-                  val purchase: ValidatedTransactionPurchase = transaction.purchase
+                  val purchase: ValidatedTransactionPurchase = transaction.purchase.get
                   UserPurchase(
 
                     purchase.productId,

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateExample.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateExample.scala
@@ -25,17 +25,17 @@ object ValidateExample {
     "20000034829192",
     validated = true,
     finishTransaction = true,
-    ValidatedTransactionPurchase("uk.co.guardian.gce.plusobserver.1monthsub", "20000001746150", ValidatedTransactionPurchaseActiveInterval(
-      "2012-09-30T12:24:36.000Z", "2012-11-06T13:24:36.000Z")), 0)
+    Some(ValidatedTransactionPurchase("uk.co.guardian.gce.plusobserver.1monthsub", "20000001746150", ValidatedTransactionPurchaseActiveInterval(
+      "2012-09-30T12:24:36.000Z", "2012-11-06T13:24:36.000Z"))), 0)
 
   def successValidatedTransaction: ValidatedTransaction = ValidatedTransaction(
     "20000034829192",
     1,
     1,
-    ValidatedTransactionPurchase(
+    Some(ValidatedTransactionPurchase(
       "uk.co.guardian.gla.1month",
       "1000000036022769",
-      ValidatedTransactionPurchaseActiveInterval("2018-03-26T12:24:23.107Z", "2018-03-26T12:29:23.107Z")),
+      ValidatedTransactionPurchaseActiveInterval("2018-03-26T12:24:23.107Z", "2018-03-26T12:29:23.107Z"))),
 
     0
   )

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateReceiptsControllerSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateReceiptsControllerSpec.scala
@@ -1,5 +1,9 @@
 package com.gu.mobilepurchases.validate
 
+import java.time.Instant
+
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import com.gu.mobilepurchases.shared.cloudwatch.{ CloudWatchMetrics, Timer }
 import com.gu.mobilepurchases.shared.external.Jackson.mapper
 import com.gu.mobilepurchases.shared.lambda.{ LambdaRequest, LambdaResponse }
 import com.gu.mobilepurchases.validate.ValidateExample.{ successExample, successValidateRequest }
@@ -10,12 +14,21 @@ import scala.util.Try
 class ValidateReceiptsControllerSpec extends Specification {
 
   "ValidateReceiptsController" should {
+    val metrics: CloudWatchMetrics = new CloudWatchMetrics {
+      override def queueMetric(metricName: String, value: Double, standardUnit: StandardUnit, instant: Instant): Boolean = ???
+
+      override def startTimer(metricName: String): Timer = ???
+
+      override def meterHttpStatusResponses(metricName: String, code: Int): Unit = ???
+    }
+
     "marshals and unmarshals correctly using success example" in {
       val requestString: String = successExample.requestString
+
       new ValidateReceiptsController((validateReceiptRequest: ValidateRequest) => {
         validateReceiptRequest must beEqualTo(successValidateRequest)
         Try(ValidateResponse(Set(ValidateExample.successValidatedTransaction)))
-      })(LambdaRequest(Some(requestString))) match {
+      }, metrics)(LambdaRequest(Some(requestString))) match {
         case LambdaResponse(200, Some(body), headers) => {
           headers must beEqualTo(Map("Content-Type" -> "application/json; charset=UTF-8"))
           mapper.readTree(body) must beEqualTo(mapper.readTree(successExample.responseString))

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateReceiptsRouteImplSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateReceiptsRouteImplSpec.scala
@@ -17,12 +17,12 @@ class ValidateReceiptsRouteImplSpec extends Specification with ScalaCheck {
       val validateRequest: ValidateRequest = Jackson.mapper.readValue[ValidateRequest](ValidateToAppleSpec.testRequestBytes)
       val validateResponse: ValidateResponse = Jackson.mapper.readValue[ValidateResponse](ValidateToAppleSpec.testResponseBytes)
       val extraReceiptValidateTransactions = ValidatedTransaction(
-        "1000000390101770", 1, 1, ValidatedTransactionPurchase(
-          "uk.co.guardian.gla.1month", "1000000038562242", ValidatedTransactionPurchaseActiveInterval("1970-01-01T00:00:00.002Z", "1970-01-01T00:00:00.001Z")), 21006)
+        "1000000390101770", 1, 1, Some(ValidatedTransactionPurchase(
+          "uk.co.guardian.gla.1month", "1000000038562242", ValidatedTransactionPurchaseActiveInterval("1970-01-01T00:00:00.002Z", "1970-01-01T00:00:00.001Z"))), 21006)
       val extraNestedValidatedTransaction: ValidatedTransaction = ValidatedTransaction(
         "1", 1, 1,
-        ValidatedTransactionPurchase(
-          "uk.co.guardian.gla.1month", "1234567", ValidatedTransactionPurchaseActiveInterval("2018-04-26T16:27:24.000Z", "2018-04-26T16:27:24.000Z")), 21006)
+        Some(ValidatedTransactionPurchase(
+          "uk.co.guardian.gla.1month", "1234567", ValidatedTransactionPurchaseActiveInterval("2018-04-26T16:27:24.000Z", "2018-04-26T16:27:24.000Z"))), 21006)
       val mockResponses: Map[String, AppStoreResponse] = Map(
         "ExtraReceipt" -> AppStoreExample.appStoreResponseExample.copy(
           status = "21006",

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateReceiptsTransformAppStoreResponseSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateReceiptsTransformAppStoreResponseSpec.scala
@@ -23,7 +23,7 @@ class ValidateReceiptsTransformAppStoreResponseSpec extends Specification with S
     )
     val validValidatedTransaction: ValidatedTransaction = ValidatedTransaction("transactionId", 1,
       1,
-      ValidatedTransactionPurchase("productId", "webOrderLineItemId", ValidatedTransactionPurchaseActiveInterval("2012-09-30T12:24:36.000Z", "2012-09-30T12:24:36.000Z")), 0)
+      Some(ValidatedTransactionPurchase("productId", "webOrderLineItemId", ValidatedTransactionPurchaseActiveInterval("2012-09-30T12:24:36.000Z", "2012-09-30T12:24:36.000Z"))), 0)
     val validateReceiptsTransformAppStoreResponse = new ValidateReceiptsTransformAppStoreResponseImpl()
 
     "valid receipt" in {
@@ -35,11 +35,14 @@ class ValidateReceiptsTransformAppStoreResponseSpec extends Specification with S
       transactions must beEqualTo(Set(validValidatedTransaction.copy(appStoreStatusResponse = 21006)))
     }
     "CouldNotReadJson" in {
-      val transactions: Set[ValidatedTransaction] = validateReceiptsTransformAppStoreResponse.transformAppStoreResponse(validResponse.copy(status = "21000"))
+      val transactions: Set[ValidatedTransaction] = validateReceiptsTransformAppStoreResponse.transformAppStoreResponse(
+        validResponse.copy(status = "21000"))
       transactions must beEqualTo(Set(validValidatedTransaction.copy(
         appStoreStatusResponse = 21000,
         finishTransaction = 0,
-        validated = 0
+        validated = 0,
+        purchase = None
+
       )))
     }
     "MalformedReceiptData" in {
@@ -47,7 +50,8 @@ class ValidateReceiptsTransformAppStoreResponseSpec extends Specification with S
       transactions must beEqualTo(Set(validValidatedTransaction.copy(
         appStoreStatusResponse = 21002,
         finishTransaction = 0,
-        validated = 0
+        validated = 0,
+        purchase = None
       )))
     }
 
@@ -56,7 +60,8 @@ class ValidateReceiptsTransformAppStoreResponseSpec extends Specification with S
       transactions must beEqualTo(Set(validValidatedTransaction.copy(
         appStoreStatusResponse = 21003,
         finishTransaction = 0,
-        validated = 0
+        validated = 0,
+        purchase = None
       )))
     }
     "scalacheck" >> {

--- a/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateReceiptsTransformAppStoreResponseSpec.scala
+++ b/iosvalidatereceipts/src/test/scala/com/gu/mobilepurchases/validate/ValidateReceiptsTransformAppStoreResponseSpec.scala
@@ -64,17 +64,5 @@ class ValidateReceiptsTransformAppStoreResponseSpec extends Specification with S
         purchase = None
       )))
     }
-    "scalacheck" >> {
-      implicit val arbitraryAppStoreResponse: Arbitrary[AppStoreResponse] = Arbitrary(AppStoreSpec.genLeafAppStoreResponse)
-      prop { (appStoreResponse: AppStoreResponse) =>
-        {
-          val transactions: Set[ValidatedTransaction] = validateReceiptsTransformAppStoreResponse.transformAppStoreResponse(appStoreResponse)
-          transactions must beAnInstanceOf[Set[ValidatedTransaction]]
-          transactions.size must beEqualTo(Set(appStoreResponse.latest_expired_receipt_info, appStoreResponse.latest_receipt_Info, appStoreResponse.receipt).flatMap(_.toSet).size)
-
-        }
-      }.setArbitrary(arbitraryAppStoreResponse)
-
-    }
   }
 }


### PR DESCRIPTION
Didn't notice this was optional when reading the docs, although when I re-read why, it makes a lot of sense.