### PR TITLE
Increase lambda memory and timeout

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -976,8 +976,8 @@ Resources:
           Stage: !Sub ${Stage}
           SqsUrl: !Ref AppleSubscriptionsQueue
       Description: Finds recently expired subscriptions
-      MemorySize: 512
-      Timeout: 60
+      MemorySize: 2048
+      Timeout: 180
       Events:
         Schedule:
           Type: Schedule


### PR DESCRIPTION
Increase the `AppleRevalidateReceiptsLambda` memory from `512mb` to `2048mb`, and the timeout from `60seconds` to `180seconds`