### PR TITLE
Export historical subscription state part3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ lazy val root = project
     riffRaffArtifactResources += file("tsc-target/export-subscription-events-table.zip") -> s"mobile-purchases-export-subscription-events-table/export-subscription-events-table.zip",
     riffRaffArtifactResources += file("tsc-target/export-historical-data.zip") -> s"mobile-purchases-export-historical-data/export-historical-data.zip",
     riffRaffArtifactResources += file("cloudformation.yaml") -> s"mobile-purchases-cloudformation/cloudformation.yaml",
+    riffRaffArtifactResources += file("exports-cloudformation.yaml") -> s"mobile-purchases-exports-cloudformation/exports-cloudformation.yaml",
   )
 
 def commonAssemblySettings(module: String): immutable.Seq[Def.Setting[_]] = commonSettings(module) ++ List(

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ lazy val root = project
     riffRaffArtifactResources += file("tsc-target/user-subscriptions.zip") -> s"mobile-purchases-user-subscriptions/user-subscriptions.zip",
     riffRaffArtifactResources += file("tsc-target/export-subscription-tables.zip") -> s"mobile-purchases-export-subscription-tables/export-subscription-tables.zip",
     riffRaffArtifactResources += file("tsc-target/export-subscription-events-table.zip") -> s"mobile-purchases-export-subscription-events-table/export-subscription-events-table.zip",
+    riffRaffArtifactResources += file("tsc-target/export-historical-data.zip") -> s"mobile-purchases-export-historical-data/export-historical-data.zip",
     riffRaffArtifactResources += file("cloudformation.yaml") -> s"mobile-purchases-cloudformation/cloudformation.yaml",
   )
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -119,7 +119,6 @@ Resources:
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions
 
-
         - PolicyName: Sqs
           PolicyDocument:
             Statement:
@@ -128,6 +127,8 @@ Resources:
               Resource:
                 - !GetAtt GoogleSubscriptionsQueue.Arn
                 - !GetAtt AppleSubscriptionsQueue.Arn
+                - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-apple-historical-subscriptions
+                - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-google-historical-subscriptions
         - PolicyName: Kms
           PolicyDocument:
             Statement:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -725,6 +725,7 @@ Resources:
           App: !Sub ${App}
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
+          HistoricalQueueUrl: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/${App}-${Stage}-google-historical-subscriptions
       Description: Consomes subscription data updates from google playstore from sqs and stores them in dynamo
       Handler: google-update-subscriptions.handler
       MemorySize: 512
@@ -790,7 +791,8 @@ Resources:
           App: !Sub ${App}
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
-      Description: Consomes subscription data updates from app store from sqs and stores them in dynamo
+          HistoricalQueueUrl: !Sub https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/${App}-${Stage}-apple-historical-subscriptions
+      Description: Consumes subscription data updates from app store from sqs and stores them in dynamo
       Handler: apple-update-subscriptions.handler
       MemorySize: 512
       Role: !GetAtt MobilePurchasesLambdasRole.Arn

--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: Validates mobile purchases
+Description: Exports mobile purchases data
 Parameters:
   Stack:
     Description: Stack name
@@ -29,6 +29,12 @@ Parameters:
   SubscriptionEventsExportBucket:
     Type: String
     Description: The name of the export events bucket
+  GoogleSubscriptionHistoryExportBucket:
+    Type: String
+    Description: The name of the export bucket containing the subscription history from Google
+  AppleSubscriptionHistoryExportBucket:
+    Type: String
+    Description: The name of the export bucket containing the subscription history from Apple
 
 Resources:
   ExportLambdasRole:
@@ -164,3 +170,61 @@ Resources:
         Stage: !Ref Stage
         Stack: !Ref Stack
         App: !Ref App
