### PR TITLE
Part two of exporting the events to the datalake

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,7 @@ lazy val root = project
     riffRaffArtifactResources += file("tsc-target/apple-update-subscriptions.zip") -> s"mobile-purchases-apple-update-subscriptions/apple-update-subscriptions.zip",
     riffRaffArtifactResources += file("tsc-target/user-subscriptions.zip") -> s"mobile-purchases-user-subscriptions/user-subscriptions.zip",
     riffRaffArtifactResources += file("tsc-target/export-subscription-tables.zip") -> s"mobile-purchases-export-subscription-tables/export-subscription-tables.zip",
+    riffRaffArtifactResources += file("tsc-target/export-subscription-events-table.zip") -> s"mobile-purchases-export-subscription-events-table/export-subscription-events-table.zip",
     riffRaffArtifactResources += file("cloudformation.yaml") -> s"mobile-purchases-cloudformation/cloudformation.yaml",
   )
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -47,6 +47,9 @@ Parameters:
   UserSubscriptionExportBucket:
     Type: String
     Description: The name of the export user subscription bucket
+  SubscriptionEventsExportBucket:
+    Type: String
+    Description: The name of the export events bucket
 
 Resources:
   MobilePurchasesLambdasRole:
@@ -816,9 +819,11 @@ Resources:
               Effect: Allow
               Action:
                 - "dynamodb:Scan"
