### PR TITLE
Reconfigure teamcity build to run on docker container

### DIFF
--- a/build-tc-2.sh
+++ b/build-tc-2.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd tsc-target
+
+for BUNDLE in *.js
+do
+    zip "${BUNDLE%.*}.zip" "$BUNDLE"
+done

--- a/build-tc.sh
+++ b/build-tc.sh
@@ -3,8 +3,6 @@ set -e
 
 export NODE_OPTIONS="--max-old-space-size=2048"
 
-npm install -g yarn
-
 mkdir -p tsc-target
 
 yarn install
@@ -15,10 +13,3 @@ yarn run test
 
 # Will place .js files in tsc-target
 yarn run build
-
-cd tsc-target
-
-for BUNDLE in *.js
-do
-    zip "${BUNDLE%.*}.zip" "$BUNDLE"
-done


### PR DESCRIPTION
This will run in a docker container which doesn't have zip, but does have yarn.
`build-tc-2.sh` will run outside the container (this might not want to be a file, but just a separate build step)

Will make teamcity changes to accompany merging.