### PR TITLE
Add debug statement to Play subscription check

### DIFF
--- a/typescript/src/playsubstatus/playsubstatus.ts
+++ b/typescript/src/playsubstatus/playsubstatus.ts
@@ -54,6 +54,7 @@ function getPurchaseToken(headers: HttpRequestHeaders): string {
 
 function buildGoogleUrl(pathParams: PathParameters, headers: HttpRequestHeaders) {
     const baseUrl = 'https://www.googleapis.com/androidpublisher/v3/applications/com.guardian/purchases/subscriptions';
+    console.log(`Subscription id is: ${pathParams.subscriptionId}`);
     return `${baseUrl}/${pathParams.subscriptionId}/tokens/${getPurchaseToken(headers)}`;
 }
 


### PR DESCRIPTION
Adding a debug statement as an attempt to demystify an unusual error which Google is returning for a tiny % of requests: `purchaseTokenDoesNotMatchPackageName`

