### PR TITLE
Handle invalid token errors

### DIFF
--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -19,6 +19,9 @@ async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> 
         if (exception.statusCode === 410) {
             console.log(`Purchase expired a very long time ago, ignoring`);
             return [];
+        } if (exception.statusCode === 400 && exception?.result?.error?.message === "Invalid Value") {
+            console.warn("The purchase token value was invalid, we can't recover from this error", exception);
+            throw new ProcessingError("Invalid token value", false);
         } else {
             throw exception;
         }


### PR DESCRIPTION
We get the odd error in production where Google refuses to give the status of a subscription as the purchase token seems to be invalid.

There's nothing we can do for these errors. Our default behaviour was to retry a few time and post the message to the Dead letter queue. This isn't necessary.

So this PR detects such a case, and swallows the errors.