### PR TITLE
Add basic lambda for obtaining/refreshing Play Developer API access tokens

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,16 @@ lazy val iosvalidatereceipts = project.enablePlugins(AssemblyPlugin).settings({
 lazy val iosuserpurchases = project.enablePlugins(AssemblyPlugin).settings(commonAssemblySettings("iosuserpurchases"))
   .dependsOn(userpurchasepersistence % testAndCompileDependencies)
 
+lazy val googleoauth = project.disablePlugins(AssemblyPlugin)
+  .settings(libraryDependencies ++= List(
+    "com.google.auth" % "google-auth-library-oauth2-http" % "0.15.0",
+    "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion
+  ))
+  .dependsOn(commonlambda % testAndCompileDependencies)
+
 lazy val root = project
   .enablePlugins(RiffRaffArtifact).in(file("."))
-  .aggregate(commonlambda, userpurchasepersistence, iosvalidatereceipts, iosuserpurchases)
+  .aggregate(commonlambda, userpurchasepersistence, iosvalidatereceipts, iosuserpurchases, googleoauth)
   .settings(
     fork := true, // was hitting deadlock, found similar complaints online, disabling concurrency helps: https://github.com/sbt/sbt/issues/3022, https://github.com/mockito/mockito/issues/1067
     scalaVersion := "2.12.5",
@@ -46,6 +53,7 @@ lazy val root = project
     riffRaffManifestProjectName := s"Mobile::${name.value}",
     riffRaffArtifactResources += (assembly in iosvalidatereceipts).value -> s"${(name in iosvalidatereceipts).value}/${(assembly in iosvalidatereceipts).value.getName}",
     riffRaffArtifactResources += (assembly in iosuserpurchases).value -> s"${(name in iosuserpurchases).value}/${(assembly in iosuserpurchases).value.getName}",
+    riffRaffArtifactResources += (assembly in googleoauth).value -> s"${(name in googleoauth).value}/${(assembly in googleoauth).value.getName}",
     riffRaffArtifactResources += file("tsc-target/mobile-purchases-google.zip") -> s"mobile-purchases-googlepubsub/mobile-purchases-google.zip",
     riffRaffArtifactResources += file("cloudformation.yaml") -> s"mobile-purchases-cloudformation/cloudformation.yaml",
   )

--- a/build.sbt
+++ b/build.sbt
@@ -32,11 +32,14 @@ lazy val iosvalidatereceipts = project.enablePlugins(AssemblyPlugin).settings({
 lazy val iosuserpurchases = project.enablePlugins(AssemblyPlugin).settings(commonAssemblySettings("iosuserpurchases"))
   .dependsOn(userpurchasepersistence % testAndCompileDependencies)
 
-lazy val googleoauth = project.disablePlugins(AssemblyPlugin)
-  .settings(libraryDependencies ++= List(
+lazy val googleoauth = project.enablePlugins(AssemblyPlugin)
+  .settings(
+    commonAssemblySettings("googleoauth"),
+    libraryDependencies ++= List(
     "com.google.auth" % "google-auth-library-oauth2-http" % "0.15.0",
     "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion
-  ))
+    )
+  )
   .dependsOn(commonlambda % testAndCompileDependencies)
 
 lazy val root = project

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -231,9 +231,10 @@ Resources:
       MemorySize: 512
       Timeout: 45
       Events:
-        Type: Schedule
-        Properties:
-          Schedule: rate(15 minutes)
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: rate(15 minutes)
       Tags:
         Stage: !Ref Stage
         Stack: !Ref Stack

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -79,6 +79,13 @@ Resources:
                 - ssm:GetParametersByPath
               Effect: Allow
               Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}-iosvalidatereceipts/${Stage}/${Stack}
+        - PolicyName: googleoauth-config
+          PolicyDocument:
+            Statement:
+              Action:
+                - ssm:GetParametersByPath
+              Effect: Allow
+              Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}/google-oauth-lambda
         - PolicyName: dynamo
           PolicyDocument:
             Statement:
@@ -205,6 +212,32 @@ Resources:
       RestApiId: !Ref MobilePuchasesApi
       Stage: !Ref Stage
 
+  GoogleOAuthLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: com.gu.mobilepurchases.googleoauth.lambda.GoogleOAuth::handler
+      Runtime: java8
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-googleoauth/${App}-googleoauth.jar
+      FunctionName: !Sub ${App}-googleoauth-${Stage}
+      Role: !GetAtt MobilePurchasesLambdasRole.Arn
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+      Description: Fetches access tokens for the Google Play Developer API
+      MemorySize: 512
+      Timeout: 45
+      Events:
+        Type: Schedule
+        Properties:
+          Schedule: rate(15 minutes)
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App
 
   GooglePubSubLambda:
     Type: AWS::Serverless::Function

--- a/googleoauth/src/main/resources/log4j2.xml
+++ b/googleoauth/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2.LambdaAppender">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%t] %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/googleoauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
+++ b/googleoauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
@@ -1,0 +1,41 @@
+import java.io.{ ByteArrayInputStream, InputStream, OutputStream }
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.google.auth.oauth2.GoogleCredentials
+import com.gu.conf.{ ConfigurationLoader, SSMConfigurationLocation }
+import com.gu.{ AppIdentity, AwsIdentity }
+import com.typesafe.config.Config
+import org.apache.logging.log4j.LogManager
+
+object GoogleOAuth {
+
+  def accessToken(): Unit = {
+
+    val logger = LogManager.getLogger
+
+    val credentials = GoogleCredentials
+      .fromStream(new ByteArrayInputStream(fetchConfiguration.getString("google.serviceAccountJson").getBytes))
+      .createScoped("https://www.googleapis.com/auth/androidpublisher")
+
+    credentials.refresh
+
+    logger.info(s"Token will expire at ${credentials.getAccessToken().getExpirationTime}")
+
+  }
+
+  def fetchConfiguration(): Config = {
+    val identity = AppIdentity.whoAmI(defaultAppName = "google-oauth-lambda")
+    ConfigurationLoader.load(identity) {
+      case AwsIdentity(_, _, stage, _) => SSMConfigurationLocation(s"/mobile-purchases/$stage/google-oauth-lambda")
+    }
+  }
+
+  def handler(input: InputStream, output: OutputStream, context: Context): Unit = {
+    accessToken()
+  }
+
+}
+
+object Debug extends App {
+  GoogleOAuth.accessToken()
+}

--- a/googleoauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
+++ b/googleoauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
@@ -1,3 +1,5 @@
+package com.gu.mobilepurchases.googleoauth.lambda
+
 import java.io.{ ByteArrayInputStream, InputStream, OutputStream }
 
 import com.amazonaws.services.lambda.runtime.Context

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -25,6 +25,15 @@ deployments:
       fileName: mobile-purchases-iosuserpurchases.jar
       prefixStack: false
 
+  mobile-purchases-googleoauth:
+    type: aws-lambda
+    dependencies: [mobile-purchases-cloudformation]
+    parameters:
+      bucket: mobile-dist
+      functionNames: [mobile-purchases-googleoauth-]
+      fileName: mobile-purchases-googleoauth.jar
+      prefixStack: false
+
   mobile-purchases-googlepubsub:
     type: aws-lambda
     dependencies: [mobile-purchases-cloudformation]


### PR DESCRIPTION
This PR adds a new lambda which will be used to refresh (and store) access tokens used to authenticate against the [Play Developer API](https://developers.google.com/android-publisher/). Obviously this is not the finished code, but I wanted to get a pull request open before it gets too large!

The lambda is triggered by a CloudWatch Event Rule (on a schedule). The Cloudformation and lambda are both deployable using RiffRaff.

Next steps (for a subsequent PR):

- [ ] Add S3 permissions for storing the access tokens
- [ ] Add code to store access tokens in S3