### PR TITLE
Support checking subscription status for multiple Android apps

### DIFF
--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -41,7 +41,10 @@ export async function handler(request: APIGatewayProxyEvent): Promise<APIGateway
     if (request.pathParameters && request.headers && getPurchaseToken(request.headers)) {
         const restClient = new restm.RestClient('guardian-mobile-purchases');
         const purchaseToken = getPurchaseToken(request.headers);
-        const url = buildGoogleUrl(request.pathParameters.subscriptionId, purchaseToken, googlePackageName(request.headers));
+        const packageName = googlePackageName(request.headers);
+        const subscriptionId = request.pathParameters.subscriptionId;
+        console.log(`Searching for valid ${subscriptionId} subscription for Android app with package name: ${packageName}`);
+        const url = buildGoogleUrl(subscriptionId, purchaseToken, packageName);
         return getAccessToken(getParams(stage || ""))
             .then(accessToken =>
                 restClient.get<GoogleResponseBody>(url, {additionalHeaders: {Authorization: `Bearer ${accessToken.token}`}})

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -25,15 +25,23 @@ function getPurchaseToken(headers: HttpRequestHeaders): string {
     return headers["Play-Purchase-Token"] || headers["play-purchase-token"]
 }
 
+function googlePackageName(headers: HttpRequestHeaders): string {
+    const packageNameFromHeaders = headers["Package-Name"] || headers["package-name"];
+    if (packageNameFromHeaders) {
+        return packageNameFromHeaders
+    } else {
+        return "com.guardian";
+    }
+}
+
 export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
 
     const stage = process.env.Stage;
-    const googlePackagename =  "com.guardian"
 
     if (request.pathParameters && request.headers && getPurchaseToken(request.headers)) {
         const restClient = new restm.RestClient('guardian-mobile-purchases');
-        const purchaseToken = getPurchaseToken(request.headers)
-        const url = buildGoogleUrl(request.pathParameters.subscriptionId, purchaseToken, googlePackagename);
+        const purchaseToken = getPurchaseToken(request.headers);
+        const url = buildGoogleUrl(request.pathParameters.subscriptionId, purchaseToken, googlePackageName(request.headers));
         return getAccessToken(getParams(stage || ""))
             .then(accessToken =>
                 restClient.get<GoogleResponseBody>(url, {additionalHeaders: {Authorization: `Bearer ${accessToken.token}`}})


### PR DESCRIPTION
The team developing the puzzles app intend to start using this API to check Play subscription status.

This PR makes it possible for clients to check the subscription status of any app in our account by passing the relevant package name as a header. We default to `com.guardian` if this header is not present, which means that existing clients (i.e. current versions of the Guardian Live App) should continue to work without providing this header.

