### PR TITLE
Increase threshold for subscription status check 5XX alarm

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -635,7 +635,7 @@ Resources:
       Namespace: AWS/ApiGateway
       Period: 300
       Statistic: Sum
-      Threshold: 3
+      Threshold: 10
       TreatMissingData: notBreaching
 
 


### PR DESCRIPTION
Now that this functionality is receiving production traffic the threshold can be increased. 

Currently a handful of errors on Google's side will trigger an alert - but these types of problems are not actionable and alerting in such cases just adds noise.