### PR TITLE
Add trial period flag (part2)

### DIFF
--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -27,6 +27,9 @@ export class Subscription {
     platform?: string;
 
     @attribute()
+    freeTrial?: boolean;
+
+    @attribute()
     googlePayload?: any;
 
     @attribute()
@@ -46,6 +49,7 @@ export class Subscription {
         autoRenewing: boolean,
         productId: string,
         platform: string | undefined,
+        freeTrial: boolean | undefined,
         googlePayload?: any,
         receipt?: string,
         applePayload?: any,
@@ -58,6 +62,7 @@ export class Subscription {
         this.autoRenewing = autoRenewing;
         this.productId = productId;
         this.platform = platform;
+        this.freeTrial = freeTrial;
         this.googlePayload = googlePayload;
         this.receipt = receipt;
         this.applePayload = applePayload;
@@ -72,7 +77,7 @@ export class Subscription {
 export class ReadSubscription extends Subscription {
 
     constructor() {
-        super("", "", "", undefined, false, "", undefined)
+        super("", "", "", undefined, false, "", undefined, undefined)
     }
 
     setSubscriptionId(subscriptionId: string): ReadSubscription {

--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -18,13 +18,27 @@ export class SubscriptionEvent {
     @attribute()
     appId: string;
     @attribute()
+    freeTrial?: boolean;
+    @attribute()
     googlePayload?: any;
     @attribute()
     applePayload?: any;
     @attribute()
     ttl: number;
 
-    constructor(subscriptionId: string, timestampAndType: string, date: string, timestamp: string, eventType: string, platform: string, appId: string, googlePayload: any, applePayload: any, ttl: number) {
+    constructor(
+        subscriptionId: string,
+        timestampAndType: string,
+        date: string,
+        timestamp: string,
+        eventType: string,
+        platform: string,
+        appId: string,
+        freeTrial: boolean | undefined,
+        googlePayload: any,
+        applePayload: any,
+        ttl: number
+    ) {
         this.subscriptionId = subscriptionId;
         this.timestampAndType = timestampAndType;
         this.date = date;
@@ -32,6 +46,7 @@ export class SubscriptionEvent {
         this.eventType = eventType;
         this.platform = platform;
         this.appId = appId;
+        this.freeTrial = freeTrial;
         this.googlePayload = googlePayload;
         this.applePayload = applePayload;
         this.ttl = ttl;
@@ -44,6 +59,6 @@ export class SubscriptionEvent {
 
 export class ReadSubscriptionEvent extends SubscriptionEvent {
     constructor() {
-        super("", "", "", "", "", "", "", {}, {}, 0);
+        super("", "", "", "", "", "", "", undefined,{}, {}, 0);
     }
 }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -98,6 +98,7 @@ export async function handler(request: APIGatewayProxyEvent): Promise<APIGateway
         request,
         parsePayload,
         toDynamoEvent,
-        toSqsSubReference
+        toSqsSubReference,
+        () => Promise.resolve(undefined)
     )
 }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -69,6 +69,8 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         console.warn(`Unknown bundle id ${receiptInfo.bid}`)
     }
 
+    const freeTrial = receiptInfo.is_trial_period === "true";
+
     return new SubscriptionEvent(
         receiptInfo.transaction_id,
         now.toISOString() + "|" + eventType,
@@ -77,6 +79,7 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         eventType,
         platform ?? "unknown",
         receiptInfo.bid,
+        freeTrial,
         null,
         notification,
         dateToSecondTimestamp(thirtyMonths(now))

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -1,11 +1,12 @@
 import 'source-map-support/register'
-import {ONE_YEAR_IN_SECONDS, parseStoreAndSend} from "./pubsub";
+import {parseStoreAndSend} from "./pubsub";
 import {SubscriptionEvent} from "../models/subscriptionEvent";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {GoogleSubscriptionReference} from "../models/subscriptionReference";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Option} from "../utils/option";
 import {fromGooglePackageName} from "../services/appToPlatform";
+import {fetchGoogleSubscription, GoogleResponseBody} from "../services/google-play";
 
 interface DeveloperNotification {
     version: string,
@@ -21,6 +22,9 @@ interface SubscriptionNotification {
     subscriptionId: string
 }
 
+interface MetaData {
+    freeTrial: boolean
+}
 
 export function parsePayload(body: Option<string>): Error | DeveloperNotification {
     try {
@@ -46,7 +50,26 @@ const GOOGLE_SUBS_EVENT_TYPE: {[_: number]: string} = {
     13: "SUBSCRIPTION_EXPIRED"
 };
 
-export function toDynamoEvent(notification: DeveloperNotification): SubscriptionEvent {
+async function fetchMetadata(notification: DeveloperNotification): Promise<MetaData | undefined> {
+    try {
+        const subscription = await fetchGoogleSubscription(
+            notification.subscriptionNotification.subscriptionId,
+            notification.subscriptionNotification.purchaseToken,
+            notification.packageName
+        );
+        return {
+            freeTrial : subscription?.paymentState === 2 // 2 is freeTrial
+        }
+    } catch (exception) {
+        // here we really don't want to stop the processing of that event if we can't fetch metadata,
+        // as storing the event in the dynamo DB, and posting to the SQS queue are higher priority.
+        // So even if something goes horribly wrong, we'll cary on the processing
+        console.error(`Unable to fetch the subscription associated with the event`, exception);
+        return undefined;
+    }
+}
+
+export function toDynamoEvent(notification: DeveloperNotification, metaData?: MetaData): SubscriptionEvent {
     const eventDate = new Date(Number.parseInt(notification.eventTimeMillis));
     const eventTimestamp = eventDate.toISOString();
     const date = eventTimestamp.substr(0, 10);
@@ -56,6 +79,7 @@ export function toDynamoEvent(notification: DeveloperNotification): Subscription
     if (!platform) {
         console.warn(`Unknown package name ${notification.packageName}`)
     }
+
     return new SubscriptionEvent(
         notification.subscriptionNotification.purchaseToken,
         eventTimestamp + "|" + eventTypeString,
@@ -64,7 +88,7 @@ export function toDynamoEvent(notification: DeveloperNotification): Subscription
         eventTypeString,
         platform ?? "unknown",
         notification.packageName,
-        undefined,
+        metaData?.freeTrial,
         notification,
         null,
         dateToSecondTimestamp(thirtyMonths(eventDate))
@@ -84,6 +108,7 @@ export async function handler(request: APIGatewayProxyEvent): Promise<APIGateway
         request,
         parsePayload,
         toDynamoEvent,
-        toSqsSubReference
+        toSqsSubReference,
+        fetchMetadata
     )
 }

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -64,6 +64,7 @@ export function toDynamoEvent(notification: DeveloperNotification): Subscription
         eventTypeString,
         platform ?? "unknown",
         notification.packageName,
+        undefined,
         notification,
         null,
         dateToSecondTimestamp(thirtyMonths(eventDate))

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -6,7 +6,7 @@ import {GoogleSubscriptionReference} from "../models/subscriptionReference";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Option} from "../utils/option";
 import {fromGooglePackageName} from "../services/appToPlatform";
-import {fetchGoogleSubscription, GoogleResponseBody} from "../services/google-play";
+import {fetchGoogleSubscription, GOOGLE_PAYMENT_STATE} from "../services/google-play";
 
 interface DeveloperNotification {
     version: string,
@@ -58,7 +58,7 @@ async function fetchMetadata(notification: DeveloperNotification): Promise<MetaD
             notification.packageName
         );
         return {
-            freeTrial : subscription?.paymentState === 2 // 2 is freeTrial
+            freeTrial : subscription?.paymentState === GOOGLE_PAYMENT_STATE.FREE_TRIAL
         }
     } catch (exception) {
         // here we really don't want to stop the processing of that event if we can't fetch metadata,

--- a/typescript/src/services/google-play.ts
+++ b/typescript/src/services/google-play.ts
@@ -3,6 +3,13 @@ import S3 from 'aws-sdk/clients/s3'
 import {Stage} from "../utils/appIdentity";
 import {restClient} from "../utils/restClient";
 
+export const GOOGLE_PAYMENT_STATE = {
+    PAYMENT_PENDING: 0,
+    PAYMENT_RECEIVED: 1,
+    FREE_TRIAL: 2,
+    PENDING: 3
+};
+
 export interface AccessToken {
     token: string,
     date: Date

--- a/typescript/src/services/google-play.ts
+++ b/typescript/src/services/google-play.ts
@@ -39,7 +39,8 @@ export interface GoogleResponseBody {
     startTimeMillis: string,
     expiryTimeMillis: string,
     userCancellationTimeMillis: string,
-    autoRenewing: boolean
+    autoRenewing: boolean,
+    paymentState: 0 | 1 | 2 | 3
 }
 
 export async function fetchGoogleSubscription(subscriptionId: string, purchaseToken: string, packageName: string): Promise<GoogleResponseBody | null> {

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -28,6 +28,7 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         autoRenewStatus,
         latestReceiptInfo.productId,
         fromAppleBundle(response.latestReceiptInfo.bundleId)?.toString(),
+        latestReceiptInfo.trialPeriod,
         null,
         response.latestReceipt,
         response.originalResponse,

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -29,6 +29,7 @@ async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> 
     }
 
     const expiryDate = new Date(Number.parseInt(response.expiryTimeMillis));
+    const freeTrial = response.paymentState === 2; // PaymentState 2 is free trial
     return [new Subscription(
         sub.purchaseToken,
         new Date(Number.parseInt(response.startTimeMillis)).toISOString(),
@@ -37,6 +38,7 @@ async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> 
         response.autoRenewing,
         sub.subscriptionId,
         fromGooglePackageName(sub.packageName)?.toString(),
+        freeTrial,
         response,
         undefined,
         null,

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -6,7 +6,7 @@ import {ProcessingError} from "../models/processingError";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {GoogleSubscriptionReference} from "../models/subscriptionReference";
 import {fromGooglePackageName} from "../services/appToPlatform";
-import {fetchGoogleSubscription} from "../services/google-play";
+import {fetchGoogleSubscription, GOOGLE_PAYMENT_STATE} from "../services/google-play";
 
 async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> {
 
@@ -29,7 +29,7 @@ async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> 
     }
 
     const expiryDate = new Date(Number.parseInt(response.expiryTimeMillis));
-    const freeTrial = response.paymentState === 2; // PaymentState 2 is free trial
+    const freeTrial = response.paymentState === GOOGLE_PAYMENT_STATE.FREE_TRIAL;
     return [new Subscription(
         sub.purchaseToken,
         new Date(Number.parseInt(response.startTimeMillis)).toISOString(),

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -55,7 +55,7 @@ export async function parseAndStoreSubscriptionUpdate(
         const subscriptions = await fetchSubscriberDetails(sqsRecord);
         await Promise.all(subscriptions.map(putSubscription));
         await Promise.all(subscriptions.map(queueHistoricalSubscription));
-        console.log(`Processed ${subscriptions.length} subscriptions`);
+        console.log(`Processed ${subscriptions.length} subscriptions: ${subscriptions.map(s => s.subscriptionId)}`);
         return "OK"
     } catch (error) {
         if (error instanceof ProcessingError) {

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -14,21 +14,30 @@ describe("The google pubsub", () => {
         process.env['Secret'] = "MYSECRET";
         process.env['QueueUrl'] = "";
 
-        const mockStoreFunction: Mock<Promise<SubscriptionEvent>, [SubscriptionEvent]>  = jest.fn((event) => {
-            return new Promise((resolve, reject) => {
-                resolve(event);
-            });
-        });
+        const mockStoreFunction: Mock<Promise<SubscriptionEvent>, [SubscriptionEvent]> = jest.fn(event => Promise.resolve(event));
 
-        const mockSqsFunction: Mock<Promise<any>, [string, {purchaseToken: string}]>  = jest.fn((queurl, event) => {
-            return new Promise((resolve, reject) => {
-                resolve({});
-            });
-        });
+        const mockSqsFunction: Mock<Promise<any>, [string, {purchaseToken: string}]> = jest.fn((queurl, event) => Promise.resolve({}));
+
+        const mockFetchMetadataFunction: Mock<Promise<any>> = jest.fn(event => Promise.resolve({freeTrial: true}));
+
+        const receivedEvent = {
+            "version":"1.0",
+            "packageName":"com.guardian.debug",
+            "eventTimeMillis":"1503349566168",
+            "subscriptionNotification":
+                {
+                    "version":"1.0",
+                    "notificationType":4,
+                    "purchaseToken":"PURCHASE_TOKEN",
+                    "subscriptionId":"my.sku"
+                }
+        };
+
+        const encodedEvent = Buffer.from(JSON.stringify(receivedEvent)).toString('base64');
 
         const body = {
             message: {
-                data:'ewogICJ2ZXJzaW9uIjoiMS4wIiwKICAicGFja2FnZU5hbWUiOiJjb20uZ3VhcmRpYW4uZGVidWciLAogICJldmVudFRpbWVNaWxsaXMiOiIxNTAzMzQ5NTY2MTY4IiwKICAic3Vic2NyaXB0aW9uTm90aWZpY2F0aW9uIjoKICB7CiAgICAidmVyc2lvbiI6IjEuMCIsCiAgICAibm90aWZpY2F0aW9uVHlwZSI6NCwKICAgICJwdXJjaGFzZVRva2VuIjoiUFVSQ0hBU0VfVE9LRU4iLAogICAgInN1YnNjcmlwdGlvbklkIjoibXkuc2t1IgogIH0KfQo=',
+                data: encodedEvent,
                 messageId: '123',
                 message_id: '123',
                 publishTime: '2019-05-24T15:06:47.701Z',
@@ -61,7 +70,7 @@ describe("The google pubsub", () => {
             "SUBSCRIPTION_PURCHASED",
             "android",
             "com.guardian.debug",
-            undefined,
+            true,
             {
                 eventTimeMillis: "1503349566168",
                 packageName: "com.guardian.debug",
@@ -77,12 +86,16 @@ describe("The google pubsub", () => {
             1582319167
         );
 
-        return parseStoreAndSend(input, parseGooglePayload, googlePayloadToDynamo, toGoogleSqsEvent, mockStoreFunction, mockSqsFunction).then(result => {
+        const expectedSubscriptionReferenceInSqs = {packageName: "com.guardian.debug", purchaseToken: "PURCHASE_TOKEN", subscriptionId: "my.sku"};
+
+        return parseStoreAndSend(input, parseGooglePayload, googlePayloadToDynamo, toGoogleSqsEvent, mockFetchMetadataFunction, mockStoreFunction, mockSqsFunction).then(result => {
             expect(result).toStrictEqual(HTTPResponses.OK);
             expect(mockStoreFunction.mock.calls.length).toEqual(1);
             expect(mockStoreFunction.mock.calls[0][0]).toStrictEqual(expectedSubscriptionEventInDynamo);
             expect(mockSqsFunction.mock.calls.length).toEqual(1);
-            expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual({packageName: "com.guardian.debug", purchaseToken: "PURCHASE_TOKEN", subscriptionId: "my.sku"});
+            expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual(expectedSubscriptionReferenceInSqs);
+            expect(mockFetchMetadataFunction.mock.calls.length).toEqual(1);
+            expect(mockFetchMetadataFunction.mock.calls[0][0]).toStrictEqual(receivedEvent);
         });
     });
 });

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -61,6 +61,7 @@ describe("The google pubsub", () => {
             "SUBSCRIPTION_PURCHASED",
             "android",
             "com.guardian.debug",
+            undefined,
             {
                 eventTimeMillis: "1503349566168",
                 packageName: "com.guardian.debug",


### PR DESCRIPTION
In this PR I'm adding a `freeTrial` flag to both the subscription table and the event table.

For context, have a look at the [architecture diagram](https://docs.google.com/drawings/d/1Lt4cxTIjg_cSWd_bJCKpKwOZDFHTN7ki_GUZWJMBRvU/edit)

## Subscription table
Adding that flag to the subscription table is pretty easy as at the time we store the subscription, we have queried the subscription and the receipt from google and apple (respectively).

## Event table
Adding the flag to the event table is also pretty easy for Apple subscriptions, as Apple informs us of the state of that subscription in the payload we receive (I believe this is a recent addition).

That leaves us with the Google subscription events, which doesn't contain the trial information.
I had to refactor the code ([part 1](https://github.com/guardian/mobile-purchases/pull/142)) in order to make querying Google's service easier.

The primary goal of the PubSub lambda is to store the event and forward it to SQS for processing later. Any technical issue during that phase is critical as there's no guarantee neither Apple nor Google will retry to send the payload. (Although it is documented that both will retry).

As such, I made sure that querying that extra information would not cause the lambda to fail, no matter the outcome. A timeout, exception, temporary server outage on Google's side will all results in that flag being undefined in our database. I believe this is acceptable.

As I often do, this PR is easier to review commit per commit.

