### PR TITLE
Support multiple subscriptions for one receipt

### DIFF
--- a/typescript/src/subscription-status/appleSubStatus.ts
+++ b/typescript/src/subscription-status/appleSubStatus.ts
@@ -55,7 +55,8 @@ export async function handler(httpRequest: APIGatewayProxyEvent): Promise<APIGat
 
     try {
         const validationResults = await Promise.all(payload.subscriptions.map(sub => validateReceipt(sub.receipt)));
-        const responsePayload = JSON.stringify(validationResults.map(toResponse));
+        const flattenedValidationResults = validationResults.reduce((agg:AppleValidationResponse[], value) => agg.concat(value), []);
+        const responsePayload = JSON.stringify(flattenedValidationResults.map(toResponse));
         return {statusCode: 200, body: responsePayload};
     } catch (e) {
         console.log(`Unable to validate receipt(s)`, e);

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -44,8 +44,5 @@ export async function handler(event: SQSEvent): Promise<String> {
     const promises = event.Records.map( record => parseAndStoreSubscriptionUpdate(record, sqsRecordToAppleSubscription));
 
     return Promise.all(promises)
-        .then( value => {
-            console.log(`Processed ${event.Records.length} subscriptions`);
-            return "OK";
-        });
+        .then( _ => "OK");
 }

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -33,11 +33,11 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
     )
 }
 
-function sqsRecordToAppleSubscription(record: SQSRecord): Promise<Subscription> {
+function sqsRecordToAppleSubscription(record: SQSRecord): Promise<Subscription[]> {
     const subRef = JSON.parse(record.body) as AppleSubscriptionReference;
 
     return validateReceipt(subRef.receipt)
-        .then(toAppleSubscription)
+        .then(subs => subs.map(toAppleSubscription))
 }
 
 export async function handler(event: SQSEvent): Promise<String> {

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -51,9 +51,6 @@ export async function handler(event: SQSEvent) {
     const promises = event.Records.map(record => parseAndStoreSubscriptionUpdate(record, getGoogleSubResponse));
     
     return Promise.all(promises)
-        .then(value  => {
-            console.log(`Processed ${event.Records.length} subscriptions`);
-            return "OK";
-        })
+        .then(_  => "OK")
 
 }

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -20,7 +20,7 @@ interface GoogleResponseBody {
 
 const restClient = new restm.RestClient('guardian-mobile-purchases');
 
-async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription> {
+async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> {
 
     const sub = JSON.parse(record.body) as GoogleSubscriptionReference;
     const url = buildGoogleUrl(sub.subscriptionId, sub.purchaseToken, sub.packageName);
@@ -30,7 +30,7 @@ async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription> {
 
     if(response.result) {
         const expiryDate = new Date(Number.parseInt(response.result.expiryTimeMillis));
-        return new Subscription(
+        return [new Subscription(
             sub.purchaseToken,
             new Date(Number.parseInt(response.result.startTimeMillis)).toISOString(),
             expiryDate.toISOString(),
@@ -41,7 +41,7 @@ async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription> {
             undefined,
             null,
             dateToSecondTimestamp(thirtyMonths(expiryDate)),
-        );
+        )];
     } else {
         throw new ProcessingError("There was no data in google response", true);
     }

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -49,12 +49,12 @@ async function queueHistoricalSubscription(subscription: Subscription): Promise<
 
 export async function parseAndStoreSubscriptionUpdate(
     sqsRecord: SQSRecord,
-    fetchSubscriberDetails: (record: SQSRecord) => Promise<Subscription>
+    fetchSubscriberDetails: (record: SQSRecord) => Promise<Subscription[]>
 ) : Promise<String> {
     try {
-        const subscription = await fetchSubscriberDetails(sqsRecord);
-        await putSubscription(subscription);
-        await queueHistoricalSubscription(subscription);
+        const subscriptions = await fetchSubscriberDetails(sqsRecord);
+        await Promise.all(subscriptions.map(putSubscription));
+        await Promise.all(subscriptions.map(queueHistoricalSubscription));
         return "OK"
     } catch (error) {
         if (error instanceof ProcessingError) {

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -55,6 +55,7 @@ export async function parseAndStoreSubscriptionUpdate(
         const subscriptions = await fetchSubscriberDetails(sqsRecord);
         await Promise.all(subscriptions.map(putSubscription));
         await Promise.all(subscriptions.map(queueHistoricalSubscription));
+        console.log(`Processed ${subscriptions.length} subscriptions`);
         return "OK"
     } catch (error) {
         if (error instanceof ProcessingError) {

--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -17,7 +17,7 @@ describe("The apple validation service", () => {
             status: 21006
         };
 
-        const expected: AppleValidationResponse = {
+        const expected: AppleValidationResponse[] = [{
             autoRenewStatus: false,
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
@@ -29,7 +29,7 @@ describe("The apple validation service", () => {
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
             },
             originalResponse: appleResponse
-        };
+        }];
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
     });
@@ -48,7 +48,7 @@ describe("The apple validation service", () => {
             status: 0
         };
 
-        const expected: AppleValidationResponse = {
+        const expected: AppleValidationResponse[] = [{
             autoRenewStatus: false,
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
@@ -60,7 +60,7 @@ describe("The apple validation service", () => {
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
             },
             originalResponse: appleResponse
-        };
+        }];
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
     })
@@ -78,7 +78,7 @@ describe("The apple validation service", () => {
             status: 0
         };
 
-        const expected: AppleValidationResponse = {
+        const expected: AppleValidationResponse[] = [{
             autoRenewStatus: false,
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
@@ -90,7 +90,7 @@ describe("The apple validation service", () => {
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
             },
             originalResponse: appleResponse
-        };
+        }];
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
     })
@@ -110,6 +110,13 @@ describe("The apple validation service", () => {
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     expires_date: "2019-09-10 11:09:54 Etc/GM",
+                    expires_date_ms: "1570705793000",
+                    original_purchase_date_ms: "1567081703000"
+                },
+                {
+                    original_transaction_id: "1235",
+                    product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                    expires_date: "2019-09-10 11:09:54 Etc/GM",
                     expires_date_ms: "1570705794000",
                     original_purchase_date_ms: "1567081703000"
                 }
@@ -117,7 +124,19 @@ describe("The apple validation service", () => {
             status: 0
         };
 
-        const expected: AppleValidationResponse = {
+        const expected: AppleValidationResponse[] = [{
+            autoRenewStatus: false,
+            isRetryable: false,
+            latestReceipt: "cmVjZWlwdA==",
+            latestReceiptInfo: {
+                cancellationDate: null,
+                expiresDate: new Date(1570705793000),
+                originalPurchaseDate: new Date(1567081703000),
+                originalTransactionId: "1234",
+                productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+            },
+            originalResponse: appleResponse
+        },{
             autoRenewStatus: false,
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
@@ -129,7 +148,7 @@ describe("The apple validation service", () => {
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
             },
             originalResponse: appleResponse
-        };
+        }];
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
     })


### PR DESCRIPTION
It turns out Apple uses only one receipt when a user has multiple subscriptions. It's not everyday's case, but it has happen in our data.

@ddramowicz sent me a test case for this code to be tested. I'll double check on CODE.
