### PR TITLE
Improve GooglePlaySubsStatus5xxErrors alert and silence CODE alerts

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -721,16 +721,16 @@ Resources:
           MetricStat:
             Metric:
               MetricName: Count
-                Namespace: AWS/ApiGateway
-                Dimensions:
-                  - Name: ApiName
-                    Value: !Sub ${App}-${Stage}
-                  - Name: Method
-                    Value: GET
-                  - Name: Resource
-                    Value: /google/subscription/{subscriptionId}/status
-                  - Name: Stage
-                    Value: !Ref Stage
+              Namespace: AWS/ApiGateway
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub ${App}-${Stage}
+                - Name: Method
+                  Value: GET
+                - Name: Resource
+                  Value: /google/subscription/{subscriptionId}/status
+                - Name: Stage
+                  Value: !Ref Stage
             Period: 600
             Stat: Sum
           ReturnData: false

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -702,7 +702,9 @@ Resources:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       AlarmName: !Sub mobile-purchases-${Stage}-play-subscription-status-check-errors
-      AlarmDescription: !Sub A high number errors are being served to the Android app when it is attempting to check Play GoogleSubscription statuses
+      AlarmDescription: |
+        More than 20% of attempts to check Play subscription status resulted in a 5XX error.
+        Runbook: https://docs.google.com/document/d/1OwNDf_xSK3hhq1K0DP_4Uq7vIBFgfvlkd4zfiRZDczw/edit#heading=h.cnuchxbdu0tl
       Metrics:
         - Id: e1
           Label: Percentage of requests which result in a 5XX error

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -694,24 +694,49 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       AlarmName: !Sub mobile-purchases-${Stage}-play-subscription-status-check-errors
       AlarmDescription: !Sub A high number errors are being served to the Android app when it is attempting to check Play GoogleSubscription statuses
+      Metrics:
+        - Id: e1
+          Label: Percentage of requests which result in a 5XX error
+          Expression: "100*(m1/m2)"
+        - Id: m1
+          Label: Number of 5XX responses
+          MetricStat:
+            Metric:
+              MetricName: 5XXError
+              Namespace: AWS/ApiGateway
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub ${App}-${Stage}
+                - Name: Method
+                  Value: GET
+                - Name: Resource
+                  Value: /google/subscription/{subscriptionId}/status
+                - Name: Stage
+                  Value: !Ref Stage
+            Period: 600
+            Stat: Sum
+          ReturnData: false
+        - Id: m2
+          Label: Total number of requests
+          MetricStat:
+            Metric:
+              MetricName: Count
+                Namespace: AWS/ApiGateway
+                Dimensions:
+                  - Name: ApiName
+                    Value: !Sub ${App}-${Stage}
+                  - Name: Method
+                    Value: GET
+                  - Name: Resource
+                    Value: /google/subscription/{subscriptionId}/status
+                  - Name: Stage
+                    Value: !Ref Stage
+            Period: 600
+            Stat: Sum
+          ReturnData: false
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: ApiName
-          Value: !Sub ${App}-${Stage}
-        - Name: Method
-          Value: GET
-        - Name: Resource
-          Value: /google/subscription/{subscriptionId}/status
-        - Name: Stage
-          Value: !Ref Stage
       EvaluationPeriods: 1
-      MetricName: 5XXError
-      Namespace: AWS/ApiGateway
-      Period: 300
-      Statistic: Sum
       Threshold: 20
-      TreatMissingData: notBreaching
-
 
   UpdateGoogleSubscriptionsLambda:
     Type: AWS::Lambda::Function

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -42,6 +42,13 @@ Parameters:
     Type: String
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to
 
+Mappings:
+  StageVariables:
+    CODE:
+      AlarmActionsEnabled: FALSE
+    PROD:
+      AlarmActionsEnabled: TRUE
+
 Resources:
   MobilePurchasesLambdasRole:
     Type: AWS::IAM::Role
@@ -671,6 +678,7 @@ Resources:
   GoogleTokenRefreshFailureAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       AlarmName: !Sub mobile-purchases-${Stage}-google-oauth-token-refresh-failure
@@ -690,6 +698,7 @@ Resources:
   GooglePlaySubsStatus5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       AlarmName: !Sub mobile-purchases-${Stage}-play-subscription-status-check-errors
@@ -835,6 +844,7 @@ Resources:
   AppleSubscriptionDlqDepthAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
       AlarmDescription: "Ensure that the apple subscription dead letter queue is empty"
       Namespace: "AWS/SQS"
       MetricName: ApproximateNumberOfMessagesVisible
@@ -853,6 +863,7 @@ Resources:
   GoogleSubscriptionDlqDepthAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
       AlarmDescription: "Ensure that the google subscription dead letter queue is empty"
       Namespace: "AWS/SQS"
       MetricName: ApproximateNumberOfMessagesVisible


### PR DESCRIPTION
#### GooglePlaySubsStatus5xxErrors Improvements

https://theguardian.atlassian.net/browse/MSS-1603

- We now alert on % of requests which resulted in 5XX errors, instead of the number of 5XXs. This means that minor issues (e.g. transient problems with the Play Developer API) should not result in an alert. We'll still be informed about more serious problems, which is useful because we will need to escalate these.
- I've also added a runbook link to help with debugging. 

#### Silencing CODE alerts

I accidentally notified everyone when testing this change. I think that firing alerts related to CODE environments is unhelpful because it makes us less sensitive to real problems. To prevent this from happening again, I've set `ActionsEnabled` to `FALSE` in CODE. Alerts can still be tested to some extent (by looking at the CloudWatch UI) but the rest of the team are not impacted/notified.