+
+  GoogleHistoricalSubscriptionsQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-google-historical-subscriptions
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt GoogleHistoricalSubscriptionsDlq.Arn
+        maxReceiveCount: 8
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
+  GoogleHistoricalSubscriptionsDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-google-historical-subscriptions-dlq
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
+  AppleHistoricalSubscriptionsQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-apple-historical-subscriptions
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt AppleHistoricalSubscriptionsDlq.Arn
+        maxReceiveCount: 8
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
+  AppleHistoricalSubscriptionsDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-apple-historical-subscriptions-dlq
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App

--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -81,6 +81,16 @@ Resources:
                 - !Sub arn:aws:s3:::${SubscriptionExportBucket}/*
                 - !Sub arn:aws:s3:::${UserSubscriptionExportBucket}/*
                 - !Sub arn:aws:s3:::${SubscriptionEventsExportBucket}/*
+                - !Sub arn:aws:s3:::${GoogleSubscriptionHistoryExportBucket}/*
+                - !Sub arn:aws:s3:::${AppleSubscriptionHistoryExportBucket}/*
+        - PolicyName: sqs
+          PolicyDocument:
+            Statement:
+              Action: sqs:*
+              Effect: Allow
+              Resource:
+                - !GetAtt AppleHistoricalSubscriptionsQueue.Arn
+                - !GetAtt GoogleHistoricalSubscriptionsQueue.Arn
 
   ExportSubscriptionTableLambda:
     Type: AWS::Serverless::Function
@@ -245,6 +255,7 @@ Resources:
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
           ExportBucket: !Ref AppleSubscriptionHistoryExportBucket
+          SqsUrl: !Ref AppleHistoricalSubscriptionsQueue
       Description: Export the historical Apple subscriptions to the data lake
       MemorySize: 512
       Timeout: 900
@@ -275,6 +286,7 @@ Resources:
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
           ExportBucket: !Ref GoogleSubscriptionHistoryExportBucket
+          SqsUrl: !Ref GoogleHistoricalSubscriptionsQueue
       Description: Export the historical Google subscriptions to the data lake
       MemorySize: 512
       Timeout: 900

--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -228,3 +228,64 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
+
+  ExportAppleHistoricalSubscriptionsLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: export-historical-data.handler
+      Runtime: nodejs10.x
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-export-historical-data/export-historical-data.zip
+      FunctionName: !Sub ${App}-export-historical-data-${Stage}
+      Role: !GetAtt ExportLambdasRole.Arn
+      Environment:
+        Variables:
+          App: !Sub ${App}
+          Stack: !Sub ${Stack}
+          Stage: !Sub ${Stage}
+          ExportBucket: !Ref AppleSubscriptionHistoryExportBucket
+      Description: Export the historical Apple subscriptions to the data lake
+      MemorySize: 512
+      Timeout: 900
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(3 0 1/1 * ? *)
+          Input
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App
+
+
+  ExportGoogleHistoricalSubscriptionsLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: export-historical-data.handler
+      Runtime: nodejs10.x
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-export-historical-data/export-historical-data.zip
+      FunctionName: !Sub ${App}-export-historical-data-${Stage}
+      Role: !GetAtt ExportLambdasRole.Arn
+      Environment:
+        Variables:
+          App: !Sub ${App}
+          Stack: !Sub ${Stack}
+          Stage: !Sub ${Stage}
+          ExportBucket: !Ref GoogleSubscriptionHistoryExportBucket
+      Description: Export the historical Google subscriptions to the data lake
+      MemorySize: 512
+      Timeout: 900
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(3 0 1/1 * ? *)
+          Input
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App

--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -237,7 +237,7 @@ Resources:
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-historical-data/export-historical-data.zip
-      FunctionName: !Sub ${App}-export-historical-data-${Stage}
+      FunctionName: !Sub ${App}-export-apple-historical-data-${Stage}
       Role: !GetAtt ExportLambdasRole.Arn
       Environment:
         Variables:
@@ -253,7 +253,6 @@ Resources:
           Type: Schedule
           Properties:
             Schedule: cron(3 0 1/1 * ? *)
-          Input
       Tags:
         Stage: !Ref Stage
         Stack: !Ref Stack
@@ -268,7 +267,7 @@ Resources:
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-historical-data/export-historical-data.zip
-      FunctionName: !Sub ${App}-export-historical-data-${Stage}
+      FunctionName: !Sub ${App}-export-google-historical-data-${Stage}
       Role: !GetAtt ExportLambdasRole.Arn
       Environment:
         Variables:
@@ -284,7 +283,6 @@ Resources:
           Type: Schedule
           Properties:
             Schedule: cron(3 0 1/1 * ? *)
-          Input
       Tags:
         Stage: !Ref Stage
         Stack: !Ref Stack

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/aws-lambda": "8.10.27",
     "@types/node": "^12.0.2",
     "@types/node-fetch": "^2.5.0",
-    "aws-sdk": "^2.465.0",
+    "aws-sdk": "^2.553.0",
     "node-fetch": "^2.6.0",
     "source-map-support": "^0.5.12",
     "typed-rest-client": "^1.4.0"

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -104,3 +104,14 @@ deployments:
     parameters:
       functionNames: [mobile-purchases-delete-user-subscription-]
       fileName: delete-user-subscription.zip
+
+  mobile-purchases-exports-cloudformation:
+    type: cloud-formation
+    parameters:
+      templatePath: cloudformation.yaml
+
+  mobile-purchases-export-historical-data:
+    template: lambda
+    parameters:
+      functionNames: [mobile-purchases-export-google-historical-data-, mobile-purchases-export-apple-historical-data-]
+      fileName: export-historical-data.zip

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -108,7 +108,7 @@ deployments:
   mobile-purchases-exports-cloudformation:
     type: cloud-formation
     parameters:
-      templatePath: cloudformation.yaml
+      templatePath: exports-cloudformation.yaml
 
   mobile-purchases-export-historical-data:
     template: lambda

--- a/typescript/src/export/exportHistoricalData.ts
+++ b/typescript/src/export/exportHistoricalData.ts
@@ -44,7 +44,7 @@ async function deleteAllSqsMessages(sqsUrl: string, receiptHandleToDelete: strin
     }
 }
 
-export async function handler(): Promise<any> {
+export async function handler(params: {date: string}): Promise<any> {
     const bucket = process.env['ExportBucket'];
     if (!bucket) throw new Error('Variable ExportBucket must be set');
 
@@ -53,7 +53,7 @@ export async function handler(): Promise<any> {
 
     let zippedStream = zlib.createGzip();
 
-    const yesterday = plusDays(new Date(), -1).toISOString().substr(0,10);
+    const yesterday = params.date || plusDays(new Date(), -1).toISOString().substr(0,10);
     const prefix = (Stage === "PROD") ? "data" : "code-data";
     const randomString = Math.random().toString(36).substring(10);
     const filename = `${prefix}/date=${yesterday}/${yesterday}-${randomString}.json.gz`;

--- a/typescript/src/export/exportHistoricalData.ts
+++ b/typescript/src/export/exportHistoricalData.ts
@@ -14,9 +14,7 @@ async function recursivelyFetchSqsMessages(sqsUrl: string, handleMsg: (message: 
     };
     const sqsResp = await sqs.receiveMessage(request).promise();
     if (sqsResp.Messages && sqsResp.Messages.length > 0) {
-        sqsResp.Messages.forEach(sqsMessage => {
-            handleMsg(sqsMessage);
-        });
+        sqsResp.Messages.forEach(handleMsg);
         return await recursivelyFetchSqsMessages(sqsUrl, handleMsg)
     }
 }
@@ -51,7 +49,7 @@ export async function handler(): Promise<any> {
     if (!bucket) throw new Error('Variable ExportBucket must be set');
 
     const sqsUrl = process.env['SqsUrl'];
-    if (!sqsUrl) throw new Error('No sqs url set, check the cloudwatch event configuration');
+    if (!sqsUrl) throw new Error('Variable SqsUrl must be set');
 
     let zippedStream = zlib.createGzip();
 

--- a/typescript/src/export/exportHistoricalData.ts
+++ b/typescript/src/export/exportHistoricalData.ts
@@ -1,0 +1,96 @@
+import 'source-map-support/register'
+import {s3, sqs} from "../utils/aws";
+import zlib from 'zlib'
+import {Stage} from "../utils/appIdentity";
+import {plusDays} from "../utils/dates";
+import {Message, ReceiveMessageRequest} from "aws-sdk/clients/sqs";
+
+async function recursivelyFetchSqsMessages(sqsUrl: string, handleMsg: (message: Message) => void): Promise<void> {
+    const request: ReceiveMessageRequest = {
+        QueueUrl: sqsUrl,
+        MaxNumberOfMessages: 10,
+        WaitTimeSeconds: 3,
+        VisibilityTimeout: 600
+    };
+    const sqsResp = await sqs.receiveMessage(request).promise();
+    if (sqsResp.Messages && sqsResp.Messages.length > 0) {
+        sqsResp.Messages.forEach(sqsMessage => {
+            handleMsg(sqsMessage);
+        });
+        return await recursivelyFetchSqsMessages(sqsUrl, handleMsg)
+    }
+}
+
+function group<A>(arrayToGroup: A[], groupSize: number): A[][] {
+    if (arrayToGroup.length > 10) {
+        const copiedArray = arrayToGroup.slice(0);
+        const firstGroup = copiedArray.splice(0, groupSize);
+        return [firstGroup].concat(group(copiedArray, groupSize));
+    } else {
+        return [arrayToGroup.slice(0)];
+    }
+}
+
+async function deleteAllSqsMessages(sqsUrl: string, receiptHandleToDelete: string[]): Promise<void> {
+    if (receiptHandleToDelete.length > 0) {
+        const batches = group(receiptHandleToDelete, 10);
+
+        const deletions = batches.map(batch => {
+            const entries = batch.map((receiptHandle, index) => {
+                return {Id: (index + 1).toString(), ReceiptHandle: receiptHandle};
+            });
+            return sqs.deleteMessageBatch({QueueUrl: sqsUrl, Entries: entries}).promise();
+        });
+
+        await Promise.all(deletions);
+    }
+}
+
+export async function handler(): Promise<any> {
+    const bucket = process.env['ExportBucket'];
+    if (!bucket) throw new Error('Variable ExportBucket must be set');
+
+    const sqsUrl = process.env['SqsUrl'];
+    if (!sqsUrl) throw new Error('No sqs url set, check the cloudwatch event configuration');
+
+    let zippedStream = zlib.createGzip();
+
+    const yesterday = plusDays(new Date(), -1).toISOString().substr(0,10);
+    const prefix = (Stage === "PROD") ? "data" : "code-data";
+    const randomString = Math.random().toString(36).substring(10);
+    const filename = `${prefix}/date=${yesterday}/${yesterday}-${randomString}.json.gz`;
+    const managedUpload = s3.upload({
+        Bucket: bucket,
+        Key: filename,
+        Body: zippedStream,
+        ACL: "bucket-owner-full-control"
+    });
+
+    const msgToDelete: string[] = [];
+    let totalMsgCount = 0;
+    let processedMsgCount = 0;
+
+    function handleOneMessage(sqsMessage: Message): void {
+        totalMsgCount++;
+        const parsedMessage = JSON.parse(sqsMessage.Body || "");
+        const messageDate = parsedMessage.snapshotDate.substr(0, 10);
+        if (messageDate == yesterday) {
+            processedMsgCount++;
+            const message = JSON.stringify(parsedMessage) + '\n';
+            zippedStream.write(message);
+            if (sqsMessage.ReceiptHandle) msgToDelete.push(sqsMessage.ReceiptHandle);
+        }
+    }
+
+    await recursivelyFetchSqsMessages(sqsUrl, handleOneMessage);
+
+    zippedStream.end();
+    await managedUpload.promise();
+
+    console.log(`Export succeeded, read ${totalMsgCount} records, processed ${processedMsgCount}`);
+
+    await deleteAllSqsMessages(sqsUrl, msgToDelete);
+    console.log(`Deleted ${msgToDelete.length} messages from the SQS queue`);
+
+    return {recordCount: totalMsgCount};
+}

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -20,34 +20,31 @@ interface GoogleResponseBody {
 
 const restClient = new restm.RestClient('guardian-mobile-purchases');
 
-export function getGoogleSubResponse(record: SQSRecord): Promise<Subscription> {
+async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription> {
 
     const sub = JSON.parse(record.body) as GoogleSubscriptionReference;
     const url = buildGoogleUrl(sub.subscriptionId, sub.purchaseToken, sub.packageName);
-    return getAccessToken(getParams(Stage))
-        .then(accessToken => {
-            return restClient.get<GoogleResponseBody>(url, {additionalHeaders: {Authorization: `Bearer ${accessToken.token}`}})
-        })
-        .then(response => {
-            if(response.result) {
-                const expiryDate = new Date(Number.parseInt(response.result.expiryTimeMillis));
-                return new Subscription(
-                    sub.purchaseToken,
-                    new Date(Number.parseInt(response.result.startTimeMillis)).toISOString(),
-                    expiryDate.toISOString(),
-                    makeCancellationTime(response.result.userCancellationTimeMillis),
-                    response.result.autoRenewing,
-                    sub.subscriptionId,
-                    response.result,
-                    undefined,
-                    null,
-                    dateToSecondTimestamp(thirtyMonths(expiryDate)),
-                );
-            } else {
-                throw new ProcessingError("There was no data in google response", true);
-            }
-        })
+    const accessToken = await getAccessToken(getParams(Stage));
 
+    const response = await restClient.get<GoogleResponseBody>(url, {additionalHeaders: {Authorization: `Bearer ${accessToken.token}`}});
+
+    if(response.result) {
+        const expiryDate = new Date(Number.parseInt(response.result.expiryTimeMillis));
+        return new Subscription(
+            sub.purchaseToken,
+            new Date(Number.parseInt(response.result.startTimeMillis)).toISOString(),
+            expiryDate.toISOString(),
+            makeCancellationTime(response.result.userCancellationTimeMillis),
+            response.result.autoRenewing,
+            sub.subscriptionId,
+            response.result,
+            undefined,
+            null,
+            dateToSecondTimestamp(thirtyMonths(expiryDate)),
+        );
+    } else {
+        throw new ProcessingError("There was no data in google response", true);
+    }
 }
 
 export async function handler(event: SQSEvent) {

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -39,7 +39,11 @@ async function queueHistoricalSubscription(subscription: Subscription): Promise<
 
     const payload = subscription.googlePayload || subscription.applePayload;
     if (payload) {
-        await sendToSqs(queueUrl, payload);
+        await sendToSqs(queueUrl, {
+            subscriptionId: subscription.subscriptionId,
+            snapshotDate: (new Date()).toISOString(),
+            payload
+        });
     }
 }
 

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -1,7 +1,6 @@
 import {SQSRecord} from 'aws-lambda'
 import {Subscription} from '../models/subscription';
-import {dynamoMapper} from "../utils/aws";
-import {ONE_YEAR_IN_SECONDS} from "../pubsub/pubsub";
+import {dynamoMapper, sendToSqs} from "../utils/aws";
 import {ProcessingError} from "../models/processingError";
 
 export function makeCancellationTime(cancellationTime: string) : string {
@@ -30,33 +29,42 @@ export class SubscriptionUpdate {
     }
 }
 
-function putSubscription(subscription: Subscription): Promise<Subscription>  {
+function putSubscription(subscription: Subscription): Promise<Subscription> {
     return dynamoMapper.put({item: subscription}).then(result => result.item)
 }
 
-export async function parseAndStoreSubscriptionUpdate (
-    sqsRecord: SQSRecord,
-    fetchSubscriberDetails: (record: SQSRecord) => Promise<Subscription>,
-) : Promise<String> {
-    return fetchSubscriberDetails(sqsRecord)
-        .then(payload => {
-            putSubscription(payload);
-            return "OK"
-        })
-        .catch(error => {
-            if (error instanceof ProcessingError) {
-               console.error("Error processing the subscription update", error);
-               if (error.shouldRetry) {
-                   console.error("Will throw an exception to retry this message");
-                   throw error;
-               }  else {
-                   console.error("The error wasn't retryable, giving up.");
-                   return "Error, giving up"
-               }
-            } else {
-               console.error("Unexpected error, will throw to retry: ", error);
-               throw error;
-            }
-        });
+async function queueHistoricalSubscription(subscription: Subscription): Promise<void> {
+    const queueUrl = process.env.HistoricalQueueUrl;
+    if (queueUrl === undefined) throw new Error("No HistoricalQueueUrl env parameter provided");
 
+    const payload = subscription.googlePayload || subscription.applePayload;
+    if (payload) {
+        await sendToSqs(queueUrl, payload);
+    }
+}
+
+export async function parseAndStoreSubscriptionUpdate(
+    sqsRecord: SQSRecord,
+    fetchSubscriberDetails: (record: SQSRecord) => Promise<Subscription>
+) : Promise<String> {
+    try {
+        const subscription = await fetchSubscriberDetails(sqsRecord);
+        await putSubscription(subscription);
+        await queueHistoricalSubscription(subscription);
+        return "OK"
+    } catch (error) {
+        if (error instanceof ProcessingError) {
+           console.error("Error processing the subscription update", error);
+           if (error.shouldRetry) {
+               console.error("Will throw an exception to retry this message");
+               throw error;
+           }  else {
+               console.error("The error wasn't retryable, giving up.");
+               return "Error, giving up"
+           }
+        } else {
+           console.error("Unexpected error, will throw to retry: ", error);
+           throw error;
+        }
+    }
 }

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -38,7 +38,7 @@ export const ssm: SSM  = new SSM({
 });
 
 
-export function sendToSqsImpl(queueUrl: string, event: any): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
+export function sendToSqs(queueUrl: string, event: any): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     return sqs.sendMessage({
         QueueUrl: queueUrl,
         MessageBody: JSON.stringify(event)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,5 +55,6 @@ module.exports = [
     deleteLink,
     userSubscriptions,
     exportSubs,
-    exportEvents
+    exportEvents,
+    exportHistoricalData
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const config = {
+module.exports = {
     devtool: 'inline-cheap-source-map',
     module: {
         rules: [
@@ -15,46 +15,25 @@ const config = {
         extensions: [ '.tsx', '.ts', '.js' ]
     },
     target: 'node',
-    mode: 'production'
+    mode: 'production',
+    entry: {
+        "google-pubsub": "./typescript/src/pubsub/google.ts",
+        "apple-pubsub": "./typescript/src/pubsub/apple.ts",
+        "google-subscription-status": "./typescript/src/subscription-status/googleSubStatus.ts",
+        "apple-subscription-status": "./typescript/src/subscription-status/appleSubStatus.ts",
+        "google-link-user-subscription": "./typescript/src/link/google.ts",
+        "apple-link-user-subscription": "./typescript/src/link/apple.ts",
+        "delete-user-subscription": "./typescript/src/link/deleteLink.ts",
+        "user-subscriptions": "./typescript/src/user/user.ts",
+        "google-update-subscriptions": "./typescript/src/update-subs/google.ts",
+        "apple-update-subscriptions": "./typescript/src/update-subs/apple.ts",
+        "export-subscription-tables": "./typescript/src/export/exportSubscriptions.ts",
+        "export-subscription-events-table": "./typescript/src/export/exportEvents.ts",
+        "export-historical-data": "./typescript/src/export/exportHistoricalData.ts",
+    },
+    output: {
+        filename: '[name].js',
+        path: path.resolve(__dirname, 'tsc-target'),
+        libraryTarget: 'commonjs2'
+    }
 };
-
-function entryPoint(sourceFile, outputFile) {
-    return Object.assign({}, config, {
-        entry: `./typescript/src/${sourceFile}`,
-        output: {
-            filename: outputFile,
-            path: path.resolve(__dirname, 'tsc-target'),
-            libraryTarget: 'commonjs2'
-        }
-    });
-}
-
-const googlePubSub = entryPoint('pubsub/google.ts', 'google-pubsub.js');
-const applePubSub = entryPoint('pubsub/apple.ts', 'apple-pubsub.js');
-const googleSubStatus = entryPoint('subscription-status/googleSubStatus.ts', 'google-subscription-status.js');
-const appleSubStatus = entryPoint('subscription-status/appleSubStatus.ts', 'apple-subscription-status.js');
-const googleUserLink = entryPoint('link/google.ts', 'google-link-user-subscription.js');
-const appleUserLink = entryPoint('link/apple.ts', 'apple-link-user-subscription.js');
-const deleteLink = entryPoint('link/deleteLink.ts', 'delete-user-subscription.js');
-const userSubscriptions = entryPoint('user/user.ts', 'user-subscriptions.js');
-const googleUpdateSub = entryPoint('update-subs/google.ts', 'google-update-subscriptions.js');
-const appleUpdateSub = entryPoint('update-subs/apple.ts', 'apple-update-subscriptions.js');
-const exportSubs = entryPoint('export/exportSubscriptions.ts', 'export-subscription-tables.js');
-const exportEvents = entryPoint('export/exportEvents.ts', 'export-subscription-events-table.js');
-const exportHistoricalData = entryPoint('export/exportHistoricalData.ts', 'export-historical-data.js');
-
-module.exports = [
-    googlePubSub,
-    applePubSub,
-    googleSubStatus,
-    appleSubStatus,
-    googleUpdateSub,
-    appleUpdateSub,
-    appleUserLink,
-    googleUserLink,
-    deleteLink,
-    userSubscriptions,
-    exportSubs,
-    exportEvents,
-    exportHistoricalData
-];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ const googleUpdateSub = entryPoint('update-subs/google.ts', 'google-update-subsc
 const appleUpdateSub = entryPoint('update-subs/apple.ts', 'apple-update-subscriptions.js');
 const exportSubs = entryPoint('export/exportSubscriptions.ts', 'export-subscription-tables.js');
 const exportEvents = entryPoint('export/exportEvents.ts', 'export-subscription-events-table.js');
+const exportHistoricalData = entryPoint('export/exportHistoricalData.ts', 'export-historical-data.js');
 
 module.exports = [
     googlePubSub,

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,14 +792,14 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@^2.465.0:
-  version "2.474.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.474.0.tgz#580c7c28e00828b40e2f97b031820bcef68d2367"
-  integrity sha512-nyTZNeVRJix1AStgvH5zcacemgXOhrMrhsXHMmvPkvaXBp3Boj+A79/G8KMd3f/zfjgjRPi9VG0I/BNzfsP3HQ==
+aws-sdk@^2.553.0:
+  version "2.553.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.553.0.tgz#a82c611015138db8f720e0079fe929a65b359a8e"
+  integrity sha512-tcITF/3ijBumvP13Qrq/VB1eRWW6szKF0xVwZ/ch0MGkaEiTQ9n3zNRPtQc1drllsVEm5u5aXp3inoi5zmq0xg==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
-    ieee754 "1.1.8"
+    ieee754 "1.1.13"
     jmespath "0.15.0"
     querystring "0.2.0"
     sax "1.2.1"
@@ -2155,12 +2155,7 @@ iconv-lite@0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
-
-ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==


### PR DESCRIPTION
This is a second try at https://github.com/guardian/mobile-purchases/pull/105

There's quite a lot going on here:
 - Create SQS queues in the export cloudformation template
 - Write a new lambda function that exports the content of these queues
 - Fix the webpack config. I would get Out Of Memory errors, even after giving it 4GB of memory