### PR TITLE
Fix where the bundle ID is read from.

### DIFF
--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -181,6 +181,9 @@ export function toSensiblePayloadFormat(response: AppleValidationServerResponse,
         // which is valued but undocumented. Oh and also sometimes it's on the latest_receipt object, but sometimes
         // it's on the receipt object. Hopefully this covers all the corner cases? who knows!
         const bundleId = receiptInfo.bundle_id ?? receiptInfo.bid ?? response.receipt?.bundle_id ?? response.receipt?.bid;
+        if (!bundleId) {
+            console.warn(`Unable to identify the bundle id for the original transaction id ${receiptInfo.original_transaction_id}`)
+        }
 
         return {
             isRetryable: response["is-retryable"] === true,


### PR DESCRIPTION
So...

`bundle_id` which is [documented](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1) as the first field here, isn't always returned by Apple's service. Note how it's not mentioned that the field is optional.

There's also this [documentation](https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt), which is more recent, does mention the `bundle_id`, but doesn't mention that it's optional.

What I'm seeing in prod (but not in sandbox that would be too easy) is this field isn't present, but there's another field! called `bid` which behaves the same way. `bid` is undocumented.

Apple says:

> Keys not documented below are reserved for use by Apple and must be ignored by your app.

Yes, I'd very much like that too, but you leave me no choice Apple...