### PR TITLE
Better builds

### DIFF
--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -1,4 +1,4 @@
-import {CredentialProviderChain, ECSCredentials, SharedIniFileCredentials, AWSError} from "aws-sdk";
+import {SharedIniFileCredentials, CredentialProviderChain, ECSCredentials, AWSError} from "aws-sdk/lib/core";
 import {Region} from "./appIdentity";
 import {DataMapper, ItemNotFoundException} from "@aws/dynamodb-data-mapper";
 import DynamoDB from 'aws-sdk/clients/dynamodb';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const config = {
-    devtool: 'inline-source-map',
+    devtool: 'inline-cheap-source-map',
     module: {
         rules: [
             {
@@ -24,7 +24,7 @@ function entryPoint(sourceFile, outputFile) {
         output: {
             filename: outputFile,
             path: path.resolve(__dirname, 'tsc-target'),
-            libraryTarget: 'commonjs'
+            libraryTarget: 'commonjs2'
         }
     });
 }


### PR DESCRIPTION
Shorten build time, make bundles much smaller:

From 5.9 MiB in 184s to 1.3MiB in 47s.

Our lambdas could officially fit on a floppy disk now 💾.