### PR TITLE
Enhance timeout handling

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -383,7 +383,7 @@ Resources:
           QueueUrl: !Ref GoogleSubscriptionsQueue
       Description: Records play store events
       MemorySize: 128
-      Timeout: 45
+      Timeout: 29
       Events:
         PostApi:
           Type: Api
@@ -415,7 +415,7 @@ Resources:
           QueueUrl: !Ref AppleSubscriptionsQueue
       Description: Records play store events
       MemorySize: 128
-      Timeout: 45
+      Timeout: 29
       Events:
         PostApi:
           Type: Api
@@ -446,7 +446,7 @@ Resources:
           QueueUrl: !Ref GoogleSubscriptionsQueue
       Description: Links users to subscriptions
       MemorySize: 128
-      Timeout: 45
+      Timeout: 29
       Events:
         PostApi:
           Type: Api
@@ -477,7 +477,7 @@ Resources:
           QueueUrl: !Ref AppleSubscriptionsQueue
       Description: Links users to subscriptions
       MemorySize: 128
-      Timeout: 45
+      Timeout: 29
       Events:
         PostApi:
           Type: Api
@@ -507,7 +507,7 @@ Resources:
           App: !Ref App
       Description: Checks the status of a Play Store subscription using the Google Play Developer API
       MemorySize: 128
-      Timeout: 45
+      Timeout: 29
       Events:
         PostApi:
           Type: Api
@@ -537,7 +537,7 @@ Resources:
           App: !Ref App
       Description: Checks the status of an Apple App store subscription using the apple API
       MemorySize: 128
-      Timeout: 45
+      Timeout: 29
       Events:
         PostApi:
           Type: Api
@@ -567,7 +567,7 @@ Resources:
           App: !Ref App
       Description: Validates purchases
       MemorySize: 448
-      Timeout: 45
+      Timeout: 29
       Events:
         PostApi:
           Type: Api
@@ -597,7 +597,7 @@ Resources:
           App: !Ref App
       Description: Gets user purchases
       MemorySize: 448
-      Timeout: 45
+      Timeout: 29
       Events:
         GetApi:
           Type: Api
@@ -760,7 +760,7 @@ Resources:
           App: !Ref App
       Description: Retrieves subscription details for a given user
       MemorySize: 128
-      Timeout: 45
+      Timeout: 29
       Events:
         DirectAccess:
           Type: Api

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -75,7 +75,12 @@ function callValidateReceipt(receipt: string, forceSandbox: boolean = false): Pr
                 "password": password,
                 "exclude-old-transactions": true
             });
-            return fetch(endpoint, { method: 'POST', body: body});
+            return Promise.race([
+                fetch(endpoint, { method: 'POST', body: body}),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error("Timeout while validating receipt with Apple")), 12000)
+                ) as Promise<Response>
+            ]);
         }).then(response => {
             if (!response.ok) {
                 console.error(`Impossible to validate the receipt, got ${response.status} ${response.statusText} from ${endpoint} for ${receipt}`);


### PR DESCRIPTION
- Lambdas called by the API had a timeout of 45s, when the API Gateway has a default timeout of 30s. So I've set all the lambdas called by the API Gateway to timeout at 29s. This will allow us to know when a lambda timeouts a bit better has there was the possibility of seeing everything going well in the logs, yet the api gateway returning HTTP 504 (Timeout).

- Set a timeout on the request that goes to Apple to validate receipts such that we know if Apple is struggling to validate our receipts.