### PR TITLE
Introduce a new error type to help with error handling.

### DIFF
--- a/typescript/src/models/processingError.ts
+++ b/typescript/src/models/processingError.ts
@@ -1,0 +1,10 @@
+export class ProcessingError extends Error {
+    message: string;
+    shouldRetry?: boolean;
+
+    constructor(message: string, shouldRetry?: boolean) {
+        super(message);
+        this.message = message;
+        this.shouldRetry = shouldRetry;
+    }
+}

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -48,7 +48,7 @@ function validateReceipt(subRef: AppleSubscriptionReference): Promise<Response> 
 
 function checkResponseStatus(response: AppleValidationResponse): AppleValidationResponse {
     if ((response.status >= 21100 && response.status <= 21199) || response["is-retryable"]) {
-        console.error(`Server error received from Apple, got status ${response.status} for ${response.latest_receipt}, will retry`);
+        console.error(`Server error received from Apple, got status ${response.status}, will retry`);
         throw new ProcessingError(`Server error, status ${response.status}`, true);
     }
     if (response.status != 0 && response.status != 21006) {

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -54,6 +54,7 @@ export async function parseAndStoreSubscriptionUpdate (
                    console.error("Will throw an exception to retry this message");
                    throw error;
                }  else {
+                   console.error("The error wasn't retryable, giving up.");
                    return "Error, giving up"
                }
             } else {

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -2,6 +2,7 @@ import {SQSRecord} from 'aws-lambda'
 import {Subscription} from '../models/subscription';
 import {dynamoMapper} from "../utils/aws";
 import {ONE_YEAR_IN_SECONDS} from "../pubsub/pubsub";
+import {ProcessingError} from "../models/processingError";
 
 export function makeCancellationTime(cancellationTime: string) : string {
     if (cancellationTime) {
@@ -40,12 +41,25 @@ function putSubscription(subscription: Subscription): Promise<Subscription>  {
 export async function parseAndStoreSubscriptionUpdate (
     sqsRecord: SQSRecord,
     fetchSubscriberDetails: (record: SQSRecord) => Promise<Subscription>,
-) : Promise<Subscription> {
-   return fetchSubscriberDetails(sqsRecord)
-    .then(payload => putSubscription(payload))
-    .catch(error => {
-       console.log(`Error retrieving payload: ${error}`);
-       throw error;
-    });
+) : Promise<String> {
+    return fetchSubscriberDetails(sqsRecord)
+        .then(payload => {
+            putSubscription(payload);
+            return "OK"
+        })
+        .catch(error => {
+            if (error instanceof ProcessingError) {
+               console.error("Error processing the subscription update", error);
+               if (error.shouldRetry) {
+                   console.error("Will throw an exception to retry this message");
+                   throw error;
+               }  else {
+                   return "Error, giving up"
+               }
+            } else {
+               console.error("Unexpected error, will throw to retry: ", error);
+               throw error;
+            }
+        });
 
 }


### PR DESCRIPTION
There was no ticket for this work, I was reviewing the codebase as a whole before we release it.

The new error type carries a boolean flag to help the lambda handler decide whether or not to throw the exception or to swallow it. Some exceptions might be acceptable and the lambda considered a success, and some might require to be retried.