### PR TITLE
Raise the alarm limit to 20 errors

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -709,7 +709,7 @@ Resources:
       Namespace: AWS/ApiGateway
       Period: 300
       Statistic: Sum
-      Threshold: 10
+      Threshold: 20
       TreatMissingData: notBreaching
 
 


### PR DESCRIPTION
We're getting emails still