### PR TITLE
Handle 410 response from Google

### DIFF
--- a/typescript/src/playsubstatus/playsubstatus.ts
+++ b/typescript/src/playsubstatus/playsubstatus.ts
@@ -83,7 +83,7 @@ export async function handler(request: HTTPRequest): Promise<HTTPResponse> {
             })
             .catch(
                 error => {
-                    if (error['statusCode'] === 410) {
+                    if (error.statusCode === 410) {
                         console.log(`Purchase expired a very long time ago`);
                         return HTTPResponses.NOT_FOUND
                     } else {

--- a/typescript/src/playsubstatus/playsubstatus.ts
+++ b/typescript/src/playsubstatus/playsubstatus.ts
@@ -86,15 +86,14 @@ export async function handler(request: HTTPRequest): Promise<HTTPResponse> {
                     if (error['statusCode'] === 410) {
                         console.log(`Purchase expired a very long time ago`);
                         return HTTPResponses.NOT_FOUND
+                    } else {
+                        console.log(`Serving an Internal Server Error due to: ${error}`);
+                        return HTTPResponses.INTERNAL_ERROR
                     }
-                    console.log(`Serving an Internal Server Error due to: ${error}`);
-                    return HTTPResponses.INTERNAL_ERROR
                 }
             );
     } else {
         return HTTPResponses.INVALID_REQUEST
     }
-
-
 
 }

--- a/typescript/src/playsubstatus/playsubstatus.ts
+++ b/typescript/src/playsubstatus/playsubstatus.ts
@@ -84,7 +84,7 @@ export async function handler(request: HTTPRequest): Promise<HTTPResponse> {
             .catch(
                 error => {
                     if (error['statusCode'] === 410) {
-                        console.log(`Purchase expired a very long time ago`)
+                        console.log(`Purchase expired a very long time ago`);
                         return HTTPResponses.NOT_FOUND
                     }
                     console.log(`Serving an Internal Server Error due to: ${error}`);

--- a/typescript/src/playsubstatus/playsubstatus.ts
+++ b/typescript/src/playsubstatus/playsubstatus.ts
@@ -82,7 +82,11 @@ export async function handler(request: HTTPRequest): Promise<HTTPResponse> {
                 }
             })
             .catch(
-                error =>  {
+                error => {
+                    if (error['statusCode'] === 410) {
+                        console.log(`Purchase expired a very long time ago`)
+                        return HTTPResponses.NOT_FOUND
+                    }
                     console.log(`Serving an Internal Server Error due to: ${error}`);
                     return HTTPResponses.INTERNAL_ERROR
                 }


### PR DESCRIPTION
Prior to this PR, we were serving a 500 when attempting to look up subscriptions which expired a long time ago.

See https://stackoverflow.com/questions/45688494/google-android-publisher-api-responds-with-410-purchasetokennolongervalid-erro for more details.