### PR TITLE
Add an optional endTimestampFilter parameter and create a new revalidation lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ lazy val root = project
     riffRaffArtifactResources += file("tsc-target/export-subscription-tables.zip") -> s"mobile-purchases-export-subscription-tables/export-subscription-tables.zip",
     riffRaffArtifactResources += file("tsc-target/export-subscription-events-table.zip") -> s"mobile-purchases-export-subscription-events-table/export-subscription-events-table.zip",
     riffRaffArtifactResources += file("tsc-target/export-historical-data.zip") -> s"mobile-purchases-export-historical-data/export-historical-data.zip",
+    riffRaffArtifactResources += file("tsc-target/apple-revalidate-receipts.zip") -> s"mobile-purchases-apple-revalidate-receipts/apple-revalidate-receipts.zip",
     riffRaffArtifactResources += file("cloudformation.yaml") -> s"mobile-purchases-cloudformation/cloudformation.yaml",
     riffRaffArtifactResources += file("exports-cloudformation.yaml") -> s"mobile-purchases-exports-cloudformation/exports-cloudformation.yaml",
   )

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -888,6 +888,29 @@ Resources:
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions/*
 
+  AppleRevalidateSubscriptionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: logs
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+                - cloudwatch:putMetricData
+              Resource: "*"
+
   DeleteUserSubscriptionLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -914,6 +937,29 @@ Resources:
               Fn::ImportValue:
                 !Sub ${App}-${Stage}-subscriptions-stream-arn
             StartingPosition: LATEST
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App
+
+  AppleRevalidateReceiptsLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: apple-revalidate-receipts.handler
+      Runtime: nodejs10.x
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-apple-revalidate-receipts/apple-revalidate-receipts.zip
+      FunctionName: !Sub ${App}-apple-revalidate-receipts-${Stage}
+      Role: !GetAtt AppleRevalidateSubscriptionRole.Arn
+      Environment:
+        Variables:
+          App: !Sub ${App}
+          Stack: !Sub ${Stack}
+          Stage: !Sub ${Stage}
+      Description: Finds recently expired subscriptions
+      MemorySize: 512
+      Timeout: 60
       Tags:
         Stage: !Ref Stage
         Stack: !Ref Stack

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -115,3 +115,9 @@ deployments:
     parameters:
       functionNames: [mobile-purchases-export-google-historical-data-, mobile-purchases-export-apple-historical-data-]
       fileName: export-historical-data.zip
+
+  mobile-purchases-apple-revalidate-subscriptions:
+    template: lambda
+    parameters:
+      functionNames: [mobile-purchases-apple-revalidate-receipts-]
+      fileName: apple-revalidate-receipts.zip

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -116,7 +116,7 @@ deployments:
       functionNames: [mobile-purchases-export-google-historical-data-, mobile-purchases-export-apple-historical-data-]
       fileName: export-historical-data.zip
 
-  mobile-purchases-apple-revalidate-subscriptions:
+  mobile-purchases-apple-revalidate-receipts:
     template: lambda
     parameters:
       functionNames: [mobile-purchases-apple-revalidate-receipts-]

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -1,20 +1,21 @@
-// import {AppleValidationResponse} from "../services/appleValidateReceipts";
-// import {Subscription} from "../models/subscription";
-// import {Option} from "../utils/option";
-//
-// function endTimestampFilter(cancellationDate: Subscription): string | undefined  {
-//     let dateNow: Date = new Date();
-//     let endTimestamp = cancellationDate.endTimestamp
-//
-//     if(endTimestamp == undefined) {
-//         return dateNow.setHours(dateNow.getHours() + 3).toString();
-//     }
-// }
+import {dynamoMapper} from "../utils/aws";
+import {endTimeStampFilterSubscription} from "../models/endTimestampFilter";
+import {Option} from "../utils/option";
+import {plusDays, plusHours} from "../utils/dates";
 
-export function handler() {
- console.log("Running receipt revalidation")
+function endTimestampForQuery(event: ScheduleEvent): Date {
+ const defaultDate = plusHours(new Date(), 3);
+ if(event.endTimestampFilter) {
+  return new Date(Date.parse(event.endTimestampFilter));
+ } else {
+  return defaultDate;
+ }
 }
 
+interface ScheduleEvent {
+ endTimestampFilter?: string;
+}
 
-
-
+export function handler(event: ScheduleEvent) {
+ console.log(`Filter date will be: ${endTimestampForQuery(event)}`)
+}

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -1,7 +1,4 @@
-import {dynamoMapper} from "../utils/aws";
-import {endTimeStampFilterSubscription} from "../models/endTimestampFilter";
-import {Option} from "../utils/option";
-import {plusDays, plusHours} from "../utils/dates";
+import {plusHours} from "../utils/dates";
 
 function endTimestampForQuery(event: ScheduleEvent): Date {
  const defaultDate = plusHours(new Date(), 3);

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -1,0 +1,20 @@
+// import {AppleValidationResponse} from "../services/appleValidateReceipts";
+// import {Subscription} from "../models/subscription";
+// import {Option} from "../utils/option";
+//
+// function endTimestampFilter(cancellationDate: Subscription): string | undefined  {
+//     let dateNow: Date = new Date();
+//     let endTimestamp = cancellationDate.endTimestamp
+//
+//     if(endTimestamp == undefined) {
+//         return dateNow.setHours(dateNow.getHours() + 3).toString();
+//     }
+// }
+
+export function handler() {
+ console.log("Running receipt revalidation")
+}
+
+
+
+

--- a/typescript/src/utils/dates.ts
+++ b/typescript/src/utils/dates.ts
@@ -43,3 +43,9 @@ export function plusDays(from: Date, count: number): Date {
     newDate.setUTCDate(from.getUTCDate() + count);
     return newDate;
 }
+
+export function plusHours(from: Date, count: number): Date {
+    const newDate = new Date(from.getTime());
+    newDate.setUTCHours(from.getUTCHours() + count);
+    return newDate;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
         "export-subscription-tables": "./typescript/src/export/exportSubscriptions.ts",
         "export-subscription-events-table": "./typescript/src/export/exportEvents.ts",
         "export-historical-data": "./typescript/src/export/exportHistoricalData.ts",
+        "apple-revalidate-receipts": "./typescript/src/revalidate-receipts/appleRevalidateReceipts.ts",
     },
     output: {
         filename: '[name].js',


### PR DESCRIPTION
This PR adds creates a new apple receipt revalidation lambda, and adds an optional endTimestampFilter parameter that sets a default time of `now + 3 hours`

With the help of @jacobwinch 

This has been tested on CODE