### PR TITLE
Bump jackson-databind

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ def commonAssemblySettings(module: String): immutable.Seq[Def.Setting[_]] = comm
 def commonSettings(module: String): immutable.Seq[Def.Setting[_]] = {
   val specsVersion: String = "4.0.3"
   val log4j2Version: String = "2.11.0"
-  val jacksonVersion: String = "2.9.6"
+  val jacksonVersion: String = jacksonData
   val upgradeTransitiveDependencies = Seq(
     "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val simpleConfigurationVersion: String = "1.4.3"
 // Force a version of jackson-databind that addresses this vulnerability:
 // https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-471943
 // introduced via com.typesafe.play:play
-val jacksonData: String = "2.9.10.2"
+val jacksonData: String = "2.10.3"
 
 val scalaRoot = file("scala")
 


### PR DESCRIPTION
## Why?

Fixes an issue reported in `jackson-databind` by bumping to more recent version. Release history available [here](https://github.com/FasterXML/jackson-databind/releases).

**Note:** I can't seem to get the project running correctly locally (sbt is *not* happy), so I'm relying on CI to tell me if this compiles. Also, I'm unsure what the consequences of bumping this might be, so would appreciate your input @alexduf.

## Changes

- Update `jackson-databind` to 2.10.3
