### PR TITLE
Export historical subscription state part2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ lazy val root = project
     riffRaffArtifactResources += file("tsc-target/user-subscriptions.zip") -> s"mobile-purchases-user-subscriptions/user-subscriptions.zip",
     riffRaffArtifactResources += file("tsc-target/export-subscription-tables.zip") -> s"mobile-purchases-export-subscription-tables/export-subscription-tables.zip",
     riffRaffArtifactResources += file("tsc-target/export-subscription-events-table.zip") -> s"mobile-purchases-export-subscription-events-table/export-subscription-events-table.zip",
+    riffRaffArtifactResources += file("tsc-target/export-historical-data.zip") -> s"mobile-purchases-export-historical-data/export-historical-data.zip",
     riffRaffArtifactResources += file("cloudformation.yaml") -> s"mobile-purchases-cloudformation/cloudformation.yaml",
   )
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -119,7 +119,6 @@ Resources:
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions
 
-
         - PolicyName: Sqs
           PolicyDocument:
             Statement:
@@ -128,6 +127,8 @@ Resources:
               Resource:
                 - !GetAtt GoogleSubscriptionsQueue.Arn
                 - !GetAtt AppleSubscriptionsQueue.Arn
+                - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-apple-historical-subscriptions
+                - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-google-historical-subscriptions
         - PolicyName: Kms
           PolicyDocument:
             Statement:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -725,6 +725,7 @@ Resources:
           App: !Sub ${App}
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
+          HistoricalQueueUrl: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/${App}-${Stage}-google-historical-subscriptions
       Description: Consomes subscription data updates from google playstore from sqs and stores them in dynamo
       Handler: google-update-subscriptions.handler
       MemorySize: 512
@@ -790,7 +791,8 @@ Resources:
           App: !Sub ${App}
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
-      Description: Consomes subscription data updates from app store from sqs and stores them in dynamo
+          HistoricalQueueUrl: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/${App}-${Stage}-apple-historical-subscriptions
+      Description: Consumes subscription data updates from app store from sqs and stores them in dynamo
       Handler: apple-update-subscriptions.handler
       MemorySize: 512
       Role: !GetAtt MobilePurchasesLambdasRole.Arn

--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: Validates mobile purchases
+Description: Exports mobile purchases data
 Parameters:
   Stack:
     Description: Stack name
@@ -29,6 +29,12 @@ Parameters:
   SubscriptionEventsExportBucket:
     Type: String
     Description: The name of the export events bucket
+  GoogleSubscriptionHistoryExportBucket:
+    Type: String
+    Description: The name of the export bucket containing the subscription history from Google
+  AppleSubscriptionHistoryExportBucket:
+    Type: String
+    Description: The name of the export bucket containing the subscription history from Apple
 
 Resources:
   ExportLambdasRole:
@@ -164,3 +170,61 @@ Resources:
         Stage: !Ref Stage
         Stack: !Ref Stack
         App: !Ref App
+
+  GoogleHistoricalSubscriptionsQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-google-historical-subscriptions
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt GoogleHistoricalSubscriptionsDlq.Arn
+        maxReceiveCount: 8
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
+  GoogleHistoricalSubscriptionsDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-google-historical-subscriptions-dlq
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
+  AppleHistoricalSubscriptionsQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-apple-historical-subscriptions
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt AppleHistoricalSubscriptionsDlq.Arn
+        maxReceiveCount: 8
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
+  AppleHistoricalSubscriptionsDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-apple-historical-subscriptions-dlq
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App

--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -228,3 +228,64 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
+
+  ExportAppleHistoricalSubscriptionsLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: export-historical-data.handler
+      Runtime: nodejs10.x
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-export-historical-data/export-historical-data.zip
+      FunctionName: !Sub ${App}-export-historical-data-${Stage}
+      Role: !GetAtt ExportLambdasRole.Arn
+      Environment:
+        Variables:
+          App: !Sub ${App}
+          Stack: !Sub ${Stack}
+          Stage: !Sub ${Stage}
+          ExportBucket: !Ref AppleSubscriptionHistoryExportBucket
+      Description: Export the historical Apple subscriptions to the data lake
+      MemorySize: 512
+      Timeout: 900
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(3 0 1/1 * ? *)
+          Input
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App
+
+
+  ExportGoogleHistoricalSubscriptionsLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: export-historical-data.handler
+      Runtime: nodejs10.x
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-export-historical-data/export-historical-data.zip
+      FunctionName: !Sub ${App}-export-historical-data-${Stage}
+      Role: !GetAtt ExportLambdasRole.Arn
+      Environment:
+        Variables:
+          App: !Sub ${App}
+          Stack: !Sub ${Stack}
+          Stage: !Sub ${Stage}
+          ExportBucket: !Ref GoogleSubscriptionHistoryExportBucket
+      Description: Export the historical Google subscriptions to the data lake
+      MemorySize: 512
+      Timeout: 900
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(3 0 1/1 * ? *)
+          Input
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App

