### PR TITLE
Add alert for Google token refresh failures

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -382,7 +382,8 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test # FIXME should be mobile-server-side
-      AlarmName: !Sub Mobile Purchases ${Stage} | Failed to refresh Google OAuth Token
+      AlarmName: !Sub mobile-purchases-${Stage}-google-oauth-token-refresh-failure
+      AlarmDescription: !Sub Trigger the GoogleOAuth lambda manually to refresh the token
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
@@ -390,7 +391,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: 300
+      Period: 60
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -36,7 +36,7 @@ Parameters:
     Type: String
     Description: The secret used by google's pubsub
 Conditions:
-  CreateProdOnlyResources: !Equals [ !Ref Stage, CODE ] # FIXME should be PROD
+  CreateProdOnlyResources: !Equals [ !Ref Stage, PROD ]
 Resources:
   MobilePurchasesLambdasRole:
     Type: AWS::IAM::Role
@@ -381,7 +381,7 @@ Resources:
     Condition: CreateProdOnlyResources
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test # FIXME should be mobile-server-side
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       AlarmName: !Sub mobile-purchases-${Stage}-google-oauth-token-refresh-failure
       AlarmDescription: !Sub Trigger the GoogleOAuth lambda manually to refresh the token
       ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -35,8 +35,6 @@ Parameters:
   GooglePubSubSecret:
     Type: String
     Description: The secret used by google's pubsub
-Conditions:
-  CreateProdOnlyResources: !Equals [ !Ref Stage, PROD ]
 Resources:
   MobilePurchasesLambdasRole:
     Type: AWS::IAM::Role
@@ -378,7 +376,6 @@ Resources:
 
   GoogleTokenRefreshFailureAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateProdOnlyResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -35,6 +35,8 @@ Parameters:
   GooglePubSubSecret:
     Type: String
     Description: The secret used by google's pubsub
+Conditions:
+  CreateProdOnlyResources: !Equals [ !Ref Stage, CODE ] # FIXME should be PROD
 Resources:
   MobilePurchasesLambdasRole:
     Type: AWS::IAM::Role
@@ -373,3 +375,22 @@ Resources:
         Stage: !Ref Stage
         Stack: !Ref Stack
         App: !Ref App
+
+  GoogleTokenRefreshFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdOnlyResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test # FIXME should be mobile-server-side
+      AlarmName: !Sub Mobile Purchases ${Stage} | Failed to refresh Google OAuth Token
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref GoogleOAuthLambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching


### PR DESCRIPTION
A number of services in this project (will) depend on us successfully refreshing access tokens for the Google Play Developer API. Therefore we should be informed if there are any problems refreshing this token in PROD.

Since this lambda [throws an exception](https://github.com/guardian/mobile-purchases/blob/master/googleoauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala#L30-L33) on error, we should be able to use standard `AWS/Lambda` metrics to detect token refresh failures.