### PR TITLE
LIVE-1234: Add unified receipt, make sure latest_receipt is list type

### DIFF
--- a/typescript/src/export/exportEvents.ts
+++ b/typescript/src/export/exportEvents.ts
@@ -9,7 +9,7 @@ import {plusDays} from "../utils/dates";
 function cleanupEvent(subEvent: SubscriptionEvent): any {
     if (subEvent.applePayload) {
         delete subEvent.applePayload.password; // just to be safe
-        delete subEvent.applePayload.latest_receipt; // really no need to put that in the datalake
+        delete subEvent.applePayload.unified_receipt.latest_receipt; // really no need to put that in the datalake
     }
     return subEvent;
 }

--- a/typescript/src/export/exportEvents.ts
+++ b/typescript/src/export/exportEvents.ts
@@ -9,6 +9,7 @@ import {plusDays} from "../utils/dates";
 function cleanupEvent(subEvent: SubscriptionEvent): any {
     if (subEvent.applePayload) {
         delete subEvent.applePayload.password; // just to be safe
+        delete subEvent.applePayload.latest_receipt;
         delete subEvent.applePayload.unified_receipt.latest_receipt; // really no need to put that in the datalake
     }
     return subEvent;

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -34,7 +34,7 @@ export interface AppleReceiptInfo {
 export interface UnifiedReceiptInfo {
     environment: string,
     latest_receipt: string,
-    latest_receipt_info: AppleReceiptInfo,
+    latest_receipt_info: AppleReceiptInfo[],
     pending_renewal_info: PendingRenewalInfo[],
     status: number
 }
@@ -76,11 +76,15 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         console.warn(`Unknown bundle id ${notification.bid}`)
     }
 
+    if(receiptInfo.length == 0) {
+        console.warn(`Receipt info list is empty`)
+    }
+
     // The Guardian's "free trial" period definition is slightly different from Apple, hence why we test for is_in_intro_offer_period
-    const freeTrial = receiptInfo.is_trial_period === "true" || receiptInfo.is_in_intro_offer_period === "true";
+    const freeTrial = receiptInfo[0].is_trial_period === "true" || receiptInfo[0].is_in_intro_offer_period === "true";
 
     return new SubscriptionEvent(
-        receiptInfo.original_transaction_id,
+        receiptInfo[0].original_transaction_id,
         now.toISOString() + "|" + eventType,
         now.toISOString().substr(0, 10),
         now.toISOString(),

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -76,22 +76,16 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
     if (!platform) {
         console.warn(`Unknown bundle id ${notification.bid}`)
     }
-
-
-
-    const sortDates = receiptInfo.sort((receipt1, receipt2) => {
+    
+    const sortByExpiryDate = receiptInfo.sort((receipt1, receipt2) => {
         return Number.parseInt(receipt2.expires_date_ms) - Number.parseInt(receipt1.expires_date_ms);
     });
 
-    console.log(sortDates)
-
     // The Guardian's "free trial" period definition is slightly different from Apple, hence why we test for is_in_intro_offer_period
-    const freeTrial = sortDates[0].is_trial_period === "true" || sortDates[0].is_in_intro_offer_period === "true";
-
-    console.log(freeTrial)
+    const freeTrial = sortByExpiryDate[0].is_trial_period === "true" || sortByExpiryDate[0].is_in_intro_offer_period === "true";
 
     return new SubscriptionEvent(
-        sortDates[0].original_transaction_id,
+        sortByExpiryDate[0].original_transaction_id,
         now.toISOString() + "|" + eventType,
         now.toISOString().substr(0, 10),
         now.toISOString(),

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -76,15 +76,21 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         console.warn(`Unknown bundle id ${notification.bid}`)
     }
 
-    if(receiptInfo.length == 0) {
-        console.warn(`Receipt info list is empty`)
-    }
+
+
+    const sortDates = receiptInfo.sort((receipt1, receipt2) => {
+        return Number.parseInt(receipt2.expires_date) - Number.parseInt(receipt1.expires_date);
+    });
+
+    console.log(sortDates)
 
     // The Guardian's "free trial" period definition is slightly different from Apple, hence why we test for is_in_intro_offer_period
-    const freeTrial = receiptInfo[0].is_trial_period === "true" || receiptInfo[0].is_in_intro_offer_period === "true";
+    const freeTrial = sortDates[0].is_trial_period === "true" || sortDates[0].is_in_intro_offer_period === "true";
+
+    console.log(freeTrial)
 
     return new SubscriptionEvent(
-        receiptInfo[0].original_transaction_id,
+        sortDates[0].original_transaction_id,
         now.toISOString() + "|" + eventType,
         now.toISOString().substr(0, 10),
         now.toISOString(),

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -42,6 +42,7 @@ export interface UnifiedReceiptInfo {
 
 export interface StatusUpdateNotification {
     environment: string,
+    bid: string,
     notification_type: string,
     password?: string,
     original_transaction_id: string,
@@ -72,9 +73,9 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
 
     const receiptInfo = notification.unified_receipt.latest_receipt_info;
     console.log(`notification is from ${notification.environment}, latest_receipt_info is undefined: ${notification.unified_receipt.latest_receipt_info === undefined}`);
-    const platform = fromAppleBundle(receiptInfo.bid);
+    const platform = fromAppleBundle(notification.bid);
     if (!platform) {
-        console.warn(`Unknown bundle id ${receiptInfo.bid}`)
+        console.warn(`Unknown bundle id ${notification.bid}`)
     }
 
     // The Guardian's "free trial" period definition is slightly different from Apple, hence why we test for is_in_intro_offer_period
@@ -87,7 +88,7 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         now.toISOString(),
         eventType,
         platform ?? "unknown",
-        receiptInfo.bid,
+        notification.bid,
         freeTrial,
         null,
         notification,

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -6,6 +6,7 @@ import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Option} from "../utils/option";
 import {fromAppleBundle} from "../services/appToPlatform";
+import {PendingRenewalInfo} from "../services/appleValidateReceipts";
 
 // this is the definition of a receipt as received by the server to server notification system.
 // Not to be confused with apple's receipt validation receipt info (although they do look similar, they are different)
@@ -31,8 +32,11 @@ export interface AppleReceiptInfo {
 }
 
 export interface UnifiedReceiptInfo {
+    environment: string,
     latest_receipt: string,
-    latest_receipt_info: AppleReceiptInfo
+    latest_receipt_info: AppleReceiptInfo,
+    pending_renewal_info: PendingRenewalInfo[],
+    status: number
 }
 
 export interface StatusUpdateNotification {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -76,7 +76,11 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
     if (!platform) {
         console.warn(`Unknown bundle id ${notification.bid}`)
     }
-    
+
+    if(receiptInfo.length === 0) {
+        console.warn(`No latest_receipt_info has been found, it has returned an empty array`)
+    }
+
     const sortByExpiryDate = receiptInfo.sort((receipt1, receipt2) => {
         return Number.parseInt(receipt2.expires_date_ms) - Number.parseInt(receipt1.expires_date_ms);
     });

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -13,7 +13,6 @@ import {PendingRenewalInfo} from "../services/appleValidateReceipts";
 // See https://developer.apple.com/documentation/appstoreservernotifications/responsebody
 export interface AppleReceiptInfo {
     transaction_id: string,
-    bid: string,
     product_id: string,
     original_transaction_id: string,
     item_id: string,
@@ -25,6 +24,7 @@ export interface AppleReceiptInfo {
     purchase_date_ms: string,
     original_purchase_date_ms: string,
     expires_date: string,
+    expires_date_ms: string,
     is_in_intro_offer_period: string,
     is_trial_period: string,
     bvrs: string,
@@ -42,6 +42,7 @@ export interface UnifiedReceiptInfo {
 export interface StatusUpdateNotification {
     environment: string,
     bid: string,
+    bvrs: string,
     notification_type: string,
     password?: string,
     original_transaction_id: string,
@@ -79,7 +80,7 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
 
 
     const sortDates = receiptInfo.sort((receipt1, receipt2) => {
-        return Number.parseInt(receipt2.expires_date) - Number.parseInt(receipt1.expires_date);
+        return Number.parseInt(receipt2.expires_date_ms) - Number.parseInt(receipt1.expires_date_ms);
     });
 
     console.log(sortDates)

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -13,7 +13,6 @@ import {HTTPResponses} from "../../src/models/apiGatewayHttp";
 import {SubscriptionEvent} from "../../src/models/subscriptionEvent";
 import Mock = jest.Mock;
 import {APIGatewayProxyEvent} from "aws-lambda";
-import {dateToSecondTimestamp} from "../../src/utils/dates";
 
 describe("The google pubsub", () => {
     test("Should return HTTP 200 and store the correct data in dynamo", () => {

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -4,10 +4,16 @@ import {
     toDynamoEvent as googlePayloadToDynamo,
     toSqsSubReference as toGoogleSqsEvent
 } from "../../src/pubsub/google";
+import {
+    parsePayload as parseApplePayload,
+    toDynamoEvent as applePayloadToDynamo,
+    toSqsSubReference as toAppleSqsEvent
+} from "../../src/pubsub/apple";
 import {HTTPResponses} from "../../src/models/apiGatewayHttp";
 import {SubscriptionEvent} from "../../src/models/subscriptionEvent";
 import Mock = jest.Mock;
 import {APIGatewayProxyEvent} from "aws-lambda";
+import {dateToSecondTimestamp} from "../../src/utils/dates";
 
 describe("The google pubsub", () => {
     test("Should return HTTP 200 and store the correct data in dynamo", () => {
@@ -96,6 +102,133 @@ describe("The google pubsub", () => {
             expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual(expectedSubscriptionReferenceInSqs);
             expect(mockFetchMetadataFunction.mock.calls.length).toEqual(1);
             expect(mockFetchMetadataFunction.mock.calls[0][0]).toStrictEqual(receivedEvent);
+        });
+    });
+});
+
+describe("The apple pubsub", () => {
+    test("Should return HTTP 200 and store the correct data in dynamo", () => {
+        process.env['Secret'] = "MYSECRET";
+        process.env['QueueUrl'] = "";
+
+        const mockStoreFunction: Mock<Promise<SubscriptionEvent>, [SubscriptionEvent]> = jest.fn(event => Promise.resolve(event));
+
+        const mockSqsFunction: Mock<Promise<any>, [string, {receipt: string}]> = jest.fn((queueurl, event) => Promise.resolve({}));
+
+        const mockFetchMetadataFunction: Mock<Promise<any>> = jest.fn(event => Promise.resolve({undefined}));
+
+        const body = {
+                auto_renew_product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial",
+                auto_renew_status: true,
+                bid: "uk.co.guardian.iphone2",
+                bvrs: "TEST",
+                environment: "Sandbox",
+                notification_type: "INITIAL_BUY",
+                unified_receipt: {
+                    environment: "Sandbox",
+                    latest_receipt: "TEST",
+                    latest_receipt_info: [{
+                        app_item_id: "TEST",
+                        bid: "uk.co.guardian.iphone2",
+                        bvrs: "TEST",
+                        is_in_intro_offer_period: false,
+                        is_trial_period: true,
+                        item_id: "TEST",
+                        original_transaction_id: "TEST",
+                        product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial",
+                        quantity: "1",
+                        transaction_id: "TEST",
+                        unique_identifier: "TEST",
+                        unique_vendor_identifier: "TEST",
+                        version_external_identifier: "TEST",
+                        web_order_line_item_id: "TEST"
+                    }],
+                    pending_renewal_info: [
+                        {
+                            auto_renew_product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial",
+                            auto_renew_status: "1",
+                            original_transaction_id: "TEST",
+                            product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial"
+                        }
+                    ],
+                    status: 0
+                }
+        };
+
+        const input: APIGatewayProxyEvent = {
+            queryStringParameters: {secret: "MYSECRET"},
+            body: JSON.stringify(body),
+            headers: {},
+            multiValueHeaders: {},
+            httpMethod: "POST",
+            isBase64Encoded: false,
+            path: '',
+            pathParameters: {},
+            multiValueQueryStringParameters: {},
+            // @ts-ignore
+            requestContext: null,
+            resource: '',
+
+        };
+
+        const expectedSubscriptionEventInDynamo: any = {
+            subscriptionId: "TEST",
+            eventType: "INITIAL_BUY",
+            platform: "ios",
+            appId: "uk.co.guardian.iphone2",
+            freeTrial: false,
+            googlePayload: null,
+            applePayload:
+            {
+                auto_renew_product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial",
+                auto_renew_status: true,
+                bid: "uk.co.guardian.iphone2",
+                bvrs: "TEST",
+                environment: "Sandbox",
+                notification_type: "INITIAL_BUY",
+                unified_receipt: {
+                    environment: "Sandbox",
+                    latest_receipt: "TEST",
+                    latest_receipt_info: [
+                        {
+                            app_item_id: "TEST",
+                            bid: "uk.co.guardian.iphone2",
+                            bvrs: "TEST",
+                            is_in_intro_offer_period: false,
+                            is_trial_period: true,
+                            item_id: "TEST",
+                            original_transaction_id: "TEST",
+                            product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial",
+                            quantity: "1",
+                            transaction_id: "TEST",
+                            unique_identifier: "TEST",
+                            unique_vendor_identifier: "TEST",
+                            version_external_identifier: "TEST",
+                            web_order_line_item_id: "TEST"
+                        }
+                    ],
+                    pending_renewal_info: [
+                        {
+                        auto_renew_product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial",
+                        auto_renew_status: "1",
+                        original_transaction_id: "TEST",
+                        product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial"
+                        }
+                    ],
+                    status: 0
+                }
+            }
+        }
+
+        const expectedSubscriptionReferenceInSqs = {receipt: "TEST"};
+
+        return parseStoreAndSend(input, parseApplePayload, applePayloadToDynamo, toAppleSqsEvent, mockFetchMetadataFunction, mockStoreFunction, mockSqsFunction).then(result => {
+            expect(result).toStrictEqual(HTTPResponses.OK);
+            expect(mockStoreFunction.mock.calls.length).toEqual(1);
+            expect(mockStoreFunction.mock.calls[0][0]).toMatchObject(expectedSubscriptionEventInDynamo);
+            expect(mockSqsFunction.mock.calls.length).toEqual(1);
+            expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual(expectedSubscriptionReferenceInSqs);
+            expect(mockFetchMetadataFunction.mock.calls.length).toEqual(1);
         });
     });
 });


### PR DESCRIPTION
## What does this change?
The original PR is here:https://github.com/guardian/mobile-purchases/pull/178

When this went into production we noticed some log errors which didn't surface during our testing. `latest_receipt_info` is now an array/list rather than a single value.

This PR fixes that issue, and also adds a jest test to make sure we catch this is the future should it ever change.

We have once again tested using API gateway test too and received a 200 response.

I will also monitor the logs after merging.

paired with @marjisound