### PR TITLE
fix riff-raff deploy dependency

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,7 +4,7 @@ regions: [eu-west-1]
 templates:
   lambda:
     type: aws-lambda
-    dependencies: [mobile-purchases-cloudformation]
+    dependencies: [mobile-purchases-cloudformation, mobile-purchases-exports-cloudformation]
     parameters:
       bucket: mobile-dist
       prefixStack: false


### PR DESCRIPTION
I got the dependency wrong. It didn't show on CODE as I applied the templates manually.

This isn't critical.