### PR TITLE
Add alarm for Apple Pubsub API gateway, to alert us for 5XX errors

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -826,7 +826,7 @@ Resources:
                 - Name: ApiName
                   Value: !Sub ${App}-${Stage}
                 - Name: Method
-                  Value: GET
+                  Value: POST
                 - Name: Resource
                   Value: /apple/subscription/status
                 - Name: Stage
@@ -837,6 +837,33 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
       Threshold: 20
+
+  ApplePubsub5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
+      AlarmActions:
+        - Ref: AlarmTopic
+      OKActions:
+        - Ref: AlarmTopic
+      AlarmName: !Sub mobile-purchases-${Stage}-apple-pubsub-check-errors
+      AlarmDescription: A HTTP request to the pubsub endpoint resulted in a 5XX error.
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub ${App}-${Stage}
+        - Name: Method
+          Value: POST
+        - Name: Resource
+          Value: /apple/pubsub
+        - Name: Stage
+          Value: !Ref Stage
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: 5XXError
+      Namespace: AWS/ApiGateway
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
 
 
   UserSubscriptionsLambda:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -783,6 +783,62 @@ Resources:
       BatchSize: 1
 
 
+  AppleSubsStatus5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
+      AlarmActions:
+        - Ref: AlarmTopic
+      OKActions:
+        - Ref: AlarmTopic
+      AlarmName: !Sub mobile-purchases-${Stage}-apple-subscription-status-check-errors
+      AlarmDescription: |
+        More than 20% of attempts to check Apple subscription status resulted in a 5XX error.
+      Metrics:
+        - Id: e1
+          Label: Percentage of requests which result in a 5XX error
+          Expression: "100*(m1/m2)"
+        - Id: m1
+          Label: Number of 5XX responses
+          MetricStat:
+            Metric:
+              MetricName: 5XXError
+              Namespace: AWS/ApiGateway
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub ${App}-${Stage}
+                - Name: Method
+                  Value: POST
+                - Name: Resource
+                  Value: /apple/subscription/status
+                - Name: Stage
+                  Value: !Ref Stage
+            Period: 600
+            Stat: Sum
+          ReturnData: false
+        - Id: m2
+          Label: Total number of requests
+          MetricStat:
+            Metric:
+              MetricName: Count
+              Namespace: AWS/ApiGateway
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub ${App}-${Stage}
+                - Name: Method
+                  Value: GET
+                - Name: Resource
+                  Value: /apple/subscription/status
+                - Name: Stage
+                  Value: !Ref Stage
+            Period: 600
+            Stat: Sum
+          ReturnData: false
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 20
+
+
   UserSubscriptionsLambda:
     Type: AWS::Serverless::Function
     Properties:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -836,7 +836,7 @@ Resources:
           ReturnData: false
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      Threshold: 20
+      Threshold: 10
 
   ApplePubsub5xxErrors:
     Type: AWS::CloudWatch::Alarm
@@ -864,6 +864,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
 
 
   UserSubscriptionsLambda:


### PR DESCRIPTION
## What does this change?
Pretty much lifted this from @jacobwinch previous PR adding the same for Google Play: #155 

This should alert us to a spike in 5XX errors so we can deal with them more efficiently

NB: There is a current ongoing investigation into 5XX errors on this service so am inclined to merge this PR when that has been fixed as it may create some noise
