### PR TITLE
More capacity for subscription export

### DIFF
--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -110,7 +110,7 @@ Resources:
           ExportBucket: !Ref SubscriptionExportBucket
           ClassName: ReadSubscription
       Description: Export subscription table to the datalake
-      MemorySize: 512
+      MemorySize: 2048
       Timeout: 900
       Events:
         Schedule:


### PR DESCRIPTION
The subscription export job has failed with a timeout a few times recently. Looking at the trends it seems like the duration is proportional to the number of rows.  Since we've had more and more rows the export has now reached the maximum 15 minutes a lambda can run for.

In the short term, I'm quadrupling the capacity of the lambda it as it seems to have an impact on how quickly the table can be exported (I tested with doubling it)

In the long term we may need to re-think this export, as a lambda + s3 might not be enough to fit within 15 minutes.

