### PR TITLE
Read access tokens from S3 and improve build script

### DIFF
--- a/build-tc.sh
+++ b/build-tc.sh
@@ -6,18 +6,20 @@ npm install -g yarn
 mkdir -p tsc-target
 
 yarn install
-# Will place .js files in target
 yarn run clean
+
+# Will place .js files in tsc-target
 yarn run build
 
 yarn run test
 
 cp package.json tsc-target/
 
-pushd tsc-target
-# Ensures the RiffRaff package has the node_modules needed to run
-yarn install --production
-popd
-
 cd tsc-target
-zip -r mobile-purchases-google.zip . -i *.js
+
+# Create the .zip which will be uploaded to AWS
+zip -r mobile-purchases-google.zip . -i /google/src/*.js
+
+# Ensure node_modules (which are required by the lambdas at runtime) are included in the .zip
+yarn install --production
+zip -u -r mobile-purchases-google.zip node_modules/*

--- a/google/src/playsubstatus/playsubstatus.ts
+++ b/google/src/playsubstatus/playsubstatus.ts
@@ -1,38 +1,78 @@
 import * as restm from 'typed-rest-client/RestClient';
-import {HTTPResponseHeaders, HTTPRequest, HTTPResponse} from '../models/apiGatewayHttp';
-
-const access_token = process.env.AccessToken;
+import {HTTPResponseHeaders, HTTPRequest, HTTPResponse, HTTPResponses} from '../models/apiGatewayHttp';
+import S3 = require("aws-sdk/clients/s3");
 
 interface GoogleResponseBody {
     expiryTimeMillis: string
 }
 
+interface AccessToken {
+    token: string,
+    date: Date
+}
+
+interface SubscriptionStatusResponse {
+    "subscriptionHasLapsed": boolean
+    "subscriptionExpiryDate": Date
+}
+
+const s3: S3 = new S3();
+
+function getParams(stage: string): S3.Types.GetObjectRequest {
+    return {
+        Bucket: 'gu-mobile-access-tokens',
+        Key: `${stage}/google-play-developer-api/access_token.json`
+    }
+}
+
+function getAccessToken(params: S3.Types.GetObjectRequest): Promise<AccessToken> {
+    console.log(`Attempting to fetch access token from: Bucket: ${params.Bucket} | Key: ${params.Key}`);
+    return s3.getObject(params).promise()
+        .then(s3Output => {
+            if (s3Output.Body) {
+                return JSON.parse(s3Output.Body.toString())
+            } else {
+                throw Error("S3 output body was not defined")
+            }
+        })
+        .catch(error => {
+            console.log(`Failed to get access token from S3 due to: ${error}`);
+            throw error
+        })
+}
+
 export async function handler(request: HTTPRequest): Promise<HTTPResponse> {
+
+    const stage = process.env.Stage;
 
     if (request.pathParameters && request.headers && request.headers["Play-Purchase-Token"]) {
         const url = `https://www.googleapis.com/androidpublisher/v3/applications/com.guardian/purchases/subscriptions/${request.pathParameters.subscriptionId}/tokens/${request.headers["Play-Purchase-Token"]}`;
         const restClient = new restm.RestClient('guardian-mobile-purchases');
-        return restClient.get<GoogleResponseBody>(url, { additionalHeaders: { Authorization: `Bearer ${access_token}`}})
+        return getAccessToken(getParams(stage || ""))
+            .then(accessToken =>
+                restClient.get<GoogleResponseBody>(url, {additionalHeaders: {Authorization: `Bearer ${accessToken.token}`}})
+            )
             .then(response => {
                 if (response.result) {
                     const subscriptionExpiryDate: Date = new Date(parseInt(response.result.expiryTimeMillis));
                     const now: Date = new Date(Date.now());
                     const subscriptionHasLapsed: boolean = now > subscriptionExpiryDate;
-                    console.log(`Subscription expires on: ${subscriptionExpiryDate}. subscriptionHasLapsed: ${subscriptionHasLapsed}`);
-                    return new HTTPResponse(200, new HTTPResponseHeaders(), "OK")
+                    const responseBody: SubscriptionStatusResponse = {"subscriptionHasLapsed": subscriptionHasLapsed, "subscriptionExpiryDate": subscriptionExpiryDate};
+                    console.log(`Successfully retrieved subscription details from Play Developer API. Response body will be: ${JSON.stringify(responseBody)}`);
+                    return new HTTPResponse(200, new HTTPResponseHeaders(), JSON.stringify(responseBody))
                 } else {
                     console.log(`Failed to establish expiry time of subscription`);
-                    return new HTTPResponse(400, new HTTPResponseHeaders(), "Error")
+                    return HTTPResponses.INVALID_REQUEST
                 }
             })
             .catch(
                 error =>  {
-                    console.log(`Error: ${error}`);
-                    return new HTTPResponse(500, new HTTPResponseHeaders(), "Error")
+                    console.log(`Serving an Internal Server Error due to: ${error}`);
+                    return HTTPResponses.INTERNAL_ERROR
                 }
             );
     } else {
-        return new HTTPResponse(400, new HTTPResponseHeaders(), "Bad Request")
+        return HTTPResponses.INVALID_REQUEST
     }
 
 

--- a/google/tests/playsubstatus/playsubstatus.test.ts
+++ b/google/tests/playsubstatus/playsubstatus.test.ts
@@ -1,15 +1,17 @@
 import { handler } from "../../src/playsubstatus/playsubstatus";
 
 test("Parse and return HTTP 200", () => {
-    /*let handlerResult = handler({
-        headers: {
-            "Play-Purchase-Token": "hoofgeonpgdfcnjdiofeadbe.AO-J1Oz1chlwrlUQnFQDBD2J3JDFiVPXnvkG7BYSYrv9FsjdWf4yyJd76jDhorOcTUU-Zx3r2VYccNAlFGljcdvPnsglwXWivMrR9b6rE7OIg4WGdLCR1W9bFu_lQvltMnQUQlGgkZ4WYe_eTt44wml5TatT70ew8g"
-        },
-        pathParameters: {
-            "subscriptionId": "com.guardian.subscription.monthly.10"
-        }
-    });
-
-    handlerResult.then(result => expect(result.statusCode).toBe(200))*/
+    // process.env['Stage'] = "CODE";
+    // expect.assertions(1);
+    // let handlerResult = handler({
+    //     headers: {
+    //         "Play-Purchase-Token": "hoofgeonpgdfcnjdiofeadbe.AO-J1Oz1chlwrlUQnFQDBD2J3JDFiVPXnvkG7BYSYrv9FsjdWf4yyJd76jDhorOcTUU-Zx3r2VYccNAlFGljcdvPnsglwXWivMrR9b6rE7OIg4WGdLCR1W9bFu_lQvltMnQUQlGgkZ4WYe_eTt44wml5TatT70ew8g"
+    //     },
+    //     pathParameters: {
+    //         "subscriptionId": "com.guardian.subscription.monthly.10"
+    //     }
+    // });
+    //
+    // return handlerResult.then(result => expect(result.statusCode).toBe(200));
     expect(1).toBe(1)
 });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@types/node": "^12.0.2",
+    "aws-sdk": "^2.465.0",
     "typed-rest-client": "^1.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,6 +518,21 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+aws-sdk@^2.465.0:
+  version "2.465.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.465.0.tgz#60948a0930473f50bac23311bc48426118e79f12"
+  integrity sha512-eS3g80QUbhOo0Rd/WTudtlc4cuNpLget6Re1KyDod6319QvW2il1q28VyvZK0/Yiu8GyVh5xGbThaLEQem+fLQ==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -569,6 +584,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 base@^0.11.1:
   version "0.11.2"
@@ -644,6 +664,15 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -1015,6 +1044,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
@@ -1367,6 +1401,16 @@ iconv-lite@0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
+ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ignore-walk@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
@@ -1567,7 +1611,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -1990,6 +2034,11 @@ jest@^24.8.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -2736,6 +2785,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2750,6 +2804,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 rc@^1.2.7:
   version "1.2.8"
@@ -2961,7 +3020,12 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -3436,6 +3500,14 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -3454,7 +3526,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -3587,6 +3659,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Now that the access tokens are [stored in S3](https://github.com/guardian/mobile-purchases/pull/47), we can start using them properly!

I've also made some more changes to the build script, as I ran into problems with missing modules when testing this change initially.