### PR TITLE
Fallback on the sandbox environment

### DIFF
--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -78,7 +78,7 @@ function callValidateReceipt(receipt: string, forceSandbox: boolean = false): Pr
             return fetch(endpoint, { method: 'POST', body: body});
         }).then(response => {
             if (!response.ok) {
-                console.error(`Impossible to validate the receipt, got ${response.status} ${response.statusText} from receiptEndpoint for ${receipt}`);
+                console.error(`Impossible to validate the receipt, got ${response.status} ${response.statusText} from ${endpoint} for ${receipt}`);
                 throw new ProcessingError("Impossible to validate receipt", true);
             }
             return response

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -64,7 +64,7 @@ export interface AppleValidationResponse {
 
 const sandboxReceiptEndpoint = "https://sandbox.itunes.apple.com/verifyReceipt";
 const prodReceiptEndpoint = "https://buy.itunes.apple.com/verifyReceipt";
-const receiptEndpoint = (Stage === "PROD") ? sandboxReceiptEndpoint : prodReceiptEndpoint;
+const receiptEndpoint = (Stage === "PROD") ? prodReceiptEndpoint : sandboxReceiptEndpoint;
 
 function callValidateReceipt(receipt: string, forceSandbox: boolean = false): Promise<Response> {
     const endpoint = forceSandbox ? sandboxReceiptEndpoint : receiptEndpoint;

--- a/typescript/src/subscription-status/appleSubStatus.ts
+++ b/typescript/src/subscription-status/appleSubStatus.ts
@@ -71,7 +71,7 @@ export async function handler(httpRequest: APIGatewayProxyEvent): Promise<APIGat
     }
 
     try {
-        const validationResults = await Promise.all(payload.subscriptions.map(sub => validateReceipt(sub.receipt)));
+        const validationResults = await Promise.all(payload.subscriptions.map(sub => validateReceipt(sub.receipt, {sandboxRetry: true})));
         const flattenedValidationResults = validationResults.reduce((agg:AppleValidationResponse[], value) => agg.concat(value), []);
         const calculatedResponse = flattenedValidationResults.map(toResponse);
         logClientServerStatusDiff(calculatedResponse, payload.subscriptions);

--- a/typescript/src/subscription-status/appleSubStatus.ts
+++ b/typescript/src/subscription-status/appleSubStatus.ts
@@ -12,7 +12,7 @@ interface AppleSubscription {
 }
 
 interface AppleLinkPayload {
-    platform: Platform.DailyEdition | Platform.Ios
+    platform: Platform.DailyEdition | Platform.Ios | Platform.IosPuzzles
     subscriptions: AppleSubscription[]
 }
 

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -36,7 +36,7 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
 function sqsRecordToAppleSubscription(record: SQSRecord): Promise<Subscription[]> {
     const subRef = JSON.parse(record.body) as AppleSubscriptionReference;
 
-    return validateReceipt(subRef.receipt)
+    return validateReceipt(subRef.receipt, {sandboxRetry: false})
         .then(subs => subs.map(toAppleSubscription))
 }
 

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -36,6 +36,8 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
 function sqsRecordToAppleSubscription(record: SQSRecord): Promise<Subscription[]> {
     const subRef = JSON.parse(record.body) as AppleSubscriptionReference;
 
+    // sandboxRetry is set to false such that in production we don't store any sandbox receipt that would have snuck all the way here
+    // In CODE or locally the default endpoint will be sanbox therefore no retry is necessary
     return validateReceipt(subRef.receipt, {sandboxRetry: false})
         .then(subs => subs.map(toAppleSubscription))
 }


### PR DESCRIPTION
This is to allow beta build to validate their receipts without having to change endpoint.

The apple receipt validation service will retry to validate a receipt if it receives the code 21007, which indicates that a sandbox receipt has been validated in prod.

We only want to retry when validating a receipt as a one off. The process that stores the state of subscription shouldn't try to revalidate receipts.