### PR TITLE
Add receipts that need to be revalidated to SQS queue

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -978,6 +978,11 @@ Resources:
       Description: Finds recently expired subscriptions
       MemorySize: 512
       Timeout: 60
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 0 0/6 ? * * *)
       Tags:
         Stage: !Ref Stage
         Stack: !Ref Stack

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -887,6 +887,15 @@ Resources:
               Resource:
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-user-subscriptions/*
+        - PolicyName: sqs
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - "sqs:SendMessage"
+                - "sqs:SendMessageBatch"
+              Resource:
+                - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-apple-subscriptions-to-fetch
 
   AppleRevalidateSubscriptionRole:
     Type: AWS::IAM::Role
@@ -966,6 +975,7 @@ Resources:
           App: !Sub ${App}
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
+          SqsUrl: !Ref AppleSubscriptionsQueue
       Description: Finds recently expired subscriptions
       MemorySize: 512
       Timeout: 60

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -893,7 +893,6 @@ Resources:
               Effect: Allow
               Action:
                 - "sqs:SendMessage"
-                - "sqs:SendMessageBatch"
               Resource:
                 - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-apple-subscriptions-to-fetch
 

--- a/typescript/src/models/endTimestampFilter.ts
+++ b/typescript/src/models/endTimestampFilter.ts
@@ -1,7 +1,6 @@
 import {hashKey, attribute, rangeKey} from '@aws/dynamodb-data-mapper-annotations';
 import {DynamoDbTable} from "@aws/dynamodb-data-mapper";
 import {App, Stage} from "../utils/appIdentity";
-import {AppleSubscriptionReference} from "./subscriptionReference";
 
 export class Subscription {
 
@@ -12,12 +11,12 @@ export class Subscription {
     endTimestamp: string;
 
     @attribute()
-    receipt?: AppleSubscriptionReference;
+    receipt?: string;
 
     @attribute()
     autoRenewing: Boolean;
 
-    constructor(subscriptionId: string, endTimestamp: string, autoRenewStatus: Boolean, receipt?: AppleSubscriptionReference) {
+    constructor(subscriptionId: string, endTimestamp: string, autoRenewStatus: Boolean, receipt?: string) {
         this.subscriptionId = subscriptionId;
         this.endTimestamp = endTimestamp;
         this.receipt = receipt;
@@ -31,7 +30,7 @@ export class Subscription {
 
 }
 
-export class endTimeStampFilterSubscription extends Subscription {
+export class EndTimeStampFilterSubscription extends Subscription {
 
     constructor() {
         super("", "" , false);

--- a/typescript/src/models/endTimestampFilter.ts
+++ b/typescript/src/models/endTimestampFilter.ts
@@ -1,7 +1,7 @@
 import {hashKey, attribute, rangeKey} from '@aws/dynamodb-data-mapper-annotations';
 import {DynamoDbTable} from "@aws/dynamodb-data-mapper";
 import {App, Stage} from "../utils/appIdentity";
-import {AppleValidatedReceiptServerInfo} from "../services/appleValidateReceipts";
+import {AppleSubscriptionReference} from "./subscriptionReference";
 
 export class Subscription {
 
@@ -12,15 +12,15 @@ export class Subscription {
     endTimestamp: string;
 
     @attribute()
-    receipt?: AppleValidatedReceiptServerInfo | AppleValidatedReceiptServerInfo[];
+    receipt?: AppleSubscriptionReference;
 
     @attribute()
     autoRenewing: Boolean;
 
-    constructor(subscriptionId: string, endTimestamp: string, autoRenewStatus: Boolean, latestReceiptInfo?: AppleValidatedReceiptServerInfo | AppleValidatedReceiptServerInfo[]) {
+    constructor(subscriptionId: string, endTimestamp: string, autoRenewStatus: Boolean, receipt?: AppleSubscriptionReference) {
         this.subscriptionId = subscriptionId;
         this.endTimestamp = endTimestamp;
-        this.receipt = latestReceiptInfo;
+        this.receipt = receipt;
         this.autoRenewing = autoRenewStatus
 
     }
@@ -38,3 +38,4 @@ export class endTimeStampFilterSubscription extends Subscription {
     }
 
 }
+

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -1,5 +1,5 @@
 import {plusHours} from "../utils/dates";
-import {dynamoMapper} from "../utils/aws";
+import {dynamoMapper, sendToSqs} from "../utils/aws";
 import {endTimeStampFilterSubscription} from "../models/endTimestampFilter";
 import {
  AndExpression,
@@ -50,7 +50,10 @@ export async function handler(event: ScheduleEvent) {
  });
 
  for await (const subscription of queryScan) {
+  const queueUrl = process.env.SqsUrl
+  if (queueUrl === undefined) throw new Error("No QueueUrl env parameter provided");
+
+  await sendToSqs(queueUrl, queryScan)
   console.log(`Found subscription with id: ${subscription.subscriptionId} and expiry timestamp: ${subscription.endTimestamp}`)
  }
 }
-

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -9,7 +9,7 @@ import {
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 
 function endTimestampForQuery(event: ScheduleEvent): Date {
-    const defaultDate = plusHours(new Date(), 3);
+    const defaultDate = plusHours(new Date(), 13);
     if (event.endTimestampFilter) {
         return new Date(Date.parse(event.endTimestampFilter));
     } else {
@@ -47,8 +47,7 @@ export async function handler(event: ScheduleEvent) {
         EndTimeStampFilterSubscription,
         {
             indexName: 'ios-endTimestamp-revalidation-index',
-            filter: filter,
-            limit: 1
+            filter: filter
         });
 
     const SqsUrl = process.env.SqsUrl;

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -1,71 +1,67 @@
 import {plusHours} from "../utils/dates";
 import {dynamoMapper, sendToSqs} from "../utils/aws";
-import {endTimeStampFilterSubscription} from "../models/endTimestampFilter";
+import {EndTimeStampFilterSubscription} from "../models/endTimestampFilter";
 import {
- AndExpression,
- attributeExists,
- equals, lessThan,
+    AndExpression,
+    attributeExists,
+    equals, lessThan,
 } from '@aws/dynamodb-expressions';
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 
 function endTimestampForQuery(event: ScheduleEvent): Date {
- const defaultDate = plusHours(new Date(), 3);
- if(event.endTimestampFilter) {
-  return new Date(Date.parse(event.endTimestampFilter));
- } else {
-  return defaultDate;
- }
+    const defaultDate = plusHours(new Date(), 3);
+    if (event.endTimestampFilter) {
+        return new Date(Date.parse(event.endTimestampFilter));
+    } else {
+        return defaultDate;
+    }
 }
 
 interface ScheduleEvent {
- endTimestampFilter?: string;
+    endTimestampFilter?: string;
 }
 
 export async function handler(event: ScheduleEvent) {
- const time = endTimestampForQuery(event).toISOString();
- console.log(`Will filter subscriptions before ${time}`);
+    const time = endTimestampForQuery(event).toISOString();
+    console.log(`Will filter subscriptions before ${time}`);
 
- const filter: AndExpression = {
-  type: 'And',
-  conditions: [
-   {
-    ...equals(true),
-    subject: 'autoRenewing'
-   },
-   {
-    ...attributeExists(),
-    subject: 'receipt'
-   },
-   {
-    ...lessThan(time),
-    subject: 'endTimestamp'
-   }
-  ]
- };
+    const filter: AndExpression = {
+        type: 'And',
+        conditions: [
+            {
+                ...equals(true),
+                subject: 'autoRenewing'
+            },
+            {
+                ...attributeExists(),
+                subject: 'receipt'
+            },
+            {
+                ...lessThan(time),
+                subject: 'endTimestamp'
+            }
+        ]
+    };
 
- const queryScan = dynamoMapper.scan(
-  endTimeStampFilterSubscription,
-  {
-   indexName: 'ios-endTimestamp-revalidation-index',
-   filter: filter,
-   limit: 1
- });
+    const queryScan = dynamoMapper.scan(
+        EndTimeStampFilterSubscription,
+        {
+            indexName: 'ios-endTimestamp-revalidation-index',
+            filter: filter,
+            limit: 1
+        });
 
- for await (const subscription of queryScan) {
-  const SqsUrl = process.env.SqsUrl;
-  if (SqsUrl === undefined) throw new Error("No SqsUrl env parameter provided");
+    const SqsUrl = process.env.SqsUrl;
+    if (SqsUrl === undefined) throw new Error("No SqsUrl env parameter provided");
 
-  function AppleSubscription() {
-   const Subscription: AppleSubscriptionReference | undefined = subscription.receipt
-   if(Subscription) {
-    return {receipt: Subscription};
-   } else {
-    console.log("No receipt found")
-   }
-  }
-
-  await sendToSqs(SqsUrl, AppleSubscription());
-
-  console.log(`Found subscription with id: ${subscription.subscriptionId} and expiry timestamp: ${subscription.endTimestamp}`)
- }
+    for await (const subscription of queryScan) {
+        const receipt: string | undefined = subscription.receipt;
+        if (receipt) {
+            const subscriptionReference: AppleSubscriptionReference = {receipt: receipt}
+            await sendToSqs(SqsUrl, subscriptionReference);
+        } else {
+            console.warn(`No receipt found for ${subscription.subscriptionId}`);
+        }
+        console.log(`Found subscription with id: ${subscription.subscriptionId} and expiry timestamp: ${subscription.endTimestamp}`)
+    }
 }


### PR DESCRIPTION
Add all the receipts that have been filtered and need to be revalidated to the `apple-subscriptions-fetch queue`

@alexduf I wasn't sure which action is more appropriate?
`              - "sqs:SendMessage"`
               `- "sqs:SendMessageBatch"`

This has been tested on CODE, messages were received on the queue and no messages were in the DLQ