### PR TITLE
LIVE-1234: Add unified receipt

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -6,6 +6,7 @@ import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Option} from "../utils/option";
 import {fromAppleBundle} from "../services/appToPlatform";
+import {PendingRenewalInfo} from "../services/appleValidateReceipts";
 
 // this is the definition of a receipt as received by the server to server notification system.
 // Not to be confused with apple's receipt validation receipt info (although they do look similar, they are different)
@@ -29,6 +30,15 @@ export interface AppleReceiptInfo {
     bvrs: string,
     version_external_identifier: string
 }
+//Documentation for unified_receipt: https://developer.apple.com/documentation/appstoreservernotifications/unified_receipt
+export interface UnifiedReceiptInfo {
+    environment: string,
+    latest_receipt: string,
+    latest_receipt_info: AppleReceiptInfo,
+    pending_renewal_info: PendingRenewalInfo[],
+    status: number
+
+}
 
 export interface StatusUpdateNotification {
     environment: string,
@@ -37,10 +47,7 @@ export interface StatusUpdateNotification {
     original_transaction_id: string,
     cancellation_date: string,
     web_order_line_item_id: string,
-    latest_receipt: string,
-    latest_receipt_info: AppleReceiptInfo,
-    latest_expired_receipt: string,
-    latest_expired_receipt_info: AppleReceiptInfo,
+    unified_receipt: UnifiedReceiptInfo,
     auto_renew_status: boolean,
     auto_renew_adam_id: string,
     auto_renew_product_id: string,
@@ -63,8 +70,8 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
     const now = new Date();
     const eventType = notification.notification_type;
 
-    const receiptInfo = notification.latest_receipt_info ?? notification.latest_expired_receipt_info;
-    console.log(`notification is from ${notification.environment}, latest_receipt_info is undefined: ${notification.latest_receipt_info === undefined}, latest_expired_receipt_info is undefined: ${notification.latest_expired_receipt_info === undefined}`);
+    const receiptInfo = notification.unified_receipt.latest_receipt_info;
+    console.log(`notification is from ${notification.environment}, latest_receipt_info is undefined: ${notification.unified_receipt.latest_receipt_info === undefined}`);
     const platform = fromAppleBundle(receiptInfo.bid);
     if (!platform) {
         console.warn(`Unknown bundle id ${receiptInfo.bid}`)
@@ -89,7 +96,7 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
 }
 
 export function toSqsSubReference(event: StatusUpdateNotification): AppleSubscriptionReference {
-    const receipt = event.latest_receipt ?? event.latest_expired_receipt;
+    const receipt = event.unified_receipt.latest_receipt;
     return {
         receipt: receipt
     }


### PR DESCRIPTION
## What does this change?
Whilst investing an iOS issue around missing subscriptions, we noticed an increased amount of errors in the logs of the `mobile-purchases-applepubsub` lambda. Having dug a little we could see an error message everytime we called the Sandbox environment:

<img width="1387" alt="Screenshot 2020-12-10 at 17 09 21" src="https://user-images.githubusercontent.com/19835654/104032662-5d8f9f00-51c6-11eb-90e9-e761f1539879.png">


We could also see consistently 5XX error requests  from the Apple Pubsub API gateway over a period of time:

<img width="632" alt="Screenshot 2020-12-10 at 10 48 55" src="https://user-images.githubusercontent.com/19835654/104032621-4f418300-51c6-11eb-9a72-4cc5ebc6e6d2.png">

Checking Apple documentation, they have decided to deprecate some of the fields from the [response body](https://developer.apple.com/documentation/appstoreservernotifications/responsebody):

<img width="793" alt="Screenshot 2021-01-08 at 15 31 19" src="https://user-images.githubusercontent.com/19835654/104032826-a0517700-51c6-11eb-93e2-37687786e592.png">

These fields have already been deprecated in the Sandbox environment and so thought we was missing information that now lives in a new `unified-receipt` object.

This PR adds the new object, and prepares for the deprecation of the fields in March.

## How to test
We tested this by:
-  Deploying our branch to CODE
- In API gateway running a test event on the POST request to the pubsub endpoint in CODE, passing in some test data as a payload
- Making sure we receive a 200 response

We tested different scenarios:
- If the unified-receipt and the deprecated fields are both sent (this is current behaviour in PROD)
- If the unified-receipt is missing and the deprecated fields remain
- If the deprecated fields are missing and unified-receipt is there

It is worth noting that currently in our production data we are receiving the unified-receipt already as Apple have rolled it out in production. So our payload consists of the to be deprecated fields, and the unfied-receipt.

## Have we considered potential risks?
We considered leaving the deprecated fields in the code base until March and removing them then, but we aren't going to be using them anymore so decided this might not be a problem.

We have also added a PR to add some metrics around alarming us for 5XX errors, which will be merged following a merge of this PR: https://github.com/guardian/mobile-purchases/pull/169

Paired with @marjisound @dskamiotis @jacobwinch 
