### PR TITLE
Link retention

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val root = project
     riffRaffArtifactResources += file("tsc-target/google-playsubstatus.zip") -> s"mobile-purchases-google-playsubstatus/google-playsubstatus.zip",
     riffRaffArtifactResources += file("tsc-target/apple-link-user-subscription.zip") -> s"mobile-purchases-apple-link-user-subscription/apple-link-user-subscription.zip",
     riffRaffArtifactResources += file("tsc-target/google-link-user-subscription.zip") -> s"mobile-purchases-google-link-user-subscription/google-link-user-subscription.zip",
+    riffRaffArtifactResources += file("tsc-target/delete-user-subscription.zip") -> s"mobile-purchases-delete-user-subscription/delete-user-subscription.zip",
     riffRaffArtifactResources += file("tsc-target/google-update-subscriptions.zip") -> s"mobile-purchases-google-update-subscriptions/google-update-subscriptions.zip",
     riffRaffArtifactResources += file("tsc-target/apple-update-subscriptions.zip") -> s"mobile-purchases-apple-update-subscriptions/apple-update-subscriptions.zip",
     riffRaffArtifactResources += file("tsc-target/user-subscriptions.zip") -> s"mobile-purchases-user-subscriptions/user-subscriptions.zip",

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -924,3 +924,69 @@ Resources:
         Stage: !Ref Stage
         Stack: !Ref Stack
         App: !Ref App
+
+  DeleteUserLinkLambdasRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: logs
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+                - cloudwatch:putMetricData
+              Resource: "*"
+        - PolicyName: dynamo
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - "dynamodb:GetRecords"
+                - "dynamodb:GetShardIterator"
+                - "dynamodb:DescribeStream"
+                - "dynamodb:ListStreams"
+              Resource:
+                - Fn::ImportValue:
+                    !Sub ${App}-${Stage}-subscriptions-stream-arn
+
+  DeleteUserSubscriptionLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: delete-user-subscription.handler
+      Runtime: nodejs10.x
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-delete-user-subscription/delete-user-subscription.zip
+      FunctionName: !Sub ${App}-delete-user-subscription-${Stage}
+      Role: !GetAtt DeleteUserLinkLambdasRole.Arn
+      Environment:
+        Variables:
+          App: !Sub ${App}
+          Stack: !Sub ${Stack}
+          Stage: !Sub ${Stage}
+      Description: Delete the link to user IDs when the subscription has reached its end of life
+      MemorySize: 512
+      Timeout: 60
+      Events:
+        Schedule:
+          Type: DynamoDB
+          Properties:
+            Stream:
+              Fn::ImportValue:
+                !Sub ${App}-${Stage}-subscriptions-stream-arn
+            StartingPosition: LATEST
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -947,7 +947,7 @@ Resources:
                 - logs:PutLogEvents
                 - cloudwatch:putMetricData
               Resource: "*"
-        - PolicyName: dynamo
+        - PolicyName: dynamoStream
           PolicyDocument:
             Statement:
               Effect: Allow
@@ -959,6 +959,16 @@ Resources:
               Resource:
                 - Fn::ImportValue:
                     !Sub ${App}-${Stage}-subscriptions-stream-arn
