### PR TITLE
Refactor types such that the export takes all the fields

### DIFF
--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -1,7 +1,7 @@
 import {HTTPResponses} from '../models/apiGatewayHttp';
 
 import {UserSubscription} from "../models/userSubscription";
-import {Subscription} from "../models/subscription";
+import {ReadSubscription} from "../models/subscription";
 import {dynamoMapper, sqs} from "../utils/aws";
 import {getUserId, getIdentityToken} from "../utils/guIdentityApi";
 import {SubscriptionReference} from "../models/subscriptionReference";
@@ -16,7 +16,7 @@ export interface SubscriptionCheckData {
 
 async function enqueueUnstoredPurchaseToken(subChecks: SubscriptionCheckData[]): Promise<number> {
 
-    const dynamoResult = dynamoMapper.batchGet(subChecks.map(sub => new Subscription(sub.subscriptionId)));
+    const dynamoResult = dynamoMapper.batchGet(subChecks.map(sub => new ReadSubscription().setSubscriptionId(sub.subscriptionId)));
 
     const refsToSend = subChecks.map(s => s.subscriptionId);
 

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -1,73 +1,10 @@
-import {hashKey, rangeKey, attribute} from '@aws/dynamodb-data-mapper-annotations';
+import {hashKey, attribute} from '@aws/dynamodb-data-mapper-annotations';
 import {DynamoDbTable} from "@aws/dynamodb-data-mapper";
 import {App, Stage} from "../utils/appIdentity";
 
 
 export class Subscription {
 
-    @hashKey()
-    subscriptionId: string;
-
-    @attribute()
-    startTimestamp?: string;
-
-    @attribute()
-    endTimestamp?: string;
-
-    @attribute()
-    cancellationTimestamp?: string;
-
-    @attribute()
-    autoRenewing?: boolean;
-
-    @attribute()
-    productId?: string;
-
-    @attribute()
-    ttl?: number;
-
-    constructor(subscriptionId: string, startTimestamp?: string, endTimestamp?: string, cancellationTimestamp?: string, autoRenewing?: boolean, productId?: string, ttl?: number) {
-        this.subscriptionId = subscriptionId;
-        this.startTimestamp = startTimestamp;
-        this.endTimestamp = endTimestamp;
-        this.cancellationTimestamp = cancellationTimestamp;
-        this.autoRenewing = autoRenewing;
-        this.productId = productId;
-        this.ttl = ttl;
-    }
-
-    get [DynamoDbTable]() {
-        return `${App}-${Stage}-subscriptions`
-    }
-}
-
-export class GoogleSubscription extends Subscription {
-
-    @attribute()
-    googlePayload?: any;
-
-    constructor(subscriptionId: string, startTimestamp: string, endTimestamp: string, cancellationTimestamp: string | undefined, autoRenewing: boolean, productId: string, ttl: number, googlePayload: any) {
-        super(subscriptionId, startTimestamp, endTimestamp, cancellationTimestamp, autoRenewing, productId, ttl);
-        this.googlePayload = googlePayload;
-    }
-}
-
-export class AppleSubscription extends Subscription {
-
-    @attribute()
-    receipt: string;
-
-    @attribute()
-    applePayload?: any;
-
-    constructor(subscriptionId: string, startTimestamp: string, endTimestamp: string, cancellationTimestamp: string | undefined, autoRenewing: boolean, productId: string, ttl: number, reciept: string, applePayload: any) {
-        super(subscriptionId, startTimestamp, endTimestamp, cancellationTimestamp, autoRenewing, productId, ttl);
-        this.receipt = reciept;
-        this.applePayload = applePayload;
-    }
-}
-
-export class ReadSubscription {
     @hashKey()
     subscriptionId: string;
 
@@ -81,12 +18,61 @@ export class ReadSubscription {
     cancellationTimestamp?: string;
 
     @attribute()
-    autoRenewing?: boolean;
+    autoRenewing: boolean;
+
+    @attribute()
+    productId: string;
+
+    @attribute()
+    googlePayload?: any;
+
+    @attribute()
+    receipt?: string;
+
+    @attribute()
+    applePayload?: any;
+
+    @attribute()
+    ttl?: number;
+
+    constructor(
+        subscriptionId: string,
+        startTimestamp: string,
+        endTimestamp: string,
+        cancellationTimestamp: string | undefined,
+        autoRenewing: boolean,
+        productId: string,
+        googlePayload?: any,
+        receipt?: string,
+        applePayload?: any,
+        ttl?:number
+    ) {
+        this.subscriptionId = subscriptionId;
+        this.startTimestamp = startTimestamp;
+        this.endTimestamp = endTimestamp;
+        this.cancellationTimestamp = cancellationTimestamp;
+        this.autoRenewing = autoRenewing;
+        this.productId = productId;
+        this.googlePayload = googlePayload;
+        this.receipt = receipt;
+        this.applePayload = applePayload;
+        this.ttl = ttl;
+    }
+
+    get [DynamoDbTable]() {
+        return `${App}-${Stage}-subscriptions`
+    }
+}
+
+export class ReadSubscription extends Subscription {
 
     constructor() {
-        this.subscriptionId = "";
-        this.startTimestamp = "";
-        this.endTimestamp = "";
+        super("", "", "", undefined, false, "")
+    }
+
+    setSubscriptionId(subscriptionId: string): ReadSubscription {
+        this.subscriptionId = subscriptionId;
+        return this;
     }
 
     get [DynamoDbTable]() {

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -40,7 +40,8 @@ export interface AppleValidationResponse {
     autoRenewStatus: boolean,
     isRetryable: boolean,
     latestReceipt: string,
-    latestReceiptInfo: AppleValidatedReceiptInfo
+    latestReceiptInfo: AppleValidatedReceiptInfo,
+    originalResponse: any
 }
 
 const receiptEndpoint = (Stage === "PROD") ? "https://buy.itunes.apple.com/verifyReceipt" : "https://sandbox.itunes.apple.com/verifyReceipt";
@@ -131,7 +132,8 @@ export function toSensiblePayloadFormat(response: AppleValidationServerResponse,
             originalPurchaseDate: msToDate(receiptInfo.original_purchase_date_ms),
             originalTransactionId: receiptInfo.original_transaction_id,
             productId: receiptInfo.product_id,
-        }
+        },
+        originalResponse: response
     }
 }
 

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -1,12 +1,12 @@
 import 'source-map-support/register'
 import {SQSEvent, SQSRecord} from 'aws-lambda'
 import {parseAndStoreSubscriptionUpdate} from "./updatesub";
-import {AppleSubscription} from "../models/subscription";
-import {dateToSecondTimestamp, msToFormattedString, optionalMsToFormattedString, thirtyMonths} from "../utils/dates";
+import {Subscription} from "../models/subscription";
+import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";
 
-function toAppleSubscription(response: AppleValidationResponse): AppleSubscription {
+function toAppleSubscription(response: AppleValidationResponse): Subscription {
     const latestReceiptInfo = response.latestReceiptInfo;
 
     let autoRenewStatus: boolean = false;
@@ -19,20 +19,21 @@ function toAppleSubscription(response: AppleValidationResponse): AppleSubscripti
         cancellationDate = latestReceiptInfo.cancellationDate.toISOString()
     }
 
-    return new AppleSubscription(
+    return new Subscription(
         latestReceiptInfo.originalTransactionId,
         latestReceiptInfo.originalPurchaseDate.toISOString(),
         latestReceiptInfo.expiresDate.toISOString(),
         cancellationDate,
         autoRenewStatus,
         latestReceiptInfo.productId,
-        dateToSecondTimestamp(thirtyMonths(latestReceiptInfo.expiresDate)),
+        null,
         response.latestReceipt,
-        response
+        response,
+        dateToSecondTimestamp(thirtyMonths(latestReceiptInfo.expiresDate))
     )
 }
 
-function sqsRecordToAppleSubscription(record: SQSRecord): Promise<AppleSubscription> {
+function sqsRecordToAppleSubscription(record: SQSRecord): Promise<Subscription> {
     const subRef = JSON.parse(record.body) as AppleSubscriptionReference;
 
     return validateReceipt(subRef.receipt)

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -28,7 +28,7 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         latestReceiptInfo.productId,
         null,
         response.latestReceipt,
-        response,
+        response.originalResponse,
         dateToSecondTimestamp(thirtyMonths(latestReceiptInfo.expiresDate))
     )
 }

--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -28,6 +28,7 @@ describe("The apple validation service", () => {
                 originalTransactionId: "1234",
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
             },
+            originalResponse: appleResponse
         };
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
@@ -58,6 +59,7 @@ describe("The apple validation service", () => {
                 originalTransactionId: "1234",
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
             },
+            originalResponse: appleResponse
         };
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
@@ -87,6 +89,7 @@ describe("The apple validation service", () => {
                 originalTransactionId: "1234",
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
             },
+            originalResponse: appleResponse
         };
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
@@ -125,6 +128,7 @@ describe("The apple validation service", () => {
                 originalTransactionId: "1235",
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
             },
+            originalResponse: appleResponse
         };
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);


### PR DESCRIPTION
 - export all the fields by ensuring the type `ReadSubscription` has the same fields as the type `Subscription`
 - preserve the original apple response to store it. We've got a few days of subscription where I didn't store the correct payload.

That means I'll have to re-process a few days of data in order to clean up my mistake.