### PR TITLE
MSS-1345: Fix jackson-databind vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ import scala.collection.immutable
 val testAndCompileDependencies: String = "test->test;compile->compile"
 val awsVersion: String = "1.11.375"
 val simpleConfigurationVersion: String = "1.4.3"
+
 // Force a version of jackson-databind that addresses this vulnerability:
 // https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-471943
 // introduced via com.typesafe.play:play

--- a/build.sbt
+++ b/build.sbt
@@ -7,13 +7,17 @@ import scala.collection.immutable
 val testAndCompileDependencies: String = "test->test;compile->compile"
 val awsVersion: String = "1.11.375"
 val simpleConfigurationVersion: String = "1.4.3"
+val jacksonData: String = "2.9.10.1"
+val jacksonDatatype: String = "2.9.8"
 
 val scalaRoot = file("scala")
 
-lazy val common = project.in(scalaRoot / "common").disablePlugins(AssemblyPlugin).settings(commonSettings("common"))
+lazy val common = project.in(scalaRoot / "common")
+  .disablePlugins(AssemblyPlugin)
+  .settings(commonSettings("common"), libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonData)
 
 lazy val userPurchasePersistence = project.in(scalaRoot / "user-purchase-persistence").disablePlugins(AssemblyPlugin)
-  .settings(commonSettings("user-purchase-persistence"))
+  .settings(commonSettings("user-purchase-persistence"), libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonData)
   .dependsOn(common % testAndCompileDependencies)
 
 
@@ -24,7 +28,8 @@ lazy val iosValidateReceipts = project.in(scalaRoot / "ios-validate-receipts").e
   List(
     libraryDependencies ++= List(
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
-      "com.squareup.okhttp3" % "okhttp" % "3.10.0"
+      "com.squareup.okhttp3" % "okhttp" % "3.10.0",
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonData
     ),
     libraryDependencies ++= upgradeIosvalidatereceiptsTransitiveDependencies
   ) ++ commonAssemblySettings("ios-validate-receipts")
@@ -33,13 +38,15 @@ lazy val iosValidateReceipts = project.in(scalaRoot / "ios-validate-receipts").e
 
 lazy val iosUserPurchases = project.in(scalaRoot / "ios-user-purchases").enablePlugins(AssemblyPlugin).settings(commonAssemblySettings("ios-user-purchases"))
   .dependsOn(userPurchasePersistence % testAndCompileDependencies)
+  .settings(libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonData)
 
 lazy val googleOauth = project.in(scalaRoot / "google-oauth").enablePlugins(AssemblyPlugin)
   .settings(
     commonAssemblySettings("google-oauth"),
     libraryDependencies ++= List(
     "com.google.auth" % "google-auth-library-oauth2-http" % "0.15.0",
-    "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion
+    "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonData
     )
   )
   .dependsOn(common % testAndCompileDependencies)

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,10 @@ import scala.collection.immutable
 val testAndCompileDependencies: String = "test->test;compile->compile"
 val awsVersion: String = "1.11.375"
 val simpleConfigurationVersion: String = "1.4.3"
-val jacksonData: String = "2.9.10.1"
-val jacksonDatatype: String = "2.9.8"
+// Force a version of jackson-databind that addresses this vulnerability:
+// https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-471943
+// introduced via com.typesafe.play:play
+val jacksonData: String = "2.10.1"
 
 val scalaRoot = file("scala")
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val simpleConfigurationVersion: String = "1.4.3"
 // Force a version of jackson-databind that addresses this vulnerability:
 // https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-471943
 // introduced via com.typesafe.play:play
-val jacksonData: String = "2.9.10"
+val jacksonData: String = "2.9.10.2"
 
 val scalaRoot = file("scala")
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val simpleConfigurationVersion: String = "1.4.3"
 // Force a version of jackson-databind that addresses this vulnerability:
 // https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-471943
 // introduced via com.typesafe.play:play
-val jacksonData: String = "2.10.0"
+val jacksonData: String = "2.9.10"
 
 val scalaRoot = file("scala")
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val simpleConfigurationVersion: String = "1.4.3"
 // Force a version of jackson-databind that addresses this vulnerability:
 // https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-471943
 // introduced via com.typesafe.play:play
-val jacksonData: String = "2.10.1"
+val jacksonData: String = "2.10.0"
 
 val scalaRoot = file("scala")
 


### PR DESCRIPTION
Force jackson-databind version to fix some vulnerability issues:
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-174736

NB: remove after upgrading play app to 2.7 (if we should ever do this)