### PR TITLE
Enable detailed metrics and setup alert for Play Subscription status checks

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -139,6 +139,8 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: !Ref Stage
+      MethodSettings:
+        - MetricsEnabled: true
       DefinitionBody:
         swagger: "2.0"
         info:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -526,7 +526,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test #FIXME
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       AlarmName: !Sub mobile-purchases-${Stage}-play-subscription-status-check-errors
       AlarmDescription: !Sub A high number errors are being served to the Android app when it is attempting to check Play Subscription statuses
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -542,7 +542,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: 5XXError
       Namespace: AWS/ApiGateway
-      Period: 60
+      Period: 300
       Statistic: Sum
-      Threshold: 1
+      Threshold: 3
       TreatMissingData: notBreaching

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -139,8 +139,12 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: !Ref Stage
-      MethodSettings:
-        - MetricsEnabled: true
+      MethodSettings: [{
+          "MetricsEnabled": True,
+          "LoggingLevel": "OFF",
+          "ResourcePath": "/*",
+          "HttpMethod": "*"
+      }]
       DefinitionBody:
         swagger: "2.0"
         info:
@@ -513,6 +517,31 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  GooglePlaySubsStatus5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test #FIXME
+      AlarmName: !Sub mobile-purchases-${Stage}-play-subscription-status-check-errors
+      AlarmDescription: !Sub A high number errors are being served to the Android app when it is attempting to check Play Subscription statuses
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub ${App}-${Stage}
+        - Name: Method
+          Value: GET
+        - Name: Resource
+          Value: /google/subscription/{subscriptionId}/status
+        - Name: Stage
+          Value: !Ref Stage
+      EvaluationPeriods: 1
+      MetricName: 5XXError
+      Namespace: AWS/ApiGateway
       Period: 60
       Statistic: Sum
       Threshold: 1


### PR DESCRIPTION
By [enabling detailed metrics](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html#api-gateway-metricdimensions), we can set alerts for individual methods instead of monitoring the whole API at a high level. 

This detailed context is going to be essential when debugging production problems with this project, as we're beginning to support quite a lot of distinct functionality under the same API.

For now I've just set up one (quite cautious) alert for Play Subscription status checks, as the [related Android change](https://github.com/guardian/android-news-app/pull/5208) has now been merged (and should go to beta soon 🤞).

