### PR TITLE
Serve a 404 instead of a 400 if Google fails to return subscription info

### DIFF
--- a/typescript/src/models/apiGatewayHttp.ts
+++ b/typescript/src/models/apiGatewayHttp.ts
@@ -38,5 +38,6 @@ export const HTTPResponses = {
     OK: new HTTPResponse(200, new HTTPResponseHeaders(), "{\"status\": 200, \"message\": \"OK\"}"),
     INVALID_REQUEST: new HTTPResponse(400, new HTTPResponseHeaders(), "{\"status\": 400, \"message\": \"INVALID_REQUEST\"}"),
     UNAUTHORISED: new HTTPResponse(401, new HTTPResponseHeaders(), "{\"status\": 401, \"message\": \"UNAUTHORISED\"}"),
+    NOT_FOUND: new HTTPResponse(404, new HTTPResponseHeaders(), "{\"status\": 404, \"message\": \"NOT_FOUND\"}"),
     INTERNAL_ERROR: new HTTPResponse(500, new HTTPResponseHeaders(), "{\"status\": 500, \"message\": \"INTERNAL SERVER ERROR\"}")
 };

--- a/typescript/src/playsubstatus/playsubstatus.ts
+++ b/typescript/src/playsubstatus/playsubstatus.ts
@@ -62,7 +62,7 @@ export async function handler(request: HTTPRequest): Promise<HTTPResponse> {
                     return new HTTPResponse(200, new HTTPResponseHeaders(), JSON.stringify(responseBody))
                 } else {
                     console.log(`Failed to establish expiry time of subscription`);
-                    return HTTPResponses.INVALID_REQUEST
+                    return HTTPResponses.NOT_FOUND
                 }
             })
             .catch(


### PR DESCRIPTION
I think this is a more appropriate status code in this scenario.