--- a/typescript/src/export/exportHistoricalData.ts
+++ b/typescript/src/export/exportHistoricalData.ts
@@ -14,9 +14,7 @@ async function recursivelyFetchSqsMessages(sqsUrl: string, handleMsg: (message: 
     };
     const sqsResp = await sqs.receiveMessage(request).promise();
     if (sqsResp.Messages && sqsResp.Messages.length > 0) {
-        sqsResp.Messages.forEach(sqsMessage => {
-            handleMsg(sqsMessage);
-        });
+        sqsResp.Messages.forEach(handleMsg);
         return await recursivelyFetchSqsMessages(sqsUrl, handleMsg)
     }
 }
@@ -51,7 +49,7 @@ export async function handler(): Promise<any> {
     if (!bucket) throw new Error('Variable ExportBucket must be set');
 
     const sqsUrl = process.env['SqsUrl'];
-    if (!sqsUrl) throw new Error('No sqs url set, check the cloudwatch event configuration');
+    if (!sqsUrl) throw new Error('Variable SqsUrl must be set');
 
     let zippedStream = zlib.createGzip();
 

--- a/typescript/src/export/exportHistoricalData.ts
+++ b/typescript/src/export/exportHistoricalData.ts
@@ -1,0 +1,96 @@
+import 'source-map-support/register'
+import {s3, sqs} from "../utils/aws";
+import zlib from 'zlib'
+import {Stage} from "../utils/appIdentity";
+import {plusDays} from "../utils/dates";
+import {Message, ReceiveMessageRequest} from "aws-sdk/clients/sqs";
+
+async function recursivelyFetchSqsMessages(sqsUrl: string, handleMsg: (message: Message) => void): Promise<void> {
+    const request: ReceiveMessageRequest = {
+        QueueUrl: sqsUrl,
+        MaxNumberOfMessages: 10,
+        WaitTimeSeconds: 3,
+        VisibilityTimeout: 600
+    };
+    const sqsResp = await sqs.receiveMessage(request).promise();
+    if (sqsResp.Messages && sqsResp.Messages.length > 0) {
+        sqsResp.Messages.forEach(sqsMessage => {
+            handleMsg(sqsMessage);
+        });
+        return await recursivelyFetchSqsMessages(sqsUrl, handleMsg)
+    }
+}
+
+function group<A>(arrayToGroup: A[], groupSize: number): A[][] {
+    if (arrayToGroup.length > 10) {
+        const copiedArray = arrayToGroup.slice(0);
+        const firstGroup = copiedArray.splice(0, groupSize);
+        return [firstGroup].concat(group(copiedArray, groupSize));
+    } else {
+        return [arrayToGroup.slice(0)];
+    }
+}
+
+async function deleteAllSqsMessages(sqsUrl: string, receiptHandleToDelete: string[]): Promise<void> {
+    if (receiptHandleToDelete.length > 0) {
+        const batches = group(receiptHandleToDelete, 10);
+
+        const deletions = batches.map(batch => {
+            const entries = batch.map((receiptHandle, index) => {
+                return {Id: (index + 1).toString(), ReceiptHandle: receiptHandle};
+            });
+            return sqs.deleteMessageBatch({QueueUrl: sqsUrl, Entries: entries}).promise();
+        });
+
+        await Promise.all(deletions);
+    }
+}
+
+export async function handler(): Promise<any> {
+    const bucket = process.env['ExportBucket'];
+    if (!bucket) throw new Error('Variable ExportBucket must be set');
+
+    const sqsUrl = process.env['SqsUrl'];
+    if (!sqsUrl) throw new Error('No sqs url set, check the cloudwatch event configuration');
+
+    let zippedStream = zlib.createGzip();
+
+    const yesterday = plusDays(new Date(), -1).toISOString().substr(0,10);
+    const prefix = (Stage === "PROD") ? "data" : "code-data";
+    const randomString = Math.random().toString(36).substring(10);
+    const filename = `${prefix}/date=${yesterday}/${yesterday}-${randomString}.json.gz`;
+    const managedUpload = s3.upload({
+        Bucket: bucket,
+        Key: filename,
+        Body: zippedStream,
+        ACL: "bucket-owner-full-control"
+    });
+
+    const msgToDelete: string[] = [];
+    let totalMsgCount = 0;
+    let processedMsgCount = 0;
+
+    function handleOneMessage(sqsMessage: Message): void {
+        totalMsgCount++;
+        const parsedMessage = JSON.parse(sqsMessage.Body || "");
+        const messageDate = parsedMessage.snapshotDate.substr(0, 10);
+        if (messageDate == yesterday) {
+            processedMsgCount++;
+            const message = JSON.stringify(parsedMessage) + '\n';
+            zippedStream.write(message);
+            if (sqsMessage.ReceiptHandle) msgToDelete.push(sqsMessage.ReceiptHandle);
+        }
+    }
+
+    await recursivelyFetchSqsMessages(sqsUrl, handleOneMessage);
+
+    zippedStream.end();
+    await managedUpload.promise();
+
+    console.log(`Export succeeded, read ${totalMsgCount} records, processed ${processedMsgCount}`);
+
+    await deleteAllSqsMessages(sqsUrl, msgToDelete);
+    console.log(`Deleted ${msgToDelete.length} messages from the SQS queue`);
+
+    return {recordCount: totalMsgCount};
+}

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -20,34 +20,31 @@ interface GoogleResponseBody {
 
 const restClient = new restm.RestClient('guardian-mobile-purchases');
 
-export function getGoogleSubResponse(record: SQSRecord): Promise<Subscription> {
+async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription> {
 
     const sub = JSON.parse(record.body) as GoogleSubscriptionReference;
     const url = buildGoogleUrl(sub.subscriptionId, sub.purchaseToken, sub.packageName);
-    return getAccessToken(getParams(Stage))
-        .then(accessToken => {
-            return restClient.get<GoogleResponseBody>(url, {additionalHeaders: {Authorization: `Bearer ${accessToken.token}`}})
-        })
-        .then(response => {
-            if(response.result) {
-                const expiryDate = new Date(Number.parseInt(response.result.expiryTimeMillis));
-                return new Subscription(
-                    sub.purchaseToken,
-                    new Date(Number.parseInt(response.result.startTimeMillis)).toISOString(),
-                    expiryDate.toISOString(),
-                    makeCancellationTime(response.result.userCancellationTimeMillis),
-                    response.result.autoRenewing,
-                    sub.subscriptionId,
-                    response.result,
-                    undefined,
-                    null,
-                    dateToSecondTimestamp(thirtyMonths(expiryDate)),
-                );
-            } else {
-                throw new ProcessingError("There was no data in google response", true);
-            }
-        })
+    const accessToken = await getAccessToken(getParams(Stage));
 
+    const response = await restClient.get<GoogleResponseBody>(url, {additionalHeaders: {Authorization: `Bearer ${accessToken.token}`}});
+
+    if(response.result) {
+        const expiryDate = new Date(Number.parseInt(response.result.expiryTimeMillis));
+        return new Subscription(
+            sub.purchaseToken,
+            new Date(Number.parseInt(response.result.startTimeMillis)).toISOString(),
+            expiryDate.toISOString(),
+            makeCancellationTime(response.result.userCancellationTimeMillis),
+            response.result.autoRenewing,
+            sub.subscriptionId,
+            response.result,
+            undefined,
+            null,
+            dateToSecondTimestamp(thirtyMonths(expiryDate)),
+        );
+    } else {
+        throw new ProcessingError("There was no data in google response", true);
+    }
 }
 
 export async function handler(event: SQSEvent) {

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -39,7 +39,11 @@ async function queueHistoricalSubscription(subscription: Subscription): Promise<
 
     const payload = subscription.googlePayload || subscription.applePayload;
     if (payload) {
-        await sendToSqs(queueUrl, payload);
+        await sendToSqs(queueUrl, {
+            subscriptionId: subscription.subscriptionId,
+            snapshotDate: (new Date()).toISOString(),
+            payload
+        });
     }
 }
 

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -1,7 +1,6 @@
 import {SQSRecord} from 'aws-lambda'
 import {Subscription} from '../models/subscription';
-import {dynamoMapper} from "../utils/aws";
-import {ONE_YEAR_IN_SECONDS} from "../pubsub/pubsub";
+import {dynamoMapper, sendToSqs} from "../utils/aws";
 import {ProcessingError} from "../models/processingError";
 
 export function makeCancellationTime(cancellationTime: string) : string {
@@ -30,33 +29,42 @@ export class SubscriptionUpdate {
     }
 }
 
-function putSubscription(subscription: Subscription): Promise<Subscription>  {
+function putSubscription(subscription: Subscription): Promise<Subscription> {
     return dynamoMapper.put({item: subscription}).then(result => result.item)
 }
 
-export async function parseAndStoreSubscriptionUpdate (
-    sqsRecord: SQSRecord,
-    fetchSubscriberDetails: (record: SQSRecord) => Promise<Subscription>,
-) : Promise<String> {
-    return fetchSubscriberDetails(sqsRecord)
-        .then(payload => {
-            putSubscription(payload);
-            return "OK"
-        })
-        .catch(error => {
-            if (error instanceof ProcessingError) {
-               console.error("Error processing the subscription update", error);
-               if (error.shouldRetry) {
-                   console.error("Will throw an exception to retry this message");
-                   throw error;
-               }  else {
-                   console.error("The error wasn't retryable, giving up.");
-                   return "Error, giving up"
-               }
-            } else {
-               console.error("Unexpected error, will throw to retry: ", error);
-               throw error;
-            }
-        });
+async function queueHistoricalSubscription(subscription: Subscription): Promise<void> {
+    const queueUrl = process.env.HistoricalQueueUrl;
+    if (queueUrl === undefined) throw new Error("No HistoricalQueueUrl env parameter provided");
 
+    const payload = subscription.googlePayload || subscription.applePayload;
+    if (payload) {
+        await sendToSqs(queueUrl, payload);
+    }
+}
+
+export async function parseAndStoreSubscriptionUpdate(
+    sqsRecord: SQSRecord,
+    fetchSubscriberDetails: (record: SQSRecord) => Promise<Subscription>
+) : Promise<String> {
+    try {
+        const subscription = await fetchSubscriberDetails(sqsRecord);
+        await putSubscription(subscription);
+        await queueHistoricalSubscription(subscription);
+        return "OK"
+    } catch (error) {
+        if (error instanceof ProcessingError) {
+           console.error("Error processing the subscription update", error);
+           if (error.shouldRetry) {
+               console.error("Will throw an exception to retry this message");
+               throw error;
+           }  else {
+               console.error("The error wasn't retryable, giving up.");
+               return "Error, giving up"
+           }
+        } else {
+           console.error("Unexpected error, will throw to retry: ", error);
+           throw error;
+        }
+    }
 }

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -38,7 +38,7 @@ export const ssm: SSM  = new SSM({
 });
 
 
-export function sendToSqsImpl(queueUrl: string, event: any): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
+export function sendToSqs(queueUrl: string, event: any): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     return sqs.sendMessage({
         QueueUrl: queueUrl,
         MessageBody: JSON.stringify(event)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ const googleUpdateSub = entryPoint('update-subs/google.ts', 'google-update-subsc
 const appleUpdateSub = entryPoint('update-subs/apple.ts', 'apple-update-subscriptions.js');
 const exportSubs = entryPoint('export/exportSubscriptions.ts', 'export-subscription-tables.js');
 const exportEvents = entryPoint('export/exportEvents.ts', 'export-subscription-events-table.js');
+const exportHistoricalData = entryPoint('export/exportHistoricalData.ts', 'export-historical-data.js');
 
 module.exports = [
     googlePubSub,


### PR DESCRIPTION
This pull request:

- Creates two SQS queues and their associated dead letter queues
- Write to these SQS queues from the lambdas that fetches the latest state from the subscription services
- Create a lambda that reads all the messages from these queues once a day, and dump them on s3