### PR TITLE
Use the rest client everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     "@aws/dynamodb-expressions": "^0.7.3",
     "@types/aws-lambda": "8.10.27",
     "@types/node": "^12.0.2",
-    "@types/node-fetch": "^2.5.0",
     "aws-sdk": "^2.553.0",
-    "node-fetch": "^2.6.0",
     "source-map-support": "^0.5.12",
     "typed-rest-client": "^1.4.0"
   }

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -1,11 +1,11 @@
 import 'source-map-support/register'
-import * as restm from 'typed-rest-client/RestClient';
 import {
     HTTPResponses,
     HttpRequestHeaders
 } from '../models/apiGatewayHttp';
 import {getParams, getAccessToken, buildGoogleUrl} from "../utils/google-play";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import {restClient} from "../utils/restClient";
 
 interface GoogleResponseBody {
     expiryTimeMillis: string
@@ -40,7 +40,6 @@ export async function handler(request: APIGatewayProxyEvent): Promise<APIGateway
 
     const purchaseToken = getPurchaseToken(request.headers);
     if (request.pathParameters && request.headers && purchaseToken) {
-        const restClient = new restm.RestClient('guardian-mobile-purchases');
         const packageName = googlePackageName(request.headers);
         const subscriptionId = request.pathParameters.subscriptionId;
         console.log(`Searching for valid ${subscriptionId} subscription for Android app with package name: ${packageName}`);

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -1,6 +1,5 @@
 import 'source-map-support/register'
 import {SQSEvent, SQSRecord} from 'aws-lambda';
-import * as restm from 'typed-rest-client/RestClient';
 import {buildGoogleUrl, getAccessToken, getParams} from "../utils/google-play";
 
 import {makeCancellationTime, parseAndStoreSubscriptionUpdate} from './updatesub';
@@ -9,8 +8,8 @@ import {Subscription} from "../models/subscription";
 import {ProcessingError} from "../models/processingError";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {GoogleSubscriptionReference} from "../models/subscriptionReference";
-import {Platform} from "../models/platform";
 import {fromGooglePackageName} from "../services/appToPlatform";
+import {restClient} from "../utils/restClient";
 
 interface GoogleResponseBody {
     startTimeMillis: string,
@@ -18,10 +17,6 @@ interface GoogleResponseBody {
     userCancellationTimeMillis: string,
     autoRenewing: boolean
 }
-
-
-
-const restClient = new restm.RestClient('guardian-mobile-purchases');
 
 async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> {
 

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -1,8 +1,6 @@
 import {HttpRequestHeaders} from "../models/apiGatewayHttp";
-import * as restm from "typed-rest-client/RestClient";
 import {Option} from "./option";
-
-const restClient = new restm.RestClient('guardian-mobile-purchases');
+import {restClient} from "./restClient";
 
 interface UserId {
     id: string

--- a/typescript/src/utils/restClient.ts
+++ b/typescript/src/utils/restClient.ts
@@ -1,0 +1,3 @@
+import * as restm from "typed-rest-client/RestClient";
+
+export const restClient = new restm.RestClient('guardian-mobile-purchases', undefined,undefined, {socketTimeout: 10000});

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,18 +420,6 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/node-fetch@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.0.tgz#1c55616a4591bdd15a389fbd0da4a55b9502add5"
-  integrity sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==
-  dependencies:
-    "@types/node" "*"
-
-"@types/node@*":
-  version "12.6.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.9.tgz#ffeee23afdc19ab16e979338e7b536fdebbbaeaf"
-  integrity sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==
-
 "@types/node@^12.0.2":
   version "12.0.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
@@ -3381,11 +3369,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
`node-fetch` was only used in one spot, so we can drop one library and use the same HTTP client everywhere.

I also create one instance of the client in memory so that some lambda don't continuously re-create the HTTP client.