### PR TITLE
Filter gracefully one off purchases from the app store

### DIFF
--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -93,7 +93,7 @@ describe("The apple validation service", () => {
         }];
 
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
-    })
+    });
 
     test("Should transform a dirty apple payload with an array of latest receipts into sane one, picking the relevant receipt in the array", () => {
         const appleResponse: AppleValidationServerResponse = {
@@ -143,6 +143,44 @@ describe("The apple validation service", () => {
             latestReceiptInfo: {
                 cancellationDate: null,
                 expiresDate: new Date(1570705794000),
+                originalPurchaseDate: new Date(1567081703000),
+                originalTransactionId: "1235",
+                productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+            },
+            originalResponse: appleResponse
+        }];
+
+        expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
+    })
+
+
+    test("Should transform a dirty apple payload with an array of latest receipts into sane one, filtering receipts from one off purchases", () => {
+        const appleResponse: AppleValidationServerResponse = {
+            auto_renew_status: 0,
+            latest_receipt_info: [
+                {
+                    original_transaction_id: "1234",
+                    product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                    original_purchase_date_ms: "1567081703000"
+                },
+                {
+                    original_transaction_id: "1235",
+                    product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                    expires_date: "2019-09-10 11:09:54 Etc/GM",
+                    expires_date_ms: "1570705793000",
+                    original_purchase_date_ms: "1567081703000"
+                }
+            ],
+            status: 0
+        };
+
+        const expected: AppleValidationResponse[] = [{
+            autoRenewStatus: false,
+            isRetryable: false,
+            latestReceipt: "cmVjZWlwdA==",
+            latestReceiptInfo: {
+                cancellationDate: null,
+                expiresDate: new Date(1570705793000),
                 originalPurchaseDate: new Date(1567081703000),
                 originalTransactionId: "1235",
                 productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",


### PR DESCRIPTION
So it turns out that since I fixed the backfill this morning we get to see new use cases never seen before.

Buckle up and grab your Indiana Jones hat, we're going to do some archaeology!

So we've got this alarm that triggered in prod because some of the messages posted on the SQS queue can't be processed. After looking at the dead letter queue (where messages go if they can't be processed after a few retries), I manually tried to reproduce the case locally.

What was happening was the code would blow up when trying to read the expiry date of the subscription. After looking at the actual data returned by apple, indeed there was no `expires_date` nor `expires_date_ms` contrary to what the [official documentation](https://developer.apple.com/documentation/appstorereceipts/expires_date_ms) might indicate.
Digging deeper and unearthing older runes it's possible to see traces of why by looking at this artefact of a [documentation here](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html).

> This key is only present for auto-renewable subscription receipts.(...)

So that receipt isn't renewing automatically, I guess it means it's not a subscription but rather a one off purchase. It's strange because we're not offering that option in the app right?
Looking at the original purchase date we can see it actually was purchased in 2012. Apple started supporting subscriptions [in 2011](https://en.wikipedia.org/wiki/App_Store_(iOS)#Monetization), but it's close enough that we could simply not have migrated to subscriptions at that time, and the app would offer one off subscriptions.

So since these subs are really old and we would gain no new information by storing them, I've implemented a filter to remove these from the response from Apple.
I've also added the corresponding test case.

Once merged I'll re-process all the messages in the dead letter queue for completion