+                - "dynamodb:Query"
               Resource:
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions
+                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscription-events-v2/*
         - PolicyName: s3
           PolicyDocument:
             Statement:
@@ -829,6 +834,7 @@ Resources:
               Resource:
                 - !Sub arn:aws:s3:::${SubscriptionExportBucket}/*
                 - !Sub arn:aws:s3:::${UserSubscriptionExportBucket}/*
+                - !Sub arn:aws:s3:::${SubscriptionEventsExportBucket}/*
 
   ExportSubscriptionTableLambda:
     Type: AWS::Serverless::Function
@@ -878,6 +884,35 @@ Resources:
           ExportBucket: !Ref UserSubscriptionExportBucket
           ClassName: ReadUserSubscription
       Description: Export the user subscription table to the datalake
+      MemorySize: 512
+      Timeout: 900
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(3 0 1/1 * ? *)
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App
+
+  ExportUserSubscriptionEventsTableLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: export-subscription-events-table.handler
+      Runtime: nodejs10.x
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-export-subscription-events-table/export-subscription-events-table.zip
+      FunctionName: !Sub ${App}-export-subscription-events-table-${Stage}
+      Role: !GetAtt ExportLambdasRole.Arn
+      Environment:
+        Variables:
+          App: !Sub ${App}
+          Stack: !Sub ${Stack}
+          Stage: !Sub ${Stage}
+          ExportBucket: !Ref SubscriptionEventsExportBucket
+      Description: Export the subscription event table to the datalake
       MemorySize: 512
       Timeout: 900
       Events:

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -66,14 +66,14 @@ Resources:
         - AttributeName: timestampAndType
           KeyType: RANGE
       GlobalSecondaryIndexes:
-        - IndexName: date-timestamp-index
+        - IndexName: date-timestamp-index-v2
           KeySchema:
             - AttributeName: date
               KeyType: HASH
             - AttributeName: timestamp
               KeyType: RANGE
           Projection:
-            ProjectionType: KEYS_ONLY
+            ProjectionType: ALL
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       BillingMode: PAY_PER_REQUEST

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -47,36 +47,6 @@ Resources:
         - Key: App
           Value: !Ref App
 
-  UserSubscriptionEventsTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      TableName: !Sub ${App}-${Stage}-subscription-events
-      AttributeDefinitions:
-        - AttributeName: subscriptionId
-          AttributeType: S
-        - AttributeName: timestampAndType
-          AttributeType: S
-      KeySchema:
-        - AttributeName: subscriptionId
-          KeyType: HASH
-        - AttributeName: timestampAndType
-          KeyType: RANGE
-      PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
-      BillingMode: PAY_PER_REQUEST
-      SSESpecification:
-        SSEEnabled: true
-      TimeToLiveSpecification:
-        Enabled: true
-        AttributeName: ttl
-      Tags:
-        - Key: Stage
-          Value: !Ref Stage
-        - Key: Stack
-          Value: !Ref Stack
-        - Key: App
-          Value: !Ref App
-
   UserSubscriptionEventsTableV2:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -117,3 +117,12 @@ deployments:
       functionNames: [mobile-purchases-export-subscription-table-, mobile-purchases-export-user-subscription-table-]
       fileName: export-subscription-tables.zip
       prefixStack: false
+
+  mobile-purchases-export-subscription-events-table:
+    type: aws-lambda
+    dependencies: [mobile-purchases-cloudformation]
+    parameters:
+      bucket: mobile-dist
+      functionNames: [mobile-purchases-export-subscription-events-table-]
+      fileName: export-subscription-events-table.zip
+      prefixStack: false

--- a/typescript/src/export/exportEvents.ts
+++ b/typescript/src/export/exportEvents.ts
@@ -1,0 +1,38 @@
+import 'source-map-support/register'
+import {dynamoMapper, s3} from "../utils/aws";
+import zlib from 'zlib'
+import {Stage} from "../utils/appIdentity";
+import {DynamoStream} from "./dynamoStream";
+import {ReadSubscriptionEvent, SubscriptionEvent} from "../models/subscriptionEvent";
+import {plusDays} from "../utils/dates";
+
+function cleanupEvent(subEvent: SubscriptionEvent): any {
+    if (subEvent.applePayload) {
+        delete subEvent.applePayload.password; // just to be safe
+        delete subEvent.applePayload.latest_receipt; // really no need to put that in the datalake
+    }
+    return subEvent;
+}
+
+export async function handler(): Promise<any> {
+    const bucket = process.env['ExportBucket'];
+    if (!bucket) throw new Error('Variable ExportBucket must be set');
+
+    const yesterday = plusDays(new Date(), -1).toISOString().substr(0,10);
+
+    const iterator = dynamoMapper.query(ReadSubscriptionEvent,{date: yesterday}, {indexName: "date-timestamp-index-v2"});
+    const stream = new DynamoStream(iterator, cleanupEvent);
+
+    let zippedStream = zlib.createGzip();
+    stream.pipe(zippedStream);
+
+    const prefix = (Stage === "PROD") ? "data" : "code-data";
+    const filename = `${prefix}/date=${yesterday}/${yesterday}.json.gz`;
+    let managedUpload = s3.upload({Bucket: bucket, Key: filename, Body: zippedStream});
+
+    await managedUpload.promise();
+
+    console.log(`Export succeeded, read ${stream.recordCount()} records`);
+
+    return {recordCount: stream.recordCount()};
+}

--- a/typescript/src/export/exportEvents.ts
+++ b/typescript/src/export/exportEvents.ts
@@ -28,7 +28,12 @@ export async function handler(): Promise<any> {
 
     const prefix = (Stage === "PROD") ? "data" : "code-data";
     const filename = `${prefix}/date=${yesterday}/${yesterday}.json.gz`;
-    let managedUpload = s3.upload({Bucket: bucket, Key: filename, Body: zippedStream});
+    let managedUpload = s3.upload({
+        Bucket: bucket,
+        Key: filename,
+        Body: zippedStream,
+        ACL: "bucket-owner-full-control"
+    });
 
     await managedUpload.promise();
 

--- a/typescript/src/export/exportEvents.ts
+++ b/typescript/src/export/exportEvents.ts
@@ -14,11 +14,18 @@ function cleanupEvent(subEvent: SubscriptionEvent): any {
     return subEvent;
 }
 
-export async function handler(): Promise<any> {
+interface ManualBackfillEvent {
+    date?: string;
+}
+
+export async function handler(event?: ManualBackfillEvent): Promise<any> {
     const bucket = process.env['ExportBucket'];
     if (!bucket) throw new Error('Variable ExportBucket must be set');
 
-    const yesterday = plusDays(new Date(), -1).toISOString().substr(0,10);
+    let yesterday = plusDays(new Date(), -1).toISOString().substr(0,10);
+    if (event && event.date) {
+        yesterday = event.date;
+    }
 
     const iterator = dynamoMapper.query(ReadSubscriptionEvent,{date: yesterday}, {indexName: "date-timestamp-index-v2"});
     const stream = new DynamoStream(iterator, cleanupEvent);

--- a/typescript/src/export/exportSubscriptions.ts
+++ b/typescript/src/export/exportSubscriptions.ts
@@ -5,6 +5,7 @@ import {ReadUserSubscription} from "../models/userSubscription";
 import zlib from 'zlib'
 import {Stage} from "../utils/appIdentity";
 import {DynamoStream} from "./dynamoStream";
+import {plusDays} from "../utils/dates";
 
 export async function handler(): Promise<any> {
     const bucket = process.env['ExportBucket'];
@@ -26,9 +27,9 @@ export async function handler(): Promise<any> {
     let zippedStream = zlib.createGzip();
     stream.pipe(zippedStream);
 
-    const today = (new Date()).toISOString().substr(0,10);
+    const yesterday = plusDays(new Date(), -1).toISOString().substr(0,10);
     const prefix = (Stage === "PROD") ? "data" : "code-data";
-    const filename = `${prefix}/date=${today}/${today}.json.gz`;
+    const filename = `${prefix}/date=${yesterday}/${yesterday}.json.gz`;
     const managedUpload = s3.upload({
         Bucket: bucket,
         Key: filename,

--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -41,3 +41,9 @@ export class SubscriptionEvent {
         return App + "-" + Stage + "-subscription-events-v2";
     }
 }
+
+export class ReadSubscriptionEvent extends SubscriptionEvent {
+    constructor() {
+        super("", "", "", "", "", "", "", {}, {}, 0);
+    }
+}

--- a/typescript/src/utils/dates.ts
+++ b/typescript/src/utils/dates.ts
@@ -11,11 +11,21 @@ export function optionalMsToFormattedString(ms?: string): string | undefined {
 }
 
 export function thirtyMonths(from: Date = new Date()): Date {
-    const newDate = new Date(from.getTime());
-    newDate.setUTCMonth(from.getUTCMonth() + 30);
-    return newDate;
+    return plusMonths(from, 30);
 }
 
 export function dateToSecondTimestamp(date: Date): number {
     return Math.ceil(date.getTime() / 1000);
+}
+
+export function plusMonths(from: Date, count: number): Date {
+    const newDate = new Date(from.getTime());
+    newDate.setUTCMonth(from.getUTCMonth() + count);
+    return newDate;
+}
+
+export function plusDays(from: Date, count: number): Date {
+    const newDate = new Date(from.getTime());
+    newDate.setUTCDate(from.getUTCDate() + count);
+    return newDate;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,15 @@ const exportSubs = Object.assign({}, config, {
     }
 });
 
+const exportEvents = Object.assign({}, config, {
+    entry: './typescript/src/export/exportEvents.ts',
+    output: {
+        filename: 'export-subscription-events-table.js',
+        path: path.resolve(__dirname, 'tsc-target'),
+        libraryTarget: 'commonjs'
+    }
+});
+
 module.exports = [
     googlePubSub,
     applePubSub,
@@ -108,5 +117,6 @@ module.exports = [
     appleUserLink,
     googleUserLink,
     userSubscriptions,
-    exportSubs
+    exportSubs,
+    exportEvents
 ];


### PR DESCRIPTION
This PR aims to export the purchase events to the datalake RAW buckets.

- Drop the v1 table following the migration to the v2 of the subscription events table (v1 isn't used anymore at this point)
- Fix the date logic of the exports. The date in the s3 bucket should be yesterday. So on the 2nd of september at 00:01, what we really are exporting is the 1st of september
- Take an optional event as a parameter for the events export as we will want the capability to export previous days
- The actual logic of the export