### PR TITLE
Add the product billing

### DIFF
--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -30,6 +30,9 @@ export class Subscription {
     freeTrial?: boolean;
 
     @attribute()
+    billingPeriod?: string;
+
+    @attribute()
     googlePayload?: any;
 
     @attribute()
@@ -50,6 +53,7 @@ export class Subscription {
         productId: string,
         platform: string | undefined,
         freeTrial: boolean | undefined,
+        billingPeriod: string | undefined,
         googlePayload?: any,
         receipt?: string,
         applePayload?: any,
@@ -63,6 +67,7 @@ export class Subscription {
         this.productId = productId;
         this.platform = platform;
         this.freeTrial = freeTrial;
+        this.billingPeriod = billingPeriod;
         this.googlePayload = googlePayload;
         this.receipt = receipt;
         this.applePayload = applePayload;
@@ -77,7 +82,7 @@ export class Subscription {
 export class ReadSubscription extends Subscription {
 
     constructor() {
-        super("", "", "", undefined, false, "", undefined, undefined)
+        super("", "", "", undefined, false, "", undefined, undefined, undefined)
     }
 
     setSubscriptionId(subscriptionId: string): ReadSubscription {

--- a/typescript/src/services/productBillingPeriod.ts
+++ b/typescript/src/services/productBillingPeriod.ts
@@ -1,0 +1,27 @@
+
+// product billing period is expressed using the ISO duration format
+// see https://en.wikipedia.org/wiki/ISO_8601#Durations
+export const PRODUCT_BILLING_PERIOD: {[productId: string]: string} = {
+    "com.guardian.subscription.6monthly.12": "P6M",
+    "com.guardian.subscription.annual.13": "P1Y",
+    "com.guardian.subscription.monthly.10": "P1M",
+    "uk.co.guardian.gia.1month": "P1M",
+    "uk.co.guardian.gia.6months": "P6M",
+    "uk.co.guardian.gla.12months.2018Dec.withFreeTrial": "P1Y",
+    "uk.co.guardian.gla.1month": "P1M",
+    "uk.co.guardian.gla.1month.2017Q2.variantA": "P1M",
+    "uk.co.guardian.gla.1month.2017Q2.variantB": "P1M",
+    "uk.co.guardian.gla.1month.2018April.withFreeTrial": "P1M",
+    "uk.co.guardian.gla.1month.2018May.withFreeTrial": "P1M",
+    "uk.co.guardian.gla.6months": "P6M",
+    "uk.co.guardian.gla.6months.2018May.withFreeTrial": "P6M",
+    "uk.co.guardian.subscription": "P1M",
+    "uk.co.guardian.subscription.2": "P1M",
+    "uk.co.guardian.subscription.3": "P1M",
+    "uk.co.guardian.subscription.4": "P1M",
+    "uk.co.guardian.subscription.5": "P1M",
+    "uk.co.guardian.subscription.6": "P1M",
+    "uk.co.guardian.subscription.7": "P1M",
+    "uk.co.guardian.subscription.8": "P1M",
+    "uk.co.guardian.subscription.9": "P6M",
+};

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -6,6 +6,7 @@ import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";
 import {fromAppleBundle} from "../services/appToPlatform";
+import {PRODUCT_BILLING_PERIOD} from "../services/productBillingPeriod";
 
 function toAppleSubscription(response: AppleValidationResponse): Subscription {
     const latestReceiptInfo = response.latestReceiptInfo;
@@ -20,6 +21,11 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         cancellationDate = latestReceiptInfo.cancellationDate.toISOString()
     }
 
+    let billingPeriod = PRODUCT_BILLING_PERIOD[latestReceiptInfo.productId];
+    if (billingPeriod === undefined) {
+        console.warn(`Unable to get the billing period, unknown product ID ${latestReceiptInfo.productId}`);
+    }
+
     return new Subscription(
         latestReceiptInfo.originalTransactionId,
         latestReceiptInfo.originalPurchaseDate.toISOString(),
@@ -29,6 +35,7 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         latestReceiptInfo.productId,
         fromAppleBundle(response.latestReceiptInfo.bundleId)?.toString(),
         latestReceiptInfo.trialPeriod,
+        billingPeriod,
         null,
         response.latestReceipt,
         response.originalResponse,


### PR DESCRIPTION
Added the mapping between product id and the billing period.

It's non critical data, so if it's missing it won't be an issue.

I did add a log line to warn us if we spot a new product id, although we'd have to look at the logs to learn about it. I'm in two minds between leaving it like that and going all the way to sending a production alarm when we spot a new product id.