### PR TITLE
Support more validation cases

### DIFF
--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -13,13 +13,23 @@ export interface AppleValidatedReceiptInfo {
 }
 
 // there are more fields, I cherry picked what was relevant
-// https://developer.apple.com/documentation/appstorereceipts/responsebody
-export interface AppleValidationResponse {
+// https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html
+interface AppleValidationServerResponse {
     auto_renew_status: 0 | 1,
     "is-retryable": boolean,
     latest_receipt: string,
-    latest_receipt_info: AppleValidatedReceiptInfo,
+    // yes you've read the type well. It can both be an array or a value, good luck parsing that
+    latest_receipt_info: AppleValidatedReceiptInfo | AppleValidatedReceiptInfo[],
+    latest_expired_receipt_info: AppleValidatedReceiptInfo,
     status: number
+}
+
+// this is a sanitised and more sensible version of what the response should be
+export interface AppleValidationResponse {
+    autoRenewStatus: boolean,
+    isRetryable: boolean,
+    latestReceipt: string,
+    latestReceiptInfo: AppleValidatedReceiptInfo
 }
 
 const receiptEndpoint = (Stage === "PROD") ? "https://buy.itunes.apple.com/verifyReceipt" : "https://sandbox.itunes.apple.com/verifyReceipt";
@@ -42,25 +52,62 @@ function callValidateReceipt(receipt: string): Promise<Response> {
         })
 }
 
