### PR TITLE
Create filter for subscription table

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -915,7 +915,7 @@ Resources:
             Statement:
               Effect: Allow
               Action:
-                - "dynamodb:Scan"
+                - "dynamodb:Query"
               Resource:
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions/index/ios-endTimestamp-revalidation-index
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -910,6 +910,15 @@ Resources:
                 - logs:PutLogEvents
                 - cloudwatch:putMetricData
               Resource: "*"
+        - PolicyName: dynamo
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - "dynamodb:Scan"
+              Resource:
+                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions/index/ios-endTimestamp-revalidation-index
+                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions
 
   DeleteUserSubscriptionLambda:
     Type: AWS::Serverless::Function

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -89,6 +89,8 @@ Resources:
       AttributeDefinitions:
         - AttributeName: subscriptionId
           AttributeType: S
+        - AttributeName: endTimestamp
+          AttributeType: S
       KeySchema:
         - AttributeName: subscriptionId
           KeyType: HASH
@@ -102,6 +104,18 @@ Resources:
         AttributeName: ttl
       StreamSpecification:
         StreamViewType: KEYS_ONLY
+      GlobalSecondaryIndexes:
+        - IndexName: ios-endTimestamp-revalidation-index
+          KeySchema:
+            - AttributeName: subscriptionId
+              KeyType: HASH
+            - AttributeName: endTimestamp
+              KeyType: RANGE
+          Projection:
+            NonKeyAttributes:
+              - autoRenewing
+              - receipt
+            ProjectionType: INCLUDE
       Tags:
         - Key: Stage
           Value: !Ref Stage

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -89,8 +89,6 @@ Resources:
       AttributeDefinitions:
         - AttributeName: subscriptionId
           AttributeType: S
-        - AttributeName: endTimestamp
-          AttributeType: S
       KeySchema:
         - AttributeName: subscriptionId
           KeyType: HASH
@@ -104,18 +102,6 @@ Resources:
         AttributeName: ttl
       StreamSpecification:
         StreamViewType: KEYS_ONLY
-      GlobalSecondaryIndexes:
-        - IndexName: ios-endTimestamp-revalidation-index
-          KeySchema:
-            - AttributeName: subscriptionId
-              KeyType: HASH
-            - AttributeName: endTimestamp
-              KeyType: RANGE
-          Projection:
-            NonKeyAttributes:
-              - auto_renew_status
-              - latest_receipt_info
-            ProjectionType: INCLUDE
       Tags:
         - Key: Stage
           Value: !Ref Stage

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws/dynamodb-data-mapper": "^0.7.3",
     "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
+    "@aws/dynamodb-expressions": "^0.7.3",
     "@types/aws-lambda": "8.10.27",
     "@types/node": "^12.0.2",
     "@types/node-fetch": "^2.5.0",

--- a/typescript/src/models/endTimestampFilter.ts
+++ b/typescript/src/models/endTimestampFilter.ts
@@ -1,0 +1,40 @@
+import {hashKey, attribute, rangeKey} from '@aws/dynamodb-data-mapper-annotations';
+import {DynamoDbTable} from "@aws/dynamodb-data-mapper";
+import {App, Stage} from "../utils/appIdentity";
+import {AppleValidatedReceiptServerInfo} from "../services/appleValidateReceipts";
+
+export class Subscription {
+
+    @hashKey()
+    subscriptionId: string;
+
+    @rangeKey()
+    endTimestamp: string;
+
+    @attribute()
+    latest_receipt_info?: AppleValidatedReceiptServerInfo | AppleValidatedReceiptServerInfo[];
+
+    @attribute()
+    auto_renew_status: Boolean;
+
+    constructor(subscriptionId: string, endTimestamp: string, autoRenewStatus: Boolean, latestReceiptInfo?: AppleValidatedReceiptServerInfo | AppleValidatedReceiptServerInfo[]) {
+        this.subscriptionId = subscriptionId;
+        this.endTimestamp = endTimestamp;
+        this.latest_receipt_info = latestReceiptInfo;
+        this.auto_renew_status = autoRenewStatus
+
+    }
+
+    get[DynamoDbTable]() {
+        return `${App}-${Stage}-subscriptions`
+    }
+
+}
+
+export class endTimeStampFilterSubscription extends Subscription {
+
+    constructor() {
+        super("", "" , false);
+    }
+
+}