+        - PolicyName: dynamo
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - "dynamodb:Query"
+                - "dynamodb:DeleteItem"
+              Resource:
+                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions
+                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions/*
 
   DeleteUserSubscriptionLambda:
     Type: AWS::Serverless::Function

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -129,6 +129,15 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       SSESpecification:
         SSEEnabled: true
+      GlobalSecondaryIndexes:
+        - IndexName: subscriptionId-userId
+          KeySchema:
+            - AttributeName: subscriptionId
+              KeyType: HASH
+            - AttributeName: userId
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
       Tags:
         - Key: Stage
           Value: !Ref Stage

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -100,6 +100,8 @@ Resources:
       TimeToLiveSpecification:
         Enabled: true
         AttributeName: ttl
+      StreamSpecification:
+        StreamViewType: KEYS_ONLY
       Tags:
         - Key: Stage
           Value: !Ref Stage
@@ -127,9 +129,6 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       SSESpecification:
         SSEEnabled: true
-      TimeToLiveSpecification:
-        Enabled: true
-        AttributeName: ttl
       Tags:
         - Key: Stage
           Value: !Ref Stage
@@ -137,3 +136,10 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
+
+Outputs:
+  SubscriptionTableStream:
+    Description: The ARN of the dynamo DB stream
+    Value: !GetAtt SubscriptionTable.StreamArn
+    Export:
+      Name: !Sub ${App}-${Stage}-subscriptions-stream-arn

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,6 +1,14 @@
 stacks: [mobile]
 regions: [eu-west-1]
 
+templates:
+  lambda:
+    type: aws-lambda
+    dependencies: [mobile-purchases-cloudformation]
+    parameters:
+      bucket: mobile-dist
+      prefixStack: false
+
 deployments:
   mobile-purchases-cloudformation:
     type: cloud-formation
@@ -8,130 +16,85 @@ deployments:
       templatePath: cloudformation.yaml
 
   mobile-purchases-ios-validate-receipts:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-iosvalidatereceipts-]
       fileName: mobile-purchases-ios-validate-receipts.jar
-      prefixStack: false
 
   mobile-purchases-ios-user-purchases:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-iosuserpurchases-]
       fileName: mobile-purchases-ios-user-purchases.jar
-      prefixStack: false
 
   mobile-purchases-google-pubsub:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
-      functionNames:
-        - mobile-purchases-googlepubsub-
+      functionNames: [mobile-purchases-googlepubsub-]
       fileName: google-pubsub.zip
-      prefixStack: false
 
   mobile-purchases-apple-pubsub:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
-      functionNames:
-        - mobile-purchases-applepubsub-
+      functionNames: [mobile-purchases-applepubsub-]
       fileName: apple-pubsub.zip
-      prefixStack: false
 
   mobile-purchases-google-playsubstatus:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
-      functionNames:
-        - mobile-purchases-googleplaysubstatus-
+      functionNames: [mobile-purchases-googleplaysubstatus-]
       fileName: google-playsubstatus.zip
-      prefixStack: false
 
   mobile-purchases-google-oauth:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-googleoauth-]
       fileName: mobile-purchases-google-oauth.jar
-      prefixStack: false
 
   mobile-purchases-google-link-user-subscription:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-google-link-user-subscription-]
       fileName: google-link-user-subscription.zip
-      prefixStack: false
 
   mobile-purchases-apple-link-user-subscription:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-apple-link-user-subscription-]
       fileName: apple-link-user-subscription.zip
-      prefixStack: false
 
   mobile-purchases-google-update-subscriptions:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-google-update-subscriptions-]
       fileName: google-update-subscriptions.zip
-      prefixStack: false
 
   mobile-purchases-user-subscriptions:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-user-subscriptions-]
       fileName: user-subscriptions.zip
-      prefixStack: false
 
   mobile-purchases-apple-update-subscriptions:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-apple-update-subscriptions-]
       fileName: apple-update-subscriptions.zip
-      prefixStack: false
 
   mobile-purchases-export-subscription-tables:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-export-subscription-table-, mobile-purchases-export-user-subscription-table-]
       fileName: export-subscription-tables.zip
-      prefixStack: false
 
   mobile-purchases-export-subscription-events-table:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-export-subscription-events-table-]
       fileName: export-subscription-events-table.zip
-      prefixStack: false
 
   mobile-purchases-delete-user-subscription:
-    type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    template: lambda
     parameters:
-      bucket: mobile-dist
       functionNames: [mobile-purchases-delete-user-subscription-]
       fileName: delete-user-subscription.zip
-      prefixStack: false

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -126,3 +126,12 @@ deployments:
       functionNames: [mobile-purchases-export-subscription-events-table-]
       fileName: export-subscription-events-table.zip
       prefixStack: false
+
+  mobile-purchases-delete-user-subscription:
+    type: aws-lambda
+    dependencies: [mobile-purchases-cloudformation]
+    parameters:
+      bucket: mobile-dist
+      functionNames: [mobile-purchases-delete-user-subscription-]
+      fileName: delete-user-subscription.zip
+      prefixStack: false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
@@ -11,10 +11,10 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-     "outDir": "tsc-target",                      /* Redirect output structure to the directory. */
+    "outDir": "tsc-target",                   /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
-    // "incremental": true,                   /* Enable incremental compilation */
+    "incremental": true,                      /* Enable incremental compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */

