### PR TITLE
Add platform field to the subscription table

### DIFF
--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -24,6 +24,9 @@ export class Subscription {
     productId: string;
 
     @attribute()
+    platform?: string;
+
+    @attribute()
     googlePayload?: any;
 
     @attribute()
@@ -42,6 +45,7 @@ export class Subscription {
         cancellationTimestamp: string | undefined,
         autoRenewing: boolean,
         productId: string,
+        platform: string | undefined,
         googlePayload?: any,
         receipt?: string,
         applePayload?: any,
@@ -53,6 +57,7 @@ export class Subscription {
         this.cancellationTimestamp = cancellationTimestamp;
         this.autoRenewing = autoRenewing;
         this.productId = productId;
+        this.platform = platform;
         this.googlePayload = googlePayload;
         this.receipt = receipt;
         this.applePayload = applePayload;
@@ -67,7 +72,7 @@ export class Subscription {
 export class ReadSubscription extends Subscription {
 
     constructor() {
-        super("", "", "", undefined, false, "")
+        super("", "", "", undefined, false, "", undefined)
     }
 
     setSubscriptionId(subscriptionId: string): ReadSubscription {

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -5,6 +5,7 @@ import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {GoogleSubscriptionReference} from "../models/subscriptionReference";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Option} from "../utils/option";
+import {fromGooglePackageName} from "../services/appToPlatform";
 
 interface DeveloperNotification {
     version: string,
@@ -51,13 +52,17 @@ export function toDynamoEvent(notification: DeveloperNotification): Subscription
     const date = eventTimestamp.substr(0, 10);
     const eventType = notification.subscriptionNotification.notificationType;
     const eventTypeString = GOOGLE_SUBS_EVENT_TYPE[eventType] ?? eventType.toString();
+    const platform = fromGooglePackageName(notification.packageName)?.toString();
+    if (!platform) {
+        console.warn(`Unknown package name ${notification.packageName}`)
+    }
     return new SubscriptionEvent(
         notification.subscriptionNotification.purchaseToken,
         eventTimestamp + "|" + eventTypeString,
         date,
         eventTimestamp,
         eventTypeString,
-        "android",
+        platform ?? "unknown",
         notification.packageName,
         notification,
         null,

--- a/typescript/src/services/appToPlatform.ts
+++ b/typescript/src/services/appToPlatform.ts
@@ -1,0 +1,22 @@
+import {Platform} from "../models/platform";
+
+const bundleToPlatform: {[bundle: string]: Platform} = {
+    "uk.co.guardian.iphone2": Platform.Ios,
+    "uk.co.guardian.gce": Platform.IosEdition,
+    "uk.co.guardian.puzzles": Platform.IosPuzzles
+};
+
+export function fromAppleBundle(bundle?: string): Platform | undefined {
+    return (bundle) ? bundleToPlatform[bundle] : undefined;
+}
+
+const packageToPlatform: {[packageName: string]: Platform} = {
+    "com.guardian": Platform.Android,
+    "com.guardian.debug": Platform.Android,
+    "com.guardian.editions": Platform.AndroidEdition,
+    "uk.co.guardian.puzzles": Platform.AndroidPuzzles
+};
+
+export function fromGooglePackageName(packageName: string): Platform | undefined {
+    return packageToPlatform[packageName];
+}

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -17,6 +17,7 @@ export interface PendingRenewalInfo {
 }
 
 export interface AppleValidatedReceiptServerInfo {
+    bundle_id?: string,
     cancellation_date_ms?: string,
     expires_date?: string,
     expires_date_ms?: string,
@@ -40,10 +41,12 @@ export interface AppleValidationServerResponse {
     latest_receipt_info?: AppleValidatedReceiptServerInfo | AppleValidatedReceiptServerInfo[],
     latest_expired_receipt_info?: AppleValidatedReceiptServerInfo,
     pending_renewal_info?: PendingRenewalInfo[],
+    receipt?: AppleValidatedReceiptServerInfo,
     status: number
 }
 
 export interface AppleValidatedReceiptInfo {
+    bundleId?: string,
     autoRenewStatus: boolean,
     trialPeriod: boolean,
     cancellationDate: Option<Date>,
@@ -177,6 +180,7 @@ export function toSensiblePayloadFormat(response: AppleValidationServerResponse,
             isRetryable: response["is-retryable"] === true,
             latestReceipt: response.latest_receipt ?? receipt,
             latestReceiptInfo: {
+                bundleId: receiptInfo.bundle_id ?? response.receipt?.bundle_id,
                 autoRenewStatus: autoRenewStatus,
                 cancellationDate: optionalMsToDate(receiptInfo.cancellation_date_ms),
                 expiresDate: new Date(expiryDate(receiptInfo)),

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -5,6 +5,13 @@ import {Subscription} from "../models/subscription";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";
+import {Platform} from "../models/platform";
+
+const bundleToPlatform: {[bundle: string]: string} = {
+    "uk.co.guardian.iphone2": Platform.Ios.toString(),
+    "uk.co.guardian.gce": Platform.IosEdition.toString(),
+    "uk.co.guardian.puzzles": Platform.IosPuzzles.toString()
+};
 
 function toAppleSubscription(response: AppleValidationResponse): Subscription {
     const latestReceiptInfo = response.latestReceiptInfo;
@@ -19,6 +26,8 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         cancellationDate = latestReceiptInfo.cancellationDate.toISOString()
     }
 
+    const platform = (response.latestReceiptInfo.bundleId) ? bundleToPlatform[response.latestReceiptInfo.bundleId] : undefined;
+
     return new Subscription(
         latestReceiptInfo.originalTransactionId,
         latestReceiptInfo.originalPurchaseDate.toISOString(),
@@ -26,6 +35,7 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         cancellationDate,
         autoRenewStatus,
         latestReceiptInfo.productId,
+        platform,
         null,
         response.latestReceipt,
         response.originalResponse,

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -5,13 +5,7 @@ import {Subscription} from "../models/subscription";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";
-import {Platform} from "../models/platform";
-
-const bundleToPlatform: {[bundle: string]: string} = {
-    "uk.co.guardian.iphone2": Platform.Ios.toString(),
-    "uk.co.guardian.gce": Platform.IosEdition.toString(),
-    "uk.co.guardian.puzzles": Platform.IosPuzzles.toString()
-};
+import {fromAppleBundle} from "../services/appToPlatform";
 
 function toAppleSubscription(response: AppleValidationResponse): Subscription {
     const latestReceiptInfo = response.latestReceiptInfo;
@@ -26,8 +20,6 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         cancellationDate = latestReceiptInfo.cancellationDate.toISOString()
     }
 
-    const platform = (response.latestReceiptInfo.bundleId) ? bundleToPlatform[response.latestReceiptInfo.bundleId] : undefined;
-
     return new Subscription(
         latestReceiptInfo.originalTransactionId,
         latestReceiptInfo.originalPurchaseDate.toISOString(),
@@ -35,7 +27,7 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         cancellationDate,
         autoRenewStatus,
         latestReceiptInfo.productId,
-        platform,
+        fromAppleBundle(response.latestReceiptInfo.bundleId)?.toString(),
         null,
         response.latestReceipt,
         response.originalResponse,

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -10,6 +10,7 @@ import {ProcessingError} from "../models/processingError";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {GoogleSubscriptionReference} from "../models/subscriptionReference";
 import {Platform} from "../models/platform";
+import {fromGooglePackageName} from "../services/appToPlatform";
 
 interface GoogleResponseBody {
     startTimeMillis: string,
@@ -18,12 +19,7 @@ interface GoogleResponseBody {
     autoRenewing: boolean
 }
 
-const packageToPlatform: {[packageName: string]: string} = {
-    "com.guardian": Platform.Android.toString(),
-    "com.guardian.debug": Platform.Android.toString(),
-    "com.guardian.editions": Platform.AndroidEdition.toString(),
-    "uk.co.guardian.puzzles": Platform.AndroidPuzzles.toString()
-};
+
 
 const restClient = new restm.RestClient('guardian-mobile-purchases');
 
@@ -38,7 +34,6 @@ async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> 
 
         if(response.result) {
             const expiryDate = new Date(Number.parseInt(response.result.expiryTimeMillis));
-            const platform = packageToPlatform[sub.packageName];
             return [new Subscription(
                 sub.purchaseToken,
                 new Date(Number.parseInt(response.result.startTimeMillis)).toISOString(),
@@ -46,7 +41,7 @@ async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> 
                 makeCancellationTime(response.result.userCancellationTimeMillis),
                 response.result.autoRenewing,
                 sub.subscriptionId,
-                platform,
+                fromGooglePackageName(sub.packageName)?.toString(),
                 response.result,
                 undefined,
                 null,

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -28,7 +28,7 @@ describe("The google pubsub", () => {
 
         const body = {
             message: {
-                data:'ewogICJ2ZXJzaW9uIjoiMS4wIiwKICAicGFja2FnZU5hbWUiOiJjb20uc29tZS50aGluZyIsCiAgImV2ZW50VGltZU1pbGxpcyI6IjE1MDMzNDk1NjYxNjgiLAogICJzdWJzY3JpcHRpb25Ob3RpZmljYXRpb24iOgogIHsKICAgICJ2ZXJzaW9uIjoiMS4wIiwKICAgICJub3RpZmljYXRpb25UeXBlIjo0LAogICAgInB1cmNoYXNlVG9rZW4iOiJQVVJDSEFTRV9UT0tFTiIsCiAgICAic3Vic2NyaXB0aW9uSWQiOiJteS5za3UiCiAgfQp9Cg==',
+                data:'ewogICJ2ZXJzaW9uIjoiMS4wIiwKICAicGFja2FnZU5hbWUiOiJjb20uZ3VhcmRpYW4uZGVidWciLAogICJldmVudFRpbWVNaWxsaXMiOiIxNTAzMzQ5NTY2MTY4IiwKICAic3Vic2NyaXB0aW9uTm90aWZpY2F0aW9uIjoKICB7CiAgICAidmVyc2lvbiI6IjEuMCIsCiAgICAibm90aWZpY2F0aW9uVHlwZSI6NCwKICAgICJwdXJjaGFzZVRva2VuIjoiUFVSQ0hBU0VfVE9LRU4iLAogICAgInN1YnNjcmlwdGlvbklkIjoibXkuc2t1IgogIH0KfQo=',
                 messageId: '123',
                 message_id: '123',
                 publishTime: '2019-05-24T15:06:47.701Z',
@@ -60,10 +60,10 @@ describe("The google pubsub", () => {
             "2017-08-21T21:06:06.168Z",
             "SUBSCRIPTION_PURCHASED",
             "android",
-            "com.some.thing",
+            "com.guardian.debug",
             {
                 eventTimeMillis: "1503349566168",
-                packageName: "com.some.thing",
+                packageName: "com.guardian.debug",
                 subscriptionNotification: {
                     notificationType: 4,
                     purchaseToken: "PURCHASE_TOKEN",
@@ -81,7 +81,7 @@ describe("The google pubsub", () => {
             expect(mockStoreFunction.mock.calls.length).toEqual(1);
             expect(mockStoreFunction.mock.calls[0][0]).toStrictEqual(expectedSubscriptionEventInDynamo);
             expect(mockSqsFunction.mock.calls.length).toEqual(1);
-            expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual({packageName: "com.some.thing", purchaseToken: "PURCHASE_TOKEN", subscriptionId: "my.sku"});
+            expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual({packageName: "com.guardian.debug", purchaseToken: "PURCHASE_TOKEN", subscriptionId: "my.sku"});
         });
     });
 });

--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -9,6 +9,7 @@ describe("The apple validation service", () => {
         const appleResponse: AppleValidationServerResponse = {
             auto_renew_status: 0,
             latest_expired_receipt_info: {
+                bundle_id: "uk.co.guardian.iphone2",
                 is_trial_period: "false",
                 original_transaction_id: "1234",
                 product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -22,6 +23,7 @@ describe("The apple validation service", () => {
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
             latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
                 cancellationDate: null,
@@ -41,6 +43,7 @@ describe("The apple validation service", () => {
         const appleResponse: AppleValidationServerResponse = {
             auto_renew_status: 0,
             latest_receipt_info: {
+                bundle_id: "uk.co.guardian.iphone2",
                 is_trial_period: "false",
                 original_transaction_id: "1234",
                 product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -55,6 +58,7 @@ describe("The apple validation service", () => {
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
             latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
                 cancellationDate: null,
@@ -73,6 +77,7 @@ describe("The apple validation service", () => {
         const appleResponse: AppleValidationServerResponse = {
             auto_renew_status: 0,
             latest_receipt_info: [{
+                bundle_id: "uk.co.guardian.iphone2",
                 is_trial_period: "false",
                 original_transaction_id: "1234",
                 product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -87,6 +92,7 @@ describe("The apple validation service", () => {
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
             latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
                 cancellationDate: null,
@@ -106,6 +112,7 @@ describe("The apple validation service", () => {
             auto_renew_status: 0,
             latest_receipt_info: [
                 {
+                    bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
                     original_transaction_id: "1234",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -114,6 +121,7 @@ describe("The apple validation service", () => {
                     original_purchase_date_ms: "1567081703000"
                 },
                 {
+                    bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -122,6 +130,7 @@ describe("The apple validation service", () => {
                     original_purchase_date_ms: "1567081703000"
                 },
                 {
+                    bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -137,6 +146,7 @@ describe("The apple validation service", () => {
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
             latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
                 cancellationDate: null,
@@ -150,6 +160,7 @@ describe("The apple validation service", () => {
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
             latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
                 cancellationDate: null,
@@ -170,12 +181,14 @@ describe("The apple validation service", () => {
             auto_renew_status: 0,
             latest_receipt_info: [
                 {
+                    bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
                     original_transaction_id: "1234",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     original_purchase_date_ms: "1567081703000"
                 },
                 {
+                    bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -191,6 +204,7 @@ describe("The apple validation service", () => {
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
             latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
                 cancellationDate: null,
@@ -210,6 +224,7 @@ describe("The apple validation service", () => {
             auto_renew_status: 1,
             latest_receipt_info: [
                 {
+                    bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -218,6 +233,7 @@ describe("The apple validation service", () => {
                     original_purchase_date_ms: "1567081703000"
                 },
                 {
+                    bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
                     original_transaction_id: "1236",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
@@ -251,6 +267,7 @@ describe("The apple validation service", () => {
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
             latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
                 cancellationDate: null,
@@ -264,6 +281,7 @@ describe("The apple validation service", () => {
             isRetryable: false,
             latestReceipt: "cmVjZWlwdA==",
             latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: true,
                 trialPeriod: false,
                 cancellationDate: null,


### PR DESCRIPTION
This PR adds a much needed field to the subscription table: `platform`

This will help us recognise the relation between a subscription and which app the subscription is valid for. This is technically inferable already using the `productId` but I think it makes sense to pre calculate that field as the product list is deemed to change in the future.

- Created a shared file to determine what the platform is
- Use that logic in both the lambda that stores the subscription and the lambda that stores the subscription events