### PR TITLE
Add a global secondary index to subscription table

### DIFF
--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -102,6 +102,15 @@ Resources:
         AttributeName: ttl
       StreamSpecification:
         StreamViewType: KEYS_ONLY
+      GlobalSecondaryIndexes:
+        - IndexName: ios-endTimestamp-revalidation-index
+          KeySchema:
+            - AttributeName: subscriptionId
+              KeyType: HASH
+            - AttributeName: endTimestamp
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
       Tags:
         - Key: Stage
           Value: !Ref Stage

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -110,7 +110,10 @@ Resources:
             - AttributeName: endTimestamp
               KeyType: RANGE
           Projection:
-            ProjectionType: ALL
+            NonKeyAttributes:
+              - auto_renew_status
+              - latest_receipt_info
+            ProjectionType: INCLUDE
       Tags:
         - Key: Stage
           Value: !Ref Stage

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -89,6 +89,8 @@ Resources:
       AttributeDefinitions:
         - AttributeName: subscriptionId
           AttributeType: S
+        - AttributeName: endTimestamp
+          AttributeType: S
       KeySchema:
         - AttributeName: subscriptionId
           KeyType: HASH


### PR DESCRIPTION
Creates a new global secondary index in the subscription table, 

@alexduf the only thing I am unsure is whether to include `ALL` the attributes or just to `INCLUDE` the `latest_receipt` and the `autoRenewStatus` attributes. 