### PR TITLE
Change Apple PubSub 5XX error threshold

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -793,7 +793,7 @@ Resources:
         - Ref: AlarmTopic
       AlarmName: !Sub mobile-purchases-${Stage}-apple-subscription-status-check-errors
       AlarmDescription: |
-        More than 20% of attempts to check Apple subscription status resulted in a 5XX error.
+        More than 10% of attempts to check Apple subscription status resulted in a 5XX error.
       Metrics:
         - Id: e1
           Label: Percentage of requests which result in a 5XX error
@@ -863,7 +863,7 @@ Resources:
       Namespace: AWS/ApiGateway
       Period: 300
       Statistic: Sum
-      Threshold: 1
+      Threshold: 2
       TreatMissingData: notBreaching
 
 


### PR DESCRIPTION
## What does this change?
A threshold of 1 seems a bit too sensitive to alert us, 2 might seem more reasonable. If it triggers twice in 5 minutes then we know there is a problem.

I also noticed a typo in the alarm description.

@jacobwinch it would be good to get your opinion on this