--- a/typescript/src/models/endTimestampFilter.ts
+++ b/typescript/src/models/endTimestampFilter.ts
@@ -12,16 +12,16 @@ export class Subscription {
     endTimestamp: string;
 
     @attribute()
-    latest_receipt_info?: AppleValidatedReceiptServerInfo | AppleValidatedReceiptServerInfo[];
+    receipt?: AppleValidatedReceiptServerInfo | AppleValidatedReceiptServerInfo[];
 
     @attribute()
-    auto_renew_status: Boolean;
+    autoRenewing: Boolean;
 
     constructor(subscriptionId: string, endTimestamp: string, autoRenewStatus: Boolean, latestReceiptInfo?: AppleValidatedReceiptServerInfo | AppleValidatedReceiptServerInfo[]) {
         this.subscriptionId = subscriptionId;
         this.endTimestamp = endTimestamp;
-        this.latest_receipt_info = latestReceiptInfo;
-        this.auto_renew_status = autoRenewStatus
+        this.receipt = latestReceiptInfo;
+        this.autoRenewing = autoRenewStatus
 
     }
 

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -7,12 +7,12 @@ import {
  equals, lessThan,
 } from '@aws/dynamodb-expressions';
 
-function endTimestampForQuery(event: ScheduleEvent): string {
+function endTimestampForQuery(event: ScheduleEvent): Date {
  const defaultDate = plusHours(new Date(), 3);
  if(event.endTimestampFilter) {
-  return new Date(Date.parse(event.endTimestampFilter)).toISOString();
+  return new Date(Date.parse(event.endTimestampFilter));
  } else {
-  return defaultDate.toISOString();
+  return defaultDate;
  }
 }
 
@@ -21,7 +21,7 @@ interface ScheduleEvent {
 }
 
 export async function handler(event: ScheduleEvent) {
- const time = endTimestampForQuery(event);
+ const time = endTimestampForQuery(event).toISOString();
  console.log(`Will filter subscriptions before ${time}`);
 
  const filter: AndExpression = {

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -4,6 +4,8 @@ import {endTimeStampFilterSubscription} from "../models/endTimestampFilter";
 import {equals} from '@aws/dynamodb-expressions';
 import {ReadUserSubscription} from "../models/userSubscription";
 import {TableName} from "aws-sdk/clients/dynamodb";
+import {ReadSubscriptionEvent} from "../models/subscriptionEvent";
+import {writeSync} from "fs";
 
 function endTimestampForQuery(event: ScheduleEvent): Date {
  const defaultDate = plusHours(new Date(), 3);
@@ -19,19 +21,26 @@ interface ScheduleEvent {
 }
 
 export async function handler(event: ScheduleEvent) {
-console.log("in handler")
- const queryScan = dynamoMapper.scan({
-  valueConstructor: endTimeStampFilterSubscription,
-  indexName: 'ios-endTimestamp-revalidation-index',
-  filter: {
-   ...equals(true),
-   subject: 'autoRenewing'
-  }
- });
+// console.log("in handler")
+//  const queryScan = dynamoMapper.scan({
+//   valueConstructor: endTimeStampFilterSubscription,
+//   indexName: 'ios-endTimestamp-revalidation-index',
+//   filter: {
+//    ...equals(true),
+//    subject: 'autoRenewing'
+//   }
+//  });
+//
+//  for await (const subscription of queryScan) {
+//   console.log(`subscription is: ${subscription}`)
+//  }
+//  console.log(queryScan.count)
+//  return queryScan.count
 
- for await (const subscription of queryScan) {
+ const iterator = dynamoMapper.query(endTimeStampFilterSubscription,{subscriptionId:"100000580817300"}, {indexName: "ios-endTimestamp-revalidation-index"});
+
+ for await (const subscription of iterator) {
   console.log(`subscription is: ${subscription}`)
  }
- console.log(queryScan.count)
- return queryScan.count
 }
+

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -19,7 +19,7 @@ interface ScheduleEvent {
 }
 
 export async function handler(event: ScheduleEvent) {
-
+console.log("in handler")
  const queryScan = dynamoMapper.scan({
   valueConstructor: endTimeStampFilterSubscription,
   indexName: 'ios-endTimestamp-revalidation-index',
@@ -30,6 +30,8 @@ export async function handler(event: ScheduleEvent) {
  });
 
  for await (const subscription of queryScan) {
-  console.log(subscription)
+  console.log(`subscription is: ${subscription}`)
  }
+ console.log(queryScan.count)
+ return queryScan.count
 }

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -22,7 +22,7 @@ interface ScheduleEvent {
 
 export async function handler(event: ScheduleEvent) {
  const time = endTimestampForQuery(event).toISOString();
- console.log(`Will filter subscriptions before ${time}`);
+ console.log(`Filter date will be: ${endTimestampForQuery(event)}`);
 
  const filter: AndExpression = {
   type: 'And',

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -22,7 +22,7 @@ interface ScheduleEvent {
 
 export async function handler(event: ScheduleEvent) {
  const time = endTimestampForQuery(event).toISOString();
- console.log(`Filter date will be: ${endTimestampForQuery(event)}`);
+ console.log(`Will filter subscriptions before ${time}`);
 
  const filter: AndExpression = {
   type: 'And',

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -1,4 +1,9 @@
 import {plusHours} from "../utils/dates";
+import {dynamoMapper} from "../utils/aws";
+import {endTimeStampFilterSubscription} from "../models/endTimestampFilter";
+import {equals} from '@aws/dynamodb-expressions';
+import {ReadUserSubscription} from "../models/userSubscription";
+import {TableName} from "aws-sdk/clients/dynamodb";
 
 function endTimestampForQuery(event: ScheduleEvent): Date {
  const defaultDate = plusHours(new Date(), 3);
@@ -13,6 +18,18 @@ interface ScheduleEvent {
  endTimestampFilter?: string;
 }
 
-export function handler(event: ScheduleEvent) {
- console.log(`Filter date will be: ${endTimestampForQuery(event)}`)
+export async function handler(event: ScheduleEvent) {
+
+ const queryScan = dynamoMapper.scan({
+  valueConstructor: endTimeStampFilterSubscription,
+  indexName: 'ios-endTimestamp-revalidation-index',
+  filter: {
+   ...equals(true),
+   subject: 'autoRenewing'
+  }
+ });
+
+ for await (const subscription of queryScan) {
+  console.log(subscription)
+ }
 }


### PR DESCRIPTION
Select all the receipts in the ios-endTimestamp-revalidation-index index, filtered on 
- auto-renewing subscription (true)
- that contain a receipt
- where endTimestamp parameter is before endTimestampFilter

Related to:
https://github.com/guardian/mobile-purchases/pull/127
https://github.com/guardian/mobile-purchases/pull/130

This has been tested locally,
Reminder: the cloudformation template needs to be updated in the console for CODE and PROD

This was a joint PR with @jacobwinch 