### PR TITLE
Increase memory allocation for ExportAppleHistoricalSubscriptionsLambda

### DIFF
--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -257,7 +257,7 @@ Resources:
           ExportBucket: !Ref AppleSubscriptionHistoryExportBucket
           SqsUrl: !Ref AppleHistoricalSubscriptionsQueue
       Description: Export the historical Apple subscriptions to the data lake
-      MemorySize: 512
+      MemorySize: 3008
       Timeout: 900
       Events:
         Schedule:


### PR DESCRIPTION
I think that this lambda is regularly running out of memory (as the number of messages it needs to process has increased significantly) - this PR allows me to test that theory.