--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -3,7 +3,6 @@ import {Platform} from "../models/platform";
 import {parseAndStoreLink, SubscriptionCheckData} from "./link";
 import {HTTPRequest, HTTPResponse} from "../models/apiGatewayHttp";
 import {UserSubscription} from "../models/userSubscription";
-import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 
 type AppleSubscription = {
     receipt: string
@@ -23,8 +22,7 @@ function toUserSubscription(userId: string, payload: AppleLinkPayload): UserSubs
     return payload.subscriptions.map(sub => new UserSubscription(
         userId,
         sub.originalTransactionId,
-        new Date().toISOString(),
-        dateToSecondTimestamp(thirtyMonths())
+        new Date().toISOString()
     ));
 }
 

--- a/typescript/src/link/deleteLink.ts
+++ b/typescript/src/link/deleteLink.ts
@@ -1,0 +1,7 @@
+import 'source-map-support/register'
+import {DynamoDBStreamEvent} from "aws-lambda";
+
+export async function handler(parameter: DynamoDBStreamEvent): Promise<any> {
+    console.log(parameter);
+    return parameter;
+}

--- a/typescript/src/link/deleteLink.ts
+++ b/typescript/src/link/deleteLink.ts
@@ -1,13 +1,54 @@
 import 'source-map-support/register'
 import {DynamoDBStreamEvent} from "aws-lambda";
+import {dynamoMapper} from "../utils/aws";
+import {ReadUserSubscription} from "../models/userSubscription";
+
+async function deleteUserSubscription(subscriptionId: string): Promise<number> {
+    let count = 0;
+    const userLinks = await dynamoMapper.query(ReadUserSubscription, {subscriptionId}, {indexName: "subscriptionId-userId"});
+    for await (const userLink of userLinks) {
+        const deletionResult = await dynamoMapper.delete(userLink);
+        if (deletionResult) {
+            count++;
+        }
+    }
+
+    if (userLinks.count != count) {
+        console.warn(`Queried ${userLinks.count} rows, but only deleted ${count}`)
+    }
+
+    console.log(`Deleted ${count} rows`);
+    return count;
+}
 
 export async function handler(event: DynamoDBStreamEvent): Promise<any> {
     const ttlEvents = event.Records.filter(dynamoEvent => {
         return dynamoEvent.eventName == "REMOVE" &&
             dynamoEvent.userIdentity &&
             dynamoEvent.userIdentity.type == "Service" &&
-            dynamoEvent.userIdentity.principalId == "dynamodb.amazonaws.com"
+            dynamoEvent.userIdentity.principalId == "dynamodb.amazonaws.com" &&
+            dynamoEvent.dynamodb &&
+            dynamoEvent.dynamodb.Keys &&
+            dynamoEvent.dynamodb.Keys.subscriptionId
     });
-    console.log(JSON.stringify(ttlEvents));
-    return event;
+
+    const subscriptionsPromises = ttlEvents
+        // @ts-ignore
+        .map(event => event.dynamodb.Keys.subscriptionId.S || "")
+        .map(deleteUserSubscription);
+
+
+    let records = 0;
+    let rows = 0;
+    for await (const deletedCount of subscriptionsPromises) {
+        records++;
+        rows += deletedCount;
+    }
+
+    console.log(`Processed ${records} records from dynamo stream to delete ${rows} rows`);
+
+    return {
+        recordCount: records,
+        rowCount: rows
+    }
 }

--- a/typescript/src/link/deleteLink.ts
+++ b/typescript/src/link/deleteLink.ts
@@ -1,7 +1,13 @@
 import 'source-map-support/register'
 import {DynamoDBStreamEvent} from "aws-lambda";
 
