### PR TITLE
Add some payload and receipt logs

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -51,7 +51,6 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
     try {
         let notification = JSON.parse(body ?? "") as StatusUpdateNotification;
         delete notification.password; // no need to keep that in memory
-        console.log(`Notification payload: ${notification}`)
         return notification;
     } catch (e) {
         console.log("Error during the parsing of the HTTP Payload body: " + e);
@@ -65,8 +64,8 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
     const eventType = notification.notification_type;
 
     const receiptInfo = notification.latest_receipt_info ?? notification.latest_expired_receipt_info;
+    console.log(`latest_receipt_info is undefined: ${notification.latest_receipt_info === undefined}, latest_expired_receipt_info is undefined: ${notification.latest_expired_receipt_info === undefined}`);
     const platform = fromAppleBundle(receiptInfo.bid);
-    console.log(`Receipt info: ${receiptInfo}`)
     if (!platform) {
         console.warn(`Unknown bundle id ${receiptInfo.bid}`)
     }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -64,7 +64,7 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
     const eventType = notification.notification_type;
 
     const receiptInfo = notification.latest_receipt_info ?? notification.latest_expired_receipt_info;
-    console.log(`latest_receipt_info is undefined: ${notification.latest_receipt_info === undefined}, latest_expired_receipt_info is undefined: ${notification.latest_expired_receipt_info === undefined}`);
+    console.log(`notification is from ${notification.environment}, latest_receipt_info is undefined: ${notification.latest_receipt_info === undefined}, latest_expired_receipt_info is undefined: ${notification.latest_expired_receipt_info === undefined}`);
     const platform = fromAppleBundle(receiptInfo.bid);
     if (!platform) {
         console.warn(`Unknown bundle id ${receiptInfo.bid}`)

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -51,6 +51,7 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
     try {
         let notification = JSON.parse(body ?? "") as StatusUpdateNotification;
         delete notification.password; // no need to keep that in memory
+        console.log(`Notification payload: ${notification}`)
         return notification;
     } catch (e) {
         console.log("Error during the parsing of the HTTP Payload body: " + e);
@@ -65,6 +66,7 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
 
     const receiptInfo = notification.latest_receipt_info ?? notification.latest_expired_receipt_info;
     const platform = fromAppleBundle(receiptInfo.bid);
+    console.log(`Receipt info: ${receiptInfo}`)
     if (!platform) {
         console.warn(`Unknown bundle id ${receiptInfo.bid}`)
     }


### PR DESCRIPTION
## What does this change?
Add some logs to debug payload errors and invalid receipts easier.

This PR really is around hoping to gain some clarity on an error currently in our logs, and I want to see what the payload and receipt returns when we get this error.

<img width="715" alt="Screenshot 2020-12-10 at 10 28 30" src="https://user-images.githubusercontent.com/19835654/101760231-8727ae80-3ad2-11eb-9257-dc2417aa45c6.png">