-function checkResponseStatus(response: AppleValidationResponse): AppleValidationResponse {
+function checkResponseStatus(response: AppleValidationServerResponse): AppleValidationServerResponse {
     if ((response.status >= 21100 && response.status <= 21199) || response["is-retryable"]) {
         console.error(`Server error received from Apple, got status ${response.status}, will retry`);
         throw new ProcessingError(`Server error, status ${response.status}`, true);
+    }
+    if (response.status == 21007 || response.status == 21008) {
+        console.error(`Got status ${response.status} and we're in ${Stage}, so we are processing a receipt from the wrong environment`);
+        throw new ProcessingError(`Got status ${response.status} and we're in ${Stage}`);
     }
     if (response.status != 0 && response.status != 21006) {
         console.error(`Invalid receipt, got status ${response.status} for ${response.latest_receipt}`);
         throw new ProcessingError(`Invalid receipt, got status ${response.status}`);
     }
-    if (!response.latest_receipt_info) {
+    if (!response.latest_receipt_info && !response.latest_expired_receipt_info) {
         console.error(`No receipt info`);
         throw new ProcessingError(`Invalid validation response, no receipt info`);
     }
     return response;
 }
 
+function toSensiblePayloadFormat(response: AppleValidationServerResponse, receipt: string): AppleValidationResponse {
+    let receiptInfo: AppleValidatedReceiptInfo = response.latest_expired_receipt_info;
+    if (response.latest_receipt_info) {
+        if (Array.isArray(response.latest_receipt_info)) {
+            const latestReceipt = response.latest_receipt_info as AppleValidatedReceiptInfo[];
+            if (latestReceipt.length == 1) {
+                receiptInfo = latestReceipt[0];
+            } else if (latestReceipt.length > 1) {
+                receiptInfo = latestReceipt[0];
+                let longestSub = 0;
+                latestReceipt.forEach(sub => {
+                    if (longestSub < Number.parseInt(sub.expires_date)) {
+                        longestSub = Number.parseInt(sub.expires_date);
+                        receiptInfo = sub;
+                    }
+                });
+            } else {
+                console.error(`Invalid validation response, empty receipt info array`);
+                throw new ProcessingError(`Invalid validation response, empty receipt info array`);
+            }
+        } else {
+            receiptInfo = response.latest_receipt_info as AppleValidatedReceiptInfo;
+        }
+    }
+    return {
+        autoRenewStatus: (response.auto_renew_status === 1),
+        isRetryable: response["is-retryable"],
+        latestReceipt: response.latest_receipt || receipt,
+        latestReceiptInfo: receiptInfo
+    }
+}
+
 export function validateReceipt(receipt: string): Promise<AppleValidationResponse> {
     return callValidateReceipt(receipt)
         .then(response => response.json())
-        .then(body => body as AppleValidationResponse)
+        .then(body => body as AppleValidationServerResponse)
         .then(checkResponseStatus)
+        .then(response => toSensiblePayloadFormat(response, receipt))
 }

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -100,14 +100,7 @@ export function toSensiblePayloadFormat(response: AppleValidationServerResponse,
             if (latestReceipt.length == 1) {
                 receiptInfo = latestReceipt[0];
             } else if (latestReceipt.length > 1) {
-                receiptInfo = latestReceipt[0];
-                let furthestExpiry = expiryDate(latestReceipt[0]);
-                for (const sub of latestReceipt) {
-                    if (furthestExpiry < expiryDate(sub)) {
-                        furthestExpiry = expiryDate(sub);
-                        receiptInfo = sub;
-                    }
-                }
+                receiptInfo = latestReceipt.sort((r1, r2) => expiryDate(r2) - expiryDate(r1))[0]
             } else {
                 console.error(`Invalid validation response, empty receipt info array`);
                 throw new ProcessingError(`Invalid validation response, empty receipt info array`);

--- a/typescript/src/subscription-status/appleSubStatus.ts
+++ b/typescript/src/subscription-status/appleSubStatus.ts
@@ -1,3 +1,4 @@
+import 'source-map-support/register'
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Platform} from "../models/platform";
 import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";

--- a/typescript/src/subscription-status/appleSubStatus.ts
+++ b/typescript/src/subscription-status/appleSubStatus.ts
@@ -28,7 +28,7 @@ interface AppleSubscriptionStatusResponse {
 function toResponse(validationResponse: AppleValidationResponse): AppleSubscriptionStatusResponse {
     const now = new Date();
 
-    const receiptInfo = validationResponse.latest_receipt_info;
+    const receiptInfo = validationResponse.latestReceiptInfo;
     const start = msToDate(receiptInfo.original_purchase_date_ms);
     const end = msToDate(receiptInfo.expires_date);
     const endWithGracePeriod = plusDays(end, 30);
@@ -42,7 +42,7 @@ function toResponse(validationResponse: AppleValidationResponse): AppleSubscript
         start: start.toISOString(),
         end: end.toISOString(),
         product: receiptInfo.product_id,
-        latestReceipt: validationResponse.latest_receipt
+        latestReceipt: validationResponse.latestReceipt
     }
 }
 

--- a/typescript/src/subscription-status/appleSubStatus.ts
+++ b/typescript/src/subscription-status/appleSubStatus.ts
@@ -3,7 +3,7 @@ import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Platform} from "../models/platform";
 import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";
 import {HTTPResponses} from "../models/apiGatewayHttp";
-import {msToDate, plusDays} from "../utils/dates";
+import {plusDays} from "../utils/dates";
 
 interface AppleSubscription {
     receipt: string
@@ -29,19 +29,18 @@ function toResponse(validationResponse: AppleValidationResponse): AppleSubscript
     const now = new Date();
 
     const receiptInfo = validationResponse.latestReceiptInfo;
-    const start = msToDate(receiptInfo.original_purchase_date_ms);
-    const end = msToDate(receiptInfo.expires_date);
+    const end = receiptInfo.expiresDate;
     const endWithGracePeriod = plusDays(end, 30);
     const valid: boolean = now.getTime() <= endWithGracePeriod.getTime();
     const gracePeriod: boolean = now.getTime() > end.getTime() && valid;
 
     return {
-        originalTransactionId: receiptInfo.original_transaction_id,
+        originalTransactionId: receiptInfo.originalTransactionId,
         valid: valid,
         gracePeriod: gracePeriod,
-        start: start.toISOString(),
+        start: receiptInfo.originalPurchaseDate.toISOString(),
         end: end.toISOString(),
-        product: receiptInfo.product_id,
+        product: receiptInfo.productId,
         latestReceipt: validationResponse.latestReceipt
     }
 }

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -1,3 +1,4 @@
+import 'source-map-support/register'
 import * as restm from 'typed-rest-client/RestClient';
 import {
     HTTPResponses,

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -14,16 +14,19 @@ function toAppleSubscription(response: AppleValidationResponse): AppleSubscripti
         autoRenewStatus = true;
     }
 
-    const expiryDate = new Date(Number.parseInt(latestReceiptInfo.expires_date));
+    let cancellationDate: string | undefined;
+    if (latestReceiptInfo.cancellationDate) {
+        cancellationDate = latestReceiptInfo.cancellationDate.toISOString()
+    }
 
     return new AppleSubscription(
-        latestReceiptInfo.original_transaction_id,
-        msToFormattedString(latestReceiptInfo.original_purchase_date_ms),
-        msToFormattedString(latestReceiptInfo.expires_date),
-        optionalMsToFormattedString(latestReceiptInfo.cancellation_date_ms),
+        latestReceiptInfo.originalTransactionId,
+        latestReceiptInfo.originalPurchaseDate.toISOString(),
+        latestReceiptInfo.expiresDate.toISOString(),
+        cancellationDate,
         autoRenewStatus,
-        latestReceiptInfo.product_id,
-        dateToSecondTimestamp(thirtyMonths(expiryDate)),
+        latestReceiptInfo.productId,
+        dateToSecondTimestamp(thirtyMonths(latestReceiptInfo.expiresDate)),
         response.latestReceipt,
         response
     )

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -6,11 +6,11 @@ import {dateToSecondTimestamp, msToFormattedString, optionalMsToFormattedString,
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";
 
-function toAppleSubscription(response: AppleValidationResponse, subRef: AppleSubscriptionReference): AppleSubscription {
-    const latestReceiptInfo = response.latest_receipt_info;
+function toAppleSubscription(response: AppleValidationResponse): AppleSubscription {
+    const latestReceiptInfo = response.latestReceiptInfo;
 
     let autoRenewStatus: boolean = false;
-    if (response.auto_renew_status === 1) {
+    if (response.autoRenewStatus) {
         autoRenewStatus = true;
     }
 
@@ -24,7 +24,7 @@ function toAppleSubscription(response: AppleValidationResponse, subRef: AppleSub
         autoRenewStatus,
         latestReceiptInfo.product_id,
         dateToSecondTimestamp(thirtyMonths(expiryDate)),
-        response.latest_receipt,
+        response.latestReceipt,
         response
     )
 }
@@ -33,7 +33,7 @@ function sqsRecordToAppleSubscription(record: SQSRecord): Promise<AppleSubscript
     const subRef = JSON.parse(record.body) as AppleSubscriptionReference;
 
     return validateReceipt(subRef.receipt)
-        .then(response => toAppleSubscription(response, subRef))
+        .then(toAppleSubscription)
 }
 
 export async function handler(event: SQSEvent): Promise<String> {

--- a/typescript/src/utils/dates.ts
+++ b/typescript/src/utils/dates.ts
@@ -1,5 +1,15 @@
+import {Option} from "./option";
+
 export function msToDate(ms: string): Date {
     return new Date(Number.parseInt(ms));
+}
+
+export function optionalMsToDate(ms: Option<string> | undefined): Option<Date> {
+    if (ms) {
+        return new Date(Number.parseInt(ms));
+    } else {
+        return null;
+    }
 }
 
 export function msToFormattedString(ms: string): string {

--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -1,0 +1,132 @@
+import {
+    AppleValidationResponse,
+    AppleValidationServerResponse,
+    toSensiblePayloadFormat
+} from "../../src/services/appleValidateReceipts";
+
+describe("The apple validation service", () => {
+    test("Should transform a dirty apple payload with an expired receipt info into a sane one", () => {
+        const appleResponse: AppleValidationServerResponse = {
+            auto_renew_status: 0,
+            latest_expired_receipt_info: {
+                original_transaction_id: "1234",
+                product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                expires_date: "1570705794000",
+                original_purchase_date_ms: "1567081703000"
+            },
+            status: 21006
+        };
+
+        const expected: AppleValidationResponse = {
+            autoRenewStatus: false,
+            isRetryable: false,
+            latestReceipt: "cmVjZWlwdA==",
+            latestReceiptInfo: {
+                cancellationDate: null,
+                expiresDate: new Date(1570705794000),
+                originalPurchaseDate: new Date(1567081703000),
+                originalTransactionId: "1234",
+                productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+            },
+        };
+
+        expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
+    });
+
+
+    test("Should transform a dirty apple payload with an expired receipt info into a sane one", () => {
+        const appleResponse: AppleValidationServerResponse = {
+            auto_renew_status: 0,
+            latest_receipt_info: {
+                original_transaction_id: "1234",
+                product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                expires_date: "2019-09-10 11:09:54 Etc/GM",
+                expires_date_ms: "1570705794000",
+                original_purchase_date_ms: "1567081703000"
+            },
+            status: 0
+        };
+
+        const expected: AppleValidationResponse = {
+            autoRenewStatus: false,
+            isRetryable: false,
+            latestReceipt: "cmVjZWlwdA==",
+            latestReceiptInfo: {
+                cancellationDate: null,
+                expiresDate: new Date(1570705794000),
+                originalPurchaseDate: new Date(1567081703000),
+                originalTransactionId: "1234",
+                productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+            },
+        };
+
+        expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
+    })
+
+    test("Should transform a dirty apple payload with an array of latest receipts into sane one", () => {
+        const appleResponse: AppleValidationServerResponse = {
+            auto_renew_status: 0,
+            latest_receipt_info: [{
+                original_transaction_id: "1234",
+                product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                expires_date: "2019-09-10 11:09:54 Etc/GM",
+                expires_date_ms: "1570705794000",
+                original_purchase_date_ms: "1567081703000"
+            }],
+            status: 0
+        };
+
+        const expected: AppleValidationResponse = {
+            autoRenewStatus: false,
+            isRetryable: false,
+            latestReceipt: "cmVjZWlwdA==",
+            latestReceiptInfo: {
+                cancellationDate: null,
+                expiresDate: new Date(1570705794000),
+                originalPurchaseDate: new Date(1567081703000),
+                originalTransactionId: "1234",
+                productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+            },
+        };
+
+        expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
+    })
+
+    test("Should transform a dirty apple payload with an array of latest receipts into sane one, picking the relevant receipt in the array", () => {
+        const appleResponse: AppleValidationServerResponse = {
+            auto_renew_status: 0,
+            latest_receipt_info: [
+                {
+                    original_transaction_id: "1234",
+                    product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                    expires_date: "2019-09-10 11:09:54 Etc/GM",
+                    expires_date_ms: "1570705793000",
+                    original_purchase_date_ms: "1567081703000"
+                },
+                {
+                    original_transaction_id: "1235",
+                    product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                    expires_date: "2019-09-10 11:09:54 Etc/GM",
+                    expires_date_ms: "1570705794000",
+                    original_purchase_date_ms: "1567081703000"
+                }
+            ],
+            status: 0
+        };
+
+        const expected: AppleValidationResponse = {
+            autoRenewStatus: false,
+            isRetryable: false,
+            latestReceipt: "cmVjZWlwdA==",
+            latestReceiptInfo: {
+                cancellationDate: null,
+                expiresDate: new Date(1570705794000),
+                originalPurchaseDate: new Date(1567081703000),
+                originalTransactionId: "1235",
+                productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+            },
+        };
+
+        expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
+    })
+});

--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -34,7 +34,7 @@ describe("The apple validation service", () => {
     });
 
 
-    test("Should transform a dirty apple payload with an expired receipt info into a sane one", () => {
+    test("Should transform a dirty apple payload with the latest receipt info into a sane one", () => {
         const appleResponse: AppleValidationServerResponse = {
             auto_renew_status: 0,
             latest_receipt_info: {


### PR DESCRIPTION
There were two cases to support:

 - `latest_receipt_info` can either be an array or a value
 - `expires_date` sometimes contains a formatted date "2019-09-11 00:00 Timezone" or sometimes a string representation of a timestamp "1567081703000"

And I thought our own APIs were dirty but Apple raises the bar quite high.

I've added unit tests because I suspect that's not the last surprise so we may need to add more unit tests as we go.