-export async function handler(parameter: DynamoDBStreamEvent): Promise<any> {
-    console.log(parameter);
-    return parameter;
+export async function handler(event: DynamoDBStreamEvent): Promise<any> {
+    const ttlEvents = event.Records.filter(dynamoEvent => {
+        return dynamoEvent.eventName == "REMOVE" &&
+            dynamoEvent.userIdentity &&
+            dynamoEvent.userIdentity.type == "Service" &&
+            dynamoEvent.userIdentity.principalId == "dynamodb.amazonaws.com"
+    });
+    console.log(JSON.stringify(ttlEvents));
+    return event;
 }

--- a/typescript/src/link/google.ts
+++ b/typescript/src/link/google.ts
@@ -3,7 +3,6 @@ import {Platform} from "../models/platform";
 import {parseAndStoreLink, SubscriptionCheckData} from "./link";
 import {HTTPRequest, HTTPResponses} from "../models/apiGatewayHttp";
 import {UserSubscription} from "../models/userSubscription";
-import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 
 type GoogleSubscription = {
     purchaseToken: string
@@ -23,8 +22,7 @@ function toUserSubscription(userId: string, payload: GoogleLinkPayload): UserSub
     return payload.subscriptions.map(sub => new UserSubscription(
         userId,
         sub.purchaseToken,
-        new Date().toISOString(),
-        dateToSecondTimestamp(thirtyMonths())
+        new Date().toISOString()
     ));
 }
 

--- a/typescript/src/models/userSubscription.ts
+++ b/typescript/src/models/userSubscription.ts
@@ -5,24 +5,19 @@ import {App, Stage} from "../utils/appIdentity";
 export class UserSubscription {
 
     @hashKey()
-    userId: string
+    userId: string;
 
     @attribute()
-    subscriptionId: string
+    subscriptionId: string;
 
     @attribute()
-    creationTimestamp: string
+    creationTimestamp: string;
 
-    @attribute()
-    ttl: number;
-
-    constructor(userId: string, subscriptionId: string, creationTimestamp: string, ttl: number) {
+    constructor(userId: string, subscriptionId: string, creationTimestamp: string) {
         this.userId = userId;
         this.subscriptionId = subscriptionId;
         this.creationTimestamp = creationTimestamp;
-        this.ttl = ttl;
     }
-    
 
     get[DynamoDbTable]() {
         return `${App}-${Stage}-user-subscriptions`
@@ -33,7 +28,7 @@ export class UserSubscription {
 export class ReadUserSubscription extends UserSubscription {
 
     constructor() {
-        super("", "", "", 0);
+        super("", "", "");
     }
 
 }

--- a/typescript/src/models/userSubscription.ts
+++ b/typescript/src/models/userSubscription.ts
@@ -1,4 +1,4 @@
-import {hashKey, attribute} from '@aws/dynamodb-data-mapper-annotations';
+import {hashKey, attribute, rangeKey} from '@aws/dynamodb-data-mapper-annotations';
 import {DynamoDbTable} from "@aws/dynamodb-data-mapper";
 import {App, Stage} from "../utils/appIdentity";
 
@@ -7,7 +7,7 @@ export class UserSubscription {
     @hashKey()
     userId: string;
 
-    @attribute()
+    @rangeKey()
     subscriptionId: string;
 
     @attribute()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,7 @@ const applePubSub = entryPoint('pubsub/apple.ts', 'apple-pubsub.js');
 const googlePlaySubStatus = entryPoint('playsubstatus/playsubstatus.ts', 'google-playsubstatus.js');
 const googleUserLink = entryPoint('link/google.ts', 'google-link-user-subscription.js');
 const appleUserLink = entryPoint('link/apple.ts', 'apple-link-user-subscription.js');
+const deleteLink = entryPoint('link/deleteLink.ts', 'delete-user-subscription.js');
 const userSubscriptions = entryPoint('user/user.ts', 'user-subscriptions.js');
 const googleUpdateSub = entryPoint('update-subs/google.ts', 'google-update-subscriptions.js');
 const appleUpdateSub = entryPoint('update-subs/apple.ts', 'apple-update-subscriptions.js');
@@ -48,6 +49,7 @@ module.exports = [
     appleUpdateSub,
     appleUserLink,
     googleUserLink,
+    deleteLink,
     userSubscriptions,
     exportSubs,
     exportEvents


### PR DESCRIPTION
The rows in the `UserSubscription` were deleted 30 months after the last interaction with a device.

This doesn't make sense, we need to delete these rows as soon as the subscription attached to it is being deleted.

This PR:

- Enable the dynamo event stream for the `Subscription` table
- creates a lambda that listen to that stream
- reacts only on TTL events from the `Subscription` table
- delete elements in the `UserSubscription` table when the corresponding row has been deleted from the `Subscription` table