### PR TITLE
Reduce rows TTL

### DIFF
--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -4,7 +4,7 @@ import {UserSubscriptionData, parseAndStoreLink} from "./link";
 import {HTTPRequest, HTTPResponse, HTTPResponses} from "../models/apiGatewayHttp";
 
 type AppleSubscription = {
-    reciept: string
+    receipt: string
     transactionId: string
 }
 
@@ -15,7 +15,7 @@ type AppleLinkPayload = {
 
 export function parseAppleLinkPayload(requestBody?: string): UserSubscriptionData[] {
     const payload = JSON.parse(requestBody || "") as AppleLinkPayload
-    return payload.subscriptions.map ( subscription => new UserSubscriptionData(subscription.reciept, subscription.transactionId) )
+    return payload.subscriptions.map ( subscription => new UserSubscriptionData(subscription.receipt, subscription.transactionId) )
 }
 
 export async function handler(httpRequest: HTTPRequest)  {

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -6,6 +6,7 @@ import {dynamoMapper, sendToSqsImpl} from "../utils/aws";
 import {ItemNotFoundException} from "@aws/dynamodb-data-mapper";
 import {catchClause} from "@babel/types";
 import {getUserId, getIdentityToken} from "../utils/guIdentityApi";
+import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 
 export class UserSubscriptionData {
     transactionToken: string;
@@ -21,7 +22,8 @@ function putUserSubscription(subscriptionId: string, userId: string): Promise<Us
     const userSubscription = new UserSubscription(
         userId,
         subscriptionId,
-        new Date(Date.now()).toISOString()
+        new Date(Date.now()).toISOString(),
+        dateToSecondTimestamp(thirtyMonths())
     )
     return dynamoMapper.put({item: userSubscription}).then(result => result.item)
 }

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -55,14 +55,14 @@ export class GoogleSubscription extends Subscription {
 export class AppleSubscription extends Subscription {
 
     @attribute()
-    reciept: string;
+    receipt: string;
 
     @attribute()
     applePayload?: any;
 
     constructor(subscriptionId: string, startTimeStamp: string, endTimeStamp: string, cancellationTimetamp: string | undefined, autoRenewing: boolean, productId: string, ttl: number, reciept: string, applePayload: any) {
         super(subscriptionId, startTimeStamp, endTimeStamp, cancellationTimetamp, autoRenewing, productId, ttl);
-        this.reciept = reciept;
+        this.receipt = reciept;
         this.applePayload = applePayload;
     }
 }

--- a/typescript/src/models/userSubscription.ts
+++ b/typescript/src/models/userSubscription.ts
@@ -13,10 +13,14 @@ export class UserSubscription {
     @attribute()
     creationTimestamp: string
 
-    constructor(userId: string, subscriptionId: string, creationTimestamp: string) {
+    @attribute()
+    ttl: number;
+
+    constructor(userId: string, subscriptionId: string, creationTimestamp: string, ttl: number) {
         this.userId = userId;
         this.subscriptionId = subscriptionId;
         this.creationTimestamp = creationTimestamp;
+        this.ttl = ttl;
     }
     
 
@@ -42,7 +46,7 @@ export class ReadUserSubscription {
         this.subscriptionId = ""
         this.creationTimestamp = ""
     }
-    
+
     get[DynamoDbTable]() {
         return `${App}-${Stage}-user-subscriptions`
     }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -4,6 +4,7 @@ import {ONE_YEAR_IN_SECONDS, parseStoreAndSend} from "./pubsub";
 import {SubscriptionEvent} from "../models/subscriptionEvent";
 import {AppleReceiptInfo} from "../models/appleReceiptInfo";
 import {AppleSubscriptionReference} from "../models/appleSubscriptionReference";
+import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 
 export interface StatusUpdateNotification {
     environment: string,
@@ -48,7 +49,7 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         receiptInfo.bid,
         null,
         notification,
-        Math.ceil((now.getTime() / 1000) + 7 * ONE_YEAR_IN_SECONDS)
+        dateToSecondTimestamp(thirtyMonths(now))
     );
 }
 

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -3,6 +3,7 @@ import {HTTPRequest, HTTPResponse} from "../models/apiGatewayHttp";
 import {ONE_YEAR_IN_SECONDS, parseStoreAndSend} from "./pubsub";
 import {SubscriptionEvent} from "../models/subscriptionEvent";
 import {GoogleSubscriptionReference} from "../models/googleSubscriptionReference";
+import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 
 interface DeveloperNotification {
     version: string,
@@ -44,7 +45,8 @@ const GOOGLE_SUBS_EVENT_TYPE: {[_: number]: string} = {
 };
 
 export function toDynamoEvent(notification: DeveloperNotification): SubscriptionEvent {
-    const eventTimestamp = new Date(Number.parseInt(notification.eventTimeMillis)).toISOString();
+    const eventDate = new Date(Number.parseInt(notification.eventTimeMillis));
+    const eventTimestamp = eventDate.toISOString();
     const eventType = notification.subscriptionNotification.notificationType;
     const eventTypeString = GOOGLE_SUBS_EVENT_TYPE[eventType] || eventType.toString();
     return new SubscriptionEvent(
@@ -56,7 +58,7 @@ export function toDynamoEvent(notification: DeveloperNotification): Subscription
         notification.packageName,
         notification,
         null,
-        Math.ceil((Number.parseInt(notification.eventTimeMillis) / 1000) + 7 * ONE_YEAR_IN_SECONDS)
+        dateToSecondTimestamp(thirtyMonths(eventDate))
     );
 }
 

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -6,7 +6,7 @@ import {AppleSubscriptionReference} from "../models/appleSubscriptionReference";
 import fetch from 'node-fetch';
 import {Response} from 'node-fetch';
 import {Stage} from "../utils/appIdentity";
-import {msToFormattedString, optionalMsToFormattedString} from "../utils/dates";
+import {dateToSecondTimestamp, msToFormattedString, optionalMsToFormattedString, thirtyMonths} from "../utils/dates";
 import {ProcessingError} from "../models/processingError";
 
 // const receiptEndpoint = (Stage === "PROD") ? "https://buy.itunes.apple.com/verifyReceipt" : "https://sandbox.itunes.apple.com/verifyReceipt";
@@ -70,6 +70,8 @@ function toAppleSubscription(response: AppleValidationResponse, subRef: AppleSub
         autoRenewStatus = true;
     }
 
+    const expiryDate = new Date(Number.parseInt(latestReceiptInfo.expires_date));
+
     return new AppleSubscription(
         latestReceiptInfo.original_transaction_id,
         msToFormattedString(latestReceiptInfo.original_purchase_date_ms),
@@ -77,7 +79,7 @@ function toAppleSubscription(response: AppleValidationResponse, subRef: AppleSub
         optionalMsToFormattedString(latestReceiptInfo.cancellation_date_ms),
         autoRenewStatus,
         latestReceiptInfo.product_id,
-        makeTimeToLive(new Date(Date.now())),
+        dateToSecondTimestamp(thirtyMonths(expiryDate)),
         response.latest_receipt,
         response
     )

--- a/typescript/src/utils/dates.ts
+++ b/typescript/src/utils/dates.ts
@@ -12,7 +12,7 @@ export function optionalMsToFormattedString(ms?: string): string | undefined {
 
 export function thirtyMonths(from: Date = new Date()): Date {
     const newDate = new Date(from.getTime());
-    newDate.setMonth(from.getMonth() + 30);
+    newDate.setUTCMonth(from.getUTCMonth() + 30);
     return newDate;
 }
 

--- a/typescript/src/utils/dates.ts
+++ b/typescript/src/utils/dates.ts
@@ -9,3 +9,13 @@ export function optionalMsToFormattedString(ms?: string): string | undefined {
         return undefined;
     }
 }
+
+export function thirtyMonths(from: Date = new Date()): Date {
+    const newDate = new Date(from.getTime());
+    newDate.setMonth(from.getMonth() + 30);
+    return newDate;
+}
+
+export function dateToSecondTimestamp(date: Date): number {
+    return Math.ceil(date.getTime() / 1000);
+}

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -56,7 +56,7 @@ describe("The google pubsub", () => {
                 version: "1.0"
             },
             null,
-            1582322767
+            1582319167
         );
 
         return parseStoreAndSend(input, parseGooglePayload, googlePayloadToDynamo, toGoogleSqsEvent, mockStoreFunction, mockSqsFunction).then(result => {

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -56,7 +56,7 @@ describe("The google pubsub", () => {
                 version: "1.0"
             },
             null,
-            1724252767
+            1582322767
         );
 
         return parseStoreAndSend(input, parseGooglePayload, googlePayloadToDynamo, toGoogleSqsEvent, mockStoreFunction, mockSqsFunction).then(result => {

--- a/typescript/tests/utils/dates.test.ts
+++ b/typescript/tests/utils/dates.test.ts
@@ -3,18 +3,18 @@ import {dateToSecondTimestamp, thirtyMonths} from "../../src/utils/dates";
 
 describe("The thirtyMonths function", () => {
     test("Should add thrity months", () => {
-        const result = thirtyMonths(new Date(2019, 0, 1));
-        expect(result).toStrictEqual(new Date(2021, 6, 1));
+        const result = thirtyMonths(new Date(Date.UTC(2019, 0, 1)));
+        expect(result).toStrictEqual(new Date(Date.UTC(2021, 6, 1)));
     })
 });
 
 describe("The dateToSecondTimestamp function", () => {
     test("Should get the timestamp to the second", () => {
-        const result = dateToSecondTimestamp(new Date(2019, 0, 1));
+        const result = dateToSecondTimestamp(new Date(Date.UTC(2019, 0, 1)));
         expect(result).toStrictEqual(1546300800);
     });
     test("Should get the timestamp rounded up to the next second", () => {
-        const result = dateToSecondTimestamp(new Date(2019, 0, 1, 0, 0, 0, 32));
+        const result = dateToSecondTimestamp(new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 32)));
         expect(result).toStrictEqual(1546300801);
     });
 });

--- a/typescript/tests/utils/dates.test.ts
+++ b/typescript/tests/utils/dates.test.ts
@@ -1,0 +1,20 @@
+import {dateToSecondTimestamp, thirtyMonths} from "../../src/utils/dates";
+
+
+describe("The thirtyMonths function", () => {
+    test("Should add thrity months", () => {
+        const result = thirtyMonths(new Date(2019, 0, 1));
+        expect(result).toStrictEqual(new Date(2021, 6, 1));
+    })
+});
+
+describe("The dateToSecondTimestamp function", () => {
+    test("Should get the timestamp to the second", () => {
+        const result = dateToSecondTimestamp(new Date(2019, 0, 1));
+        expect(result).toStrictEqual(1546300800);
+    });
+    test("Should get the timestamp rounded up to the next second", () => {
+        const result = dateToSecondTimestamp(new Date(2019, 0, 1, 0, 0, 0, 32));
+        expect(result).toStrictEqual(1546300801);
+    });
+});


### PR DESCRIPTION
This pull request:

- reduce the TTL for events to 30 months since the event
- reduce the TTL of subscription to 30 month after the expiry date of the subscription
- introduce a TTL for the userSubscription table