### PR TITLE
Change the definition of "free trial" for iOS subs

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -69,7 +69,8 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         console.warn(`Unknown bundle id ${receiptInfo.bid}`)
     }
 
-    const freeTrial = receiptInfo.is_trial_period === "true";
+    // The Guardian's "free trial" period definition is slightly different from Apple, hence why we test for is_in_intro_offer_period
+    const freeTrial = receiptInfo.is_trial_period === "true" || receiptInfo.is_in_intro_offer_period === "true";
 
     return new SubscriptionEvent(
         receiptInfo.original_transaction_id,

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -25,7 +25,8 @@ export interface AppleValidatedReceiptServerInfo {
     original_purchase_date_ms: string,
     original_transaction_id: string
     product_id: string,
-    is_trial_period: string
+    is_trial_period: string,
+    is_in_intro_offer_period: string
 }
 
 export interface ValidationOptions {
@@ -53,6 +54,7 @@ export interface AppleValidatedReceiptInfo {
     bundleId?: string,
     autoRenewStatus: boolean,
     trialPeriod: boolean,
+    inIntroOfferPeriod: boolean,
     cancellationDate: Option<Date>,
     expiresDate: Date,
     originalPurchaseDate: Date,
@@ -202,6 +204,7 @@ export function toSensiblePayloadFormat(response: AppleValidationServerResponse,
                 originalTransactionId: receiptInfo.original_transaction_id,
                 productId: receiptInfo.product_id,
                 trialPeriod: receiptInfo.is_trial_period === "true",
+                inIntroOfferPeriod: receiptInfo.is_in_intro_offer_period === "true",
             },
             originalResponse: response
         };

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -34,7 +34,7 @@ function toAppleSubscription(response: AppleValidationResponse): Subscription {
         autoRenewStatus,
         latestReceiptInfo.productId,
         fromAppleBundle(response.latestReceiptInfo.bundleId)?.toString(),
-        latestReceiptInfo.trialPeriod,
+        latestReceiptInfo.trialPeriod || latestReceiptInfo.inIntroOfferPeriod,
         billingPeriod,
         null,
         response.latestReceipt,

--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -40,6 +40,41 @@ describe("The apple validation service", () => {
         expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
     });
 
+    test("Should pass the introOffer flag through the cleanup", () => {
+        const appleResponse: AppleValidationServerResponse = {
+            auto_renew_status: 0,
+            latest_expired_receipt_info: {
+                bundle_id: "uk.co.guardian.iphone2",
+                is_trial_period: "false",
+                is_in_intro_offer_period: "true",
+                original_transaction_id: "1234",
+                product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+                expires_date: "1570705794000",
+                original_purchase_date_ms: "1567081703000"
+            },
+            status: 21006
+        };
+
+        const expected: AppleValidationResponse[] = [{
+            isRetryable: false,
+            latestReceipt: "cmVjZWlwdA==",
+            latestReceiptInfo: {
+                bundleId: "uk.co.guardian.iphone2",
+                autoRenewStatus: false,
+                trialPeriod: false,
+                inIntroOfferPeriod: true,
+                cancellationDate: null,
+                expiresDate: new Date(1570705794000),
+                originalPurchaseDate: new Date(1567081703000),
+                originalTransactionId: "1234",
+                productId: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+            },
+            originalResponse: appleResponse
+        }];
+
+        expect(toSensiblePayloadFormat(appleResponse, "cmVjZWlwdA==")).toStrictEqual(expected);
+    });
+
 
     test("Should transform a dirty apple payload with the latest receipt info into a sane one", () => {
         const appleResponse: AppleValidationServerResponse = {

--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -11,6 +11,7 @@ describe("The apple validation service", () => {
             latest_expired_receipt_info: {
                 bundle_id: "uk.co.guardian.iphone2",
                 is_trial_period: "false",
+                is_in_intro_offer_period: "false",
                 original_transaction_id: "1234",
                 product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                 expires_date: "1570705794000",
@@ -26,6 +27,7 @@ describe("The apple validation service", () => {
                 bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
+                inIntroOfferPeriod: false,
                 cancellationDate: null,
                 expiresDate: new Date(1570705794000),
                 originalPurchaseDate: new Date(1567081703000),
@@ -45,6 +47,7 @@ describe("The apple validation service", () => {
             latest_receipt_info: {
                 bundle_id: "uk.co.guardian.iphone2",
                 is_trial_period: "false",
+                is_in_intro_offer_period: "false",
                 original_transaction_id: "1234",
                 product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                 expires_date: "2019-09-10 11:09:54 Etc/GM",
@@ -61,6 +64,7 @@ describe("The apple validation service", () => {
                 bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
+                inIntroOfferPeriod: false,
                 cancellationDate: null,
                 expiresDate: new Date(1570705794000),
                 originalPurchaseDate: new Date(1567081703000),
@@ -79,6 +83,7 @@ describe("The apple validation service", () => {
             latest_receipt_info: [{
                 bundle_id: "uk.co.guardian.iphone2",
                 is_trial_period: "false",
+                is_in_intro_offer_period: "false",
                 original_transaction_id: "1234",
                 product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                 expires_date: "2019-09-10 11:09:54 Etc/GM",
@@ -95,6 +100,7 @@ describe("The apple validation service", () => {
                 bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
+                inIntroOfferPeriod: false,
                 cancellationDate: null,
                 expiresDate: new Date(1570705794000),
                 originalPurchaseDate: new Date(1567081703000),
@@ -114,6 +120,7 @@ describe("The apple validation service", () => {
                 {
                     bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
+                    is_in_intro_offer_period: "false",
                     original_transaction_id: "1234",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     expires_date: "2019-09-10 11:09:54 Etc/GM",
@@ -123,6 +130,7 @@ describe("The apple validation service", () => {
                 {
                     bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
+                    is_in_intro_offer_period: "false",
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     expires_date: "2019-09-10 11:09:54 Etc/GM",
@@ -132,6 +140,7 @@ describe("The apple validation service", () => {
                 {
                     bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
+                    is_in_intro_offer_period: "false",
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     expires_date: "2019-09-10 11:09:54 Etc/GM",
@@ -149,6 +158,7 @@ describe("The apple validation service", () => {
                 bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
+                inIntroOfferPeriod: false,
                 cancellationDate: null,
                 expiresDate: new Date(1570705793000),
                 originalPurchaseDate: new Date(1567081703000),
@@ -163,6 +173,7 @@ describe("The apple validation service", () => {
                 bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
+                inIntroOfferPeriod: false,
                 cancellationDate: null,
                 expiresDate: new Date(1570705794000),
                 originalPurchaseDate: new Date(1567081703000),
@@ -183,6 +194,7 @@ describe("The apple validation service", () => {
                 {
                     bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
+                    is_in_intro_offer_period: "false",
                     original_transaction_id: "1234",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     original_purchase_date_ms: "1567081703000"
@@ -190,6 +202,7 @@ describe("The apple validation service", () => {
                 {
                     bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
+                    is_in_intro_offer_period: "false",
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     expires_date: "2019-09-10 11:09:54 Etc/GM",
@@ -207,6 +220,7 @@ describe("The apple validation service", () => {
                 bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
+                inIntroOfferPeriod: false,
                 cancellationDate: null,
                 expiresDate: new Date(1570705793000),
                 originalPurchaseDate: new Date(1567081703000),
@@ -226,6 +240,7 @@ describe("The apple validation service", () => {
                 {
                     bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
+                    is_in_intro_offer_period: "false",
                     original_transaction_id: "1235",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     expires_date: "2019-09-10 11:09:54 Etc/GM",
@@ -235,6 +250,7 @@ describe("The apple validation service", () => {
                 {
                     bundle_id: "uk.co.guardian.iphone2",
                     is_trial_period: "false",
+                    is_in_intro_offer_period: "false",
                     original_transaction_id: "1236",
                     product_id: "uk.co.guardian.gla.1month.2018May.withFreeTrial",
                     expires_date: "2019-09-10 11:09:54 Etc/GM",
@@ -270,6 +286,7 @@ describe("The apple validation service", () => {
                 bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: false,
                 trialPeriod: false,
+                inIntroOfferPeriod: false,
                 cancellationDate: null,
                 expiresDate: new Date(1570705793000),
                 originalPurchaseDate: new Date(1567081703000),
@@ -284,6 +301,7 @@ describe("The apple validation service", () => {
                 bundleId: "uk.co.guardian.iphone2",
                 autoRenewStatus: true,
                 trialPeriod: false,
+                inIntroOfferPeriod: false,
                 cancellationDate: null,
                 expiresDate: new Date(1570705793000),
                 originalPurchaseDate: new Date(1567081703000),


### PR DESCRIPTION
It seems like the Guardian and Google agree on what a "free trial" is, but Apple has a slightly more nuanced definition.

This fixes the flag for all new events and all subscriptions that will be updated in the future.

Aside from this change I'm preparing a script that will update our existing database rows with the same definition.