### PR TITLE
Force batch size to 1, otherwise this breaks our retry model

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -740,7 +740,7 @@ Resources:
       FunctionName: !Ref UpdateGoogleSubscriptionsLambda
       Enabled: true
       EventSourceArn: !GetAtt GoogleSubscriptionsQueue.Arn
-      BatchSize: 10
+      BatchSize: 1
 
 
   UserSubscriptionsLambda:
@@ -805,7 +805,7 @@ Resources:
       FunctionName: !Ref UpdateAppleSubscriptionsLambda
       Enabled: true
       EventSourceArn: !GetAtt AppleSubscriptionsQueue.Arn
-      BatchSize: 10
+      BatchSize: 1
 
   AppleSubscriptionDlqDepthAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
Why?

SQS can batch messages together and trigger one lambda with an array of messages. Because our retry model relies on having the whole lambda failing, some of our messages that are perfectly valid and were processed successfully are being retried for no good reason.

This PR fixes this by forcing the batch size to be 1