### PR TITLE
Prepare for prod

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -104,6 +104,7 @@ Resources:
               Action:
                   - "dynamodb:GetItem"
                   - "dynamodb:BatchGetItem"
+                  - "dynamodb:BatchWriteItem"
                   - "dynamodb:PutItem"
                   - "dynamodb:UpdateItem"
                   - "dynamodb:Query"

--- a/typescript/src/link/google.ts
+++ b/typescript/src/link/google.ts
@@ -1,7 +1,9 @@
 import 'source-map-support/register'
 import {Platform} from "../models/platform";
-import {parseAndStoreLink, UserSubscriptionData} from "./link";
+import {parseAndStoreLink, SubscriptionCheckData} from "./link";
 import {HTTPRequest, HTTPResponses} from "../models/apiGatewayHttp";
+import {UserSubscription} from "../models/userSubscription";
+import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 
 type GoogleSubscription = {
     purchaseToken: string
@@ -10,18 +12,38 @@ type GoogleSubscription = {
 
 type GoogleLinkPayload = {
     platform: Platform.Android,
-    subscriptions: [GoogleSubscription]
+    subscriptions: GoogleSubscription[]
 }
 
-export function parseGoogleLinkPayload(requestBody?: string): UserSubscriptionData[] {
-    const payload = JSON.parse(requestBody || "") as GoogleLinkPayload
-    return payload.subscriptions.map ( subscription => new UserSubscriptionData(subscription.purchaseToken, subscription.subscriptionId))
+export function parseGoogleLinkPayload(request: HTTPRequest): GoogleLinkPayload {
+    return JSON.parse(request.body || "") as GoogleLinkPayload
+}
+
+function toUserSubscription(userId: string, payload: GoogleLinkPayload): UserSubscription[] {
+    return payload.subscriptions.map(sub => new UserSubscription(
+        userId,
+        sub.purchaseToken,
+        new Date().toISOString(),
+        dateToSecondTimestamp(thirtyMonths())
+    ));
+}
+
+function toSqsPayload(payload: GoogleLinkPayload): SubscriptionCheckData[] {
+    return payload.subscriptions.map(sub => ({
+        subscriptionId: sub.purchaseToken,
+        subscriptionReference: {
+            packageName: "com.guardian",
+            purchaseToken: sub.purchaseToken,
+            subscriptionId: sub.subscriptionId
+        }
+    }))
 }
 
 export async function handler(httpRequest: HTTPRequest) {
-    return parseAndStoreLink(httpRequest, parseGoogleLinkPayload)
-        .catch( error => {
-            console.log(`Error linking sub: ${error}`)
-            return HTTPResponses.INTERNAL_ERROR
-        })
+    return parseAndStoreLink(
+        httpRequest,
+        parseGoogleLinkPayload,
+        toUserSubscription,
+        toSqsPayload
+    )
 }

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -68,7 +68,7 @@ export async function parseAndStoreLink<A, B>(
             const userId = await getUserId(httpRequest.headers);
             const insertCount = await persistUserSubscriptionLinks(toUserSubscription(userId, payload));
             const sqsCount = await enqueueUnstoredPurchaseToken(toSqsPayload(payload));
-            console.log(`Put ${insertCount} links in the DB, and send ${sqsCount} subscription refs to SQS`);
+            console.log(`Put ${insertCount} links in the DB, and sent ${sqsCount} subscription refs to SQS`);
 
             return HTTPResponses.OK;
         } else {

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -2,99 +2,80 @@ import {HTTPRequest, HTTPResponse, HTTPResponses} from '../models/apiGatewayHttp
 
 import {UserSubscription} from "../models/userSubscription";
 import {Subscription} from "../models/subscription";
-import {dynamoMapper, sendToSqsImpl} from "../utils/aws";
+import {dynamoMapper, sqs} from "../utils/aws";
 import {ItemNotFoundException} from "@aws/dynamodb-data-mapper";
 import {getUserId, getIdentityToken} from "../utils/guIdentityApi";
-import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
+import {SubscriptionReference} from "../models/subscriptionReference";
+import {SendMessageBatchRequestEntry} from "aws-sdk/clients/sqs";
+import {ProcessingError} from "../models/processingError";
 
-export class UserSubscriptionData {
-    transactionToken: string;
-    subscriptionId: string;
+export interface SubscriptionCheckData {
+    subscriptionId: string
+    subscriptionReference: SubscriptionReference
+}
 
-    constructor(transactionToken: string, subscriptionId: string) {
-        this.transactionToken = transactionToken;
-        this.subscriptionId = subscriptionId;
+async function enqueueUnstoredPurchaseToken(subChecks: SubscriptionCheckData[]): Promise<number> {
+
+    const dynamoResult = dynamoMapper.batchGet(subChecks.map(sub => new Subscription(sub.subscriptionId)));
+
+    const refsToSend = subChecks.map(s => s.subscriptionId);
+
+    for await (const result of dynamoResult) {
+        const index = refsToSend.indexOf(result.subscriptionId);
+        if (index > -1) {
+            refsToSend.splice(index, 1);
+        }
     }
-}
 
-function putUserSubscription(subscriptionId: string, userId: string): Promise<UserSubscription> {
-    const userSubscription = new UserSubscription(
-        userId,
-        subscriptionId,
-        new Date(Date.now()).toISOString(),
-        dateToSecondTimestamp(thirtyMonths())
-    );
-    return dynamoMapper.put({item: userSubscription}).then(result => result.item)
-}
+    if (refsToSend.length > 0) {
+        const queueUrl = process.env.QueueUrl;
+        if (queueUrl === undefined) throw new Error("No QueueUrl env parameter provided");
 
-function subscriptionExists(purchaseToken: string): Promise<boolean> {
-    return dynamoMapper.get({item: new Subscription(purchaseToken)} ).then ( result => true )
-        .catch( error => {
-            if ( error.name === "ItemNotFoundException" ) {
-                return false
-            } else {
-                throw error
-            }
-        })
-}
+        const sqsMessages: SendMessageBatchRequestEntry[] = refsToSend.map((subscriptionId, index) => ({
+            Id: index.toString(),
+            MessageBody: JSON.stringify(subscriptionId)
+        }));
 
-function enqueueUnstoredPurchaseToken(subscriptionId: string, purchaseToken: string): Promise<void> {
-
-    const queueUrl = process.env.QueueUrl;
-    if (queueUrl === undefined) throw new Error("No QueueUrl env parameter provided");
-    const packageName = "com.guardian";
-
-    return subscriptionExists(purchaseToken).then(alreadyStored => {
-        if(!alreadyStored) {
-            const sqsEvent = {
-                packageName: packageName,
-                purchaseToken: purchaseToken,
-                subscriptionId: subscriptionId
-            };
-            return sendToSqsImpl(queueUrl, sqsEvent).then(() => undefined)
-        } else return Promise.resolve();
-    }).catch(error => {
-        console.log(`Error retrieving sub details ${error}`);
-        throw error
-    })
-}
-
-function persistUserSubscriptionLinks(userId: string, userSubscriptions: UserSubscriptionData[]): Promise<void>  {
-
-    const updatedSubLinks = userSubscriptions.map( subscription =>
-        putUserSubscription(subscription.transactionToken, userId)
-            .then( sub => enqueueUnstoredPurchaseToken(subscription.subscriptionId, subscription.transactionToken))
-            .catch( error => {
-                console.log(`Error persisting subscription links. ${error}`);
-                throw error
-            })
-    );
-
-    return Promise.all(updatedSubLinks)
-        .then(result => console.log(`Successfully stored a user subscription`))
-        .catch(error => {
-            console.log(`Unable to store subscription links: ${error}`);
-            throw error
-        });
-}
-
-export async function parseAndStoreLink (
-    httpRequest: HTTPRequest,
-    parsePayload: (requestBody?: string) => UserSubscriptionData[]
-): Promise<HTTPResponse> {
-
-    if(httpRequest.headers && getIdentityToken(httpRequest.headers)) {
-        return getUserId(httpRequest.headers)
-            .then( userId => {
-                const subscriptions = parsePayload(httpRequest.body);
-                return persistUserSubscriptionLinks(userId, subscriptions)
-            })
-            .then(result => HTTPResponses.OK)
-            .catch(error => {
-                console.log(`Error creating subscription link: ${error}`);
-                return HTTPResponses.INTERNAL_ERROR
-            });
+        const result = await sqs.sendMessageBatch({QueueUrl: queueUrl, Entries: sqsMessages}).promise();
+        if (result.Failed && result.Failed.length > 0) {
+            throw new ProcessingError("Unable to send all the subscription reference to SQS, will retry", true);
+        }
+        return result.Successful.length;
     } else {
-        return HTTPResponses.INVALID_REQUEST
+        return 0;
+    }
+
+}
+
+async function persistUserSubscriptionLinks(userSubscriptions: UserSubscription[]): Promise<number>  {
+    let count = 0;
+    for await (const r of dynamoMapper.batchPut(userSubscriptions)) {
+        count++;
+    }
+    return count;
+}
+
+export async function parseAndStoreLink<A, B>(
+    httpRequest: HTTPRequest,
+    parsePayload: (request: HTTPRequest) => A,
+    toUserSubscription: (userId: string, payload: A) => UserSubscription[],
+    toSqsPayload: (payload: A) => SubscriptionCheckData[]
+): Promise<HTTPResponse> {
+    try {
+        if (httpRequest.headers && getIdentityToken(httpRequest.headers)) {
+
+            const payload: A = parsePayload(httpRequest);
+            const userId = await getUserId(httpRequest.headers);
+            const insertCount = await persistUserSubscriptionLinks(toUserSubscription(userId, payload));
+            const sqsCount = await enqueueUnstoredPurchaseToken(toSqsPayload(payload));
+            console.log(`Put ${insertCount} links in the DB, and send ${sqsCount} subscription refs to SQS`);
+
+            return HTTPResponses.OK;
+        } else {
+            return HTTPResponses.INVALID_REQUEST
+        }
+    } catch (error) {
+        console.error("Internal Server Error", error);
+        return HTTPResponses.INTERNAL_ERROR
     }
 }

--- a/typescript/src/models/apiGatewayHttp.ts
+++ b/typescript/src/models/apiGatewayHttp.ts
@@ -39,5 +39,5 @@ export const HTTPResponses = {
     INVALID_REQUEST: new HTTPResponse(400, new HTTPResponseHeaders(), "{\"status\": 400, \"message\": \"INVALID_REQUEST\"}"),
     UNAUTHORISED: new HTTPResponse(401, new HTTPResponseHeaders(), "{\"status\": 401, \"message\": \"UNAUTHORISED\"}"),
     NOT_FOUND: new HTTPResponse(404, new HTTPResponseHeaders(), "{\"status\": 404, \"message\": \"NOT_FOUND\"}"),
-    INTERNAL_ERROR: new HTTPResponse(500, new HTTPResponseHeaders(), "{\"status\": 500, \"message\": \"INTERNAL SERVER ERROR\"}")
+    INTERNAL_ERROR: new HTTPResponse(500, new HTTPResponseHeaders(), "{\"status\": 500, \"message\": \"INTERNAL_SERVER_ERROR\"}")
 };

--- a/typescript/src/models/appleSubscriptionReference.ts
+++ b/typescript/src/models/appleSubscriptionReference.ts
@@ -1,4 +1,3 @@
 export interface AppleSubscriptionReference {
-    password: string,
     receipt: string
 }

--- a/typescript/src/models/appleSubscriptionReference.ts
+++ b/typescript/src/models/appleSubscriptionReference.ts
@@ -1,3 +1,0 @@
-export interface AppleSubscriptionReference {
-    receipt: string
-}

--- a/typescript/src/models/googleSubscriptionReference.ts
+++ b/typescript/src/models/googleSubscriptionReference.ts
@@ -1,7 +1,0 @@
-export interface GoogleSubscriptionReference {
-    packageName: string,
-    purchaseToken: string,
-    subscriptionId: string
-}
-
-

--- a/typescript/src/models/subscriptionReference.ts
+++ b/typescript/src/models/subscriptionReference.ts
@@ -1,0 +1,12 @@
+export interface SubscriptionReference {
+}
+
+export interface GoogleSubscriptionReference extends SubscriptionReference {
+    packageName: string,
+    purchaseToken: string,
+    subscriptionId: string
+}
+
+export interface AppleSubscriptionReference extends SubscriptionReference {
+    receipt: string
+}

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -3,8 +3,8 @@ import {HTTPRequest, HTTPResponse} from "../models/apiGatewayHttp";
 import {ONE_YEAR_IN_SECONDS, parseStoreAndSend} from "./pubsub";
 import {SubscriptionEvent} from "../models/subscriptionEvent";
 import {AppleReceiptInfo} from "../models/appleReceiptInfo";
-import {AppleSubscriptionReference} from "../models/appleSubscriptionReference";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
+import {AppleSubscriptionReference} from "../models/subscriptionReference";
 
 export interface StatusUpdateNotification {
     environment: string,

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -9,7 +9,7 @@ import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 export interface StatusUpdateNotification {
     environment: string,
     notification_type: string,
-    password: string,
+    password?: string,
     original_transaction_id: string,
     cancellation_date: string,
     web_order_line_item_id: string,
@@ -26,6 +26,7 @@ export interface StatusUpdateNotification {
 export function parsePayload(body?: string): Error | StatusUpdateNotification {
     try {
         let notification = JSON.parse(body || "") as StatusUpdateNotification;
+        delete notification.password; // no need to keep that in memory
         return notification;
     } catch (e) {
         console.log("Error during the parsing of the HTTP Payload body: " + e);
@@ -54,10 +55,8 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
 }
 
 export function toSqsSubReference(event: StatusUpdateNotification): AppleSubscriptionReference {
-    const receiptInfo = event.latest_receipt_info || event.latest_expired_receipt_info;
     const receipt = event.latest_receipt || event.latest_expired_receipt;
     return {
-        password: event.password,
         receipt: receipt
     }
 }

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -2,8 +2,8 @@ import 'source-map-support/register'
 import {HTTPRequest, HTTPResponse} from "../models/apiGatewayHttp";
 import {ONE_YEAR_IN_SECONDS, parseStoreAndSend} from "./pubsub";
 import {SubscriptionEvent} from "../models/subscriptionEvent";
-import {GoogleSubscriptionReference} from "../models/googleSubscriptionReference";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
+import {GoogleSubscriptionReference} from "../models/subscriptionReference";
 
 interface DeveloperNotification {
     version: string,

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -9,10 +9,8 @@ import {Stage} from "../utils/appIdentity";
 import {dateToSecondTimestamp, msToFormattedString, optionalMsToFormattedString, thirtyMonths} from "../utils/dates";
 import {ProcessingError} from "../models/processingError";
 
-// const receiptEndpoint = (Stage === "PROD") ? "https://buy.itunes.apple.com/verifyReceipt" : "https://sandbox.itunes.apple.com/verifyReceipt";
-// const environment = (Stage === "PROD") ? "Production" : "Sandbox";
-const receiptEndpoint = "https://buy.itunes.apple.com/verifyReceipt";
-const environment = "Production";
+const receiptEndpoint = (Stage === "PROD") ? "https://buy.itunes.apple.com/verifyReceipt" : "https://sandbox.itunes.apple.com/verifyReceipt";
+const environment = (Stage === "PROD") ? "Production" : "Sandbox";
 
 interface AppleValidatedReceiptInfo {
     cancellation_date_ms?: string,

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -1,14 +1,14 @@
 import 'source-map-support/register'
 import {SQSEvent, SQSRecord} from 'aws-lambda'
-import {makeTimeToLive, parseAndStoreSubscriptionUpdate} from "./updatesub";
+import {parseAndStoreSubscriptionUpdate} from "./updatesub";
 import {AppleSubscription} from "../models/subscription";
-import {AppleSubscriptionReference} from "../models/appleSubscriptionReference";
 import fetch from 'node-fetch';
 import {Response} from 'node-fetch';
 import {Stage} from "../utils/appIdentity";
 import {dateToSecondTimestamp, msToFormattedString, optionalMsToFormattedString, thirtyMonths} from "../utils/dates";
 import {ProcessingError} from "../models/processingError";
 import {getConfigValue} from "../utils/ssmConfig";
+import {AppleSubscriptionReference} from "../models/subscriptionReference";
 
 const receiptEndpoint = (Stage === "PROD") ? "https://buy.itunes.apple.com/verifyReceipt" : "https://sandbox.itunes.apple.com/verifyReceipt";
 

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -6,10 +6,10 @@ import {buildGoogleUrl, getAccessToken, getParams} from "../utils/google-play";
 import {parseAndStoreSubscriptionUpdate} from './updatesub';
 import {Stage} from "../utils/appIdentity";
 import {GoogleSubscription} from "../models/subscription";
-import {makeCancellationTime, makeTimeToLive} from "./updatesub";
-import {GoogleSubscriptionReference} from "../models/googleSubscriptionReference";
+import {makeCancellationTime} from "./updatesub";
 import {ProcessingError} from "../models/processingError";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
+import {GoogleSubscriptionReference} from "../models/subscriptionReference";
 
 interface GoogleResponseBody {
     startTimeMillis: string,

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -12,10 +12,6 @@ export function makeCancellationTime(cancellationTime: string) : string {
     }
 }
 
-export function makeTimeToLive(date: Date) {
-    return Math.ceil((date.getTime() / 1000) + 7 * ONE_YEAR_IN_SECONDS)
-}
-
 export class SubscriptionUpdate {
     purchaseToken: string;
     startTimeMillis: string;

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -5,6 +5,7 @@ import DynamoDB from 'aws-sdk/clients/dynamodb';
 import Sqs from 'aws-sdk/clients/sqs';
 import S3 from 'aws-sdk/clients/s3';
 import {PromiseResult} from "aws-sdk/lib/request";
+import SSM = require("aws-sdk/clients/ssm");
 
 
 const credentialProvider = new CredentialProviderChain([
@@ -27,6 +28,11 @@ export const sqs = new Sqs({
 });
 
 export const s3: S3  = new S3({
+    region: Region ,
+    credentialProvider: credentialProvider
+});
+
+export const ssm: SSM  = new SSM({
     region: Region ,
     credentialProvider: credentialProvider
 });

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -13,12 +13,12 @@ interface IdentityResponse {
 }
 
 export function getIdentityToken(headers: HttpRequestHeaders): string {
-    return headers["Gu-Identity-Token"] || headers["gu-identity-token"]
+    return (headers["Authorization"] || headers["authorization"]).replace("Bearer ", "");
 }
 
 export function getUserId(headers: HttpRequestHeaders): Promise<string> {
-    const url = "https://id.guardianapis.com/user/me"
-    const identityToken = getIdentityToken(headers)
+    const url = "https://id.guardianapis.com/user/me";
+    const identityToken = getIdentityToken(headers);
 
     return restClient.get<IdentityResponse>(url, {additionalHeaders: {Authorization: `Bearer ${identityToken}`}})
         .then( res => {

--- a/typescript/src/utils/option.ts
+++ b/typescript/src/utils/option.ts
@@ -1,0 +1,1 @@
+export type Option<A> = A | null;

--- a/typescript/src/utils/ssmConfig.ts
+++ b/typescript/src/utils/ssmConfig.ts
@@ -1,0 +1,59 @@
+import {ssm} from "./aws";
+import {App, Stack, Stage} from "./appIdentity";
+import {Option} from "./option";
+
+type Config = {[key: string]: any};
+
+function recursivelyFetchConfig(nextToken?: string, currentConfig?: Config): Promise<Config> {
+    const path = `/${App}/${Stage}/${Stack}/`;
+    return ssm.getParametersByPath({
+        Path: path,
+        WithDecryption: true,
+        NextToken: nextToken
+    }).promise()
+        .then(result => {
+            const fetchedConfig: Config = {};
+            if (result.Parameters) {
+                result.Parameters.forEach(param => {
+                    if (param.Name) {
+                        const name = param.Name.replace(path, '');
+                        fetchedConfig[name] = param.Value
+                    }
+                });
+            }
+            const config = Object.assign({}, currentConfig, fetchedConfig);
+            if (result.NextToken) {
+                return recursivelyFetchConfig(result.NextToken, config);
+            } else {
+                return Promise.resolve(config);
+            }
+        });
+}
+
+let state: Option<Config> = null;
+
+function fetchConfig(): Promise<Config> {
+    if (state == null) {
+        return recursivelyFetchConfig()
+            .then(config => {
+                state = config;
+                return config;
+            })
+    } else {
+        return Promise.resolve(state);
+    }
+}
+
+export function getConfigValue<A>(key: string, defaultValue?: A): Promise<A> {
+    return fetchConfig().then(conf => {
+        if (conf[key]) {
+            return conf[key];
+        } else {
+            if (defaultValue) {
+                return defaultValue;
+            } else {
+                throw new Error(`No config value for key: /${App}/${Stage}/${Stack}/${key}`)
+            }
+        }
+    });
+}


### PR DESCRIPTION
In this PR:

- Re-establish the environment checks to point PROD to PROD and CODE to Sandbox
- Load the apple "password" from the configuration, and delete it from all payloads.
- Re-use the SQS models between the link lambda and the rest of the codebase
- Refactor the link lambda to share more code between apple and google
- Generally fix the lambda as it wasn't doing what it was expected
- Start using async await in the link lambda. We should probably start using that pattern everywhere but I didn't feel like rewriting the codebase