### PR TITLE
Improve ios receipt revalidation

### DIFF
--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -66,14 +66,17 @@ export async function handler(event: ScheduleEvent) {
     const SqsUrl = process.env.SqsUrl;
     if (SqsUrl === undefined) throw new Error("No SqsUrl env parameter provided");
 
+    let sentCount = 0;
     for await (const subscription of queryScan) {
         const receipt: string | undefined = subscription.receipt;
         if (receipt) {
-            const subscriptionReference: AppleSubscriptionReference = {receipt: receipt}
+            const subscriptionReference: AppleSubscriptionReference = {receipt: receipt};
             await sendToSqs(SqsUrl, subscriptionReference);
+            sentCount++;
+            console.log(`Sent subscription with id: ${subscription.subscriptionId} and expiry timestamp: ${subscription.endTimestamp}`)
         } else {
             console.warn(`No receipt found for ${subscription.subscriptionId}`);
         }
-        console.log(`Found subscription with id: ${subscription.subscriptionId} and expiry timestamp: ${subscription.endTimestamp}`)
     }
+    console.log(`Sent ${sentCount} subscriptions to be re-validated.`)
 }

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -71,7 +71,8 @@ export async function handler(event: ScheduleEvent) {
         const receipt: string | undefined = subscription.receipt;
         if (receipt) {
             const subscriptionReference: AppleSubscriptionReference = {receipt: receipt};
-            await sendToSqs(SqsUrl, subscriptionReference);
+            const delayInSeconds = Math.min(Math.floor(sentCount / 10), 900);
+            await sendToSqs(SqsUrl, subscriptionReference, delayInSeconds);
             sentCount++;
             console.log(`Sent subscription with id: ${subscription.subscriptionId} and expiry timestamp: ${subscription.endTimestamp}`)
         } else {

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -1,29 +1,38 @@
-import {plusHours} from "../utils/dates";
+import {plusDays, plusHours} from "../utils/dates";
 import {dynamoMapper, sendToSqs} from "../utils/aws";
 import {EndTimeStampFilterSubscription} from "../models/endTimestampFilter";
 import {
     AndExpression,
     attributeExists,
-    equals, lessThan,
+    equals, greaterThan, lessThan,
 } from '@aws/dynamodb-expressions';
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 
 function endTimestampForQuery(event: ScheduleEvent): Date {
-    const defaultDate = plusHours(new Date(), 13);
     if (event.endTimestampFilter) {
         return new Date(Date.parse(event.endTimestampFilter));
     } else {
-        return defaultDate;
+        return plusHours(new Date(), 13);
+    }
+}
+
+function startTimestampForQuery(event: ScheduleEvent): Date {
+    if (event.startTimestampFilter) {
+        return new Date(Date.parse(event.startTimestampFilter));
+    } else {
+        return plusDays(new Date(), -60);
     }
 }
 
 interface ScheduleEvent {
-    endTimestampFilter?: string;
+    endTimestampFilter?: string
+    startTimestampFilter?: string
 }
 
 export async function handler(event: ScheduleEvent) {
-    const time = endTimestampForQuery(event).toISOString();
-    console.log(`Will filter subscriptions before ${time}`);
+    const startTimestamp = startTimestampForQuery(event).toISOString();
+    const endTimestamp = endTimestampForQuery(event).toISOString();
+    console.log(`Will filter subscriptions before ${endTimestamp}`);
 
     const filter: AndExpression = {
         type: 'And',
@@ -37,7 +46,11 @@ export async function handler(event: ScheduleEvent) {
                 subject: 'receipt'
             },
             {
-                ...lessThan(time),
+                ...lessThan(endTimestamp),
+                subject: 'endTimestamp'
+            },
+            {
+                ...greaterThan(startTimestamp),
                 subject: 'endTimestamp'
             }
         ]

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -38,10 +38,11 @@ export const ssm: SSM  = new SSM({
 });
 
 
-export function sendToSqs(queueUrl: string, event: any): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
+export function sendToSqs(queueUrl: string, event: any, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     return sqs.sendMessage({
         QueueUrl: queueUrl,
-        MessageBody: JSON.stringify(event)
+        MessageBody: JSON.stringify(event),
+        DelaySeconds: delaySeconds
     }).promise()
 }
 


### PR DESCRIPTION
This PR improves the following aspects of receipt re-validations:

- Only revalidate expired receipts up to 60 days after their expiry. By then if it's still invalid there's not much we can do
- Count how many receipts we're sending to SQS, and print that count at the end of the processing
- Use that count to throttle how many receipts will be processed per second downstream. This is to avoid our downstream lambda consuming all the receipts at the same time and saturating Apple's service. This is done by using the count, divided by 10, and using that as a visibility delay on the SQS queue. So the 124th message sent will be delayed by 12 seconds before being processed downstream.