### PR TITLE
handling error for apple 21007 response

### DIFF
--- a/typescript/src/models/GracefulProcessingError.ts
+++ b/typescript/src/models/GracefulProcessingError.ts
@@ -1,10 +1,8 @@
 export class GracefulProcessingError extends Error {
     message: string;
-    shouldRetry?: boolean;
 
     constructor(message: string, shouldRetry?: boolean) {
         super(message);
         this.message = message;
-        this.shouldRetry = shouldRetry;
     }
 }

--- a/typescript/src/models/GracefulProcessingError.ts
+++ b/typescript/src/models/GracefulProcessingError.ts
@@ -1,0 +1,10 @@
+export class GracefulProcessingError extends Error {
+    message: string;
+    shouldRetry?: boolean;
+
+    constructor(message: string, shouldRetry?: boolean) {
+        super(message);
+        this.message = message;
+        this.shouldRetry = shouldRetry;
+    }
+}

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -5,6 +5,7 @@ import {optionalMsToDate} from "../utils/dates";
 import {Option} from "../utils/option";
 import {restClient} from "../utils/restClient";
 import {IHttpClientResponse} from "typed-rest-client/Interfaces";
+import {GracefulProcessingError} from "../models/GracefulProcessingError";
 
 export interface PendingRenewalInfo {
     auto_renew_product_id?: string,
@@ -104,7 +105,7 @@ function checkResponseStatus(response: AppleValidationServerResponse): AppleVali
         const msg = `Got status 21007 and we're in ${Stage}, so we are processing a receipt from the wrong environment. ` +
             `This shouldn't have happen as we should already retry receipts in sandbox if the return code was 21007`;
         console.error(msg);
-        throw new ProcessingError(`Got status ${response.status} and we're in ${Stage}`);
+        throw new GracefulProcessingError(`Got status ${response.status} and we're in ${Stage}`);
     }
     if (response.status === 21008) {
         console.error(`Got status ${response.status} and we're in ${Stage}, so we are processing a receipt from the wrong environment`);

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -102,8 +102,7 @@ function checkResponseStatus(response: AppleValidationServerResponse): AppleVali
         throw new ProcessingError(`Server error, status ${response.status}`, true);
     }
     if (response.status === 21007) {
-        const msg = `Got status 21007 and we're in ${Stage}, so we are processing a receipt from the wrong environment. ` +
-            `This shouldn't have happen as we should already retry receipts in sandbox if the return code was 21007`;
+        const msg = `Got status 21007 and we're in ${Stage}, so we are processing a receipt from the wrong environment.`;
         console.error(msg);
         throw new GracefulProcessingError(`Got status ${response.status} and we're in ${Stage}`);
     }

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -2,6 +2,7 @@ import {SQSRecord} from 'aws-lambda'
 import {Subscription} from '../models/subscription';
 import {dynamoMapper, sendToSqs} from "../utils/aws";
 import {ProcessingError} from "../models/processingError";
+import {GracefulProcessingError} from "../models/GracefulProcessingError";
 
 function putSubscription(subscription: Subscription): Promise<Subscription> {
     return dynamoMapper.put({item: subscription}).then(result => result.item)
@@ -41,6 +42,9 @@ export async function parseAndStoreSubscriptionUpdate(
                console.error("The error wasn't retryable, giving up.");
                return "Error, giving up"
            }
+        } else if(error instanceof GracefulProcessingError){
+            console.warn("Error processing the subscription update is being handled gracefully", error);
+            return "OK";
         } else {
            console.error("Unexpected error, will throw to retry: ", error);
            throw error;


### PR DESCRIPTION
## What does this change?

We noticed a spike of 5XX errors related to our newly merged work around the unified receipt, PR here: https://github.com/guardian/mobile-purchases/pull/185

The spike seems to coincide with the time I merged this piece of work in, seems like we need to make sure Apple can revalidate our receipts correctly.

Jira: [https://theguardian.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=LIVE&modal=detail&selectedIssue=LIVE-1458&assignee=5fd76101849d6401116426a3](url)

## How to test
1- **Test in CODE env**, we can test the [POST] apple/pubsub api endpoint in CODE env and make sure the whole flow is taken successfully for the request. 


2- **To test the impact in PROD**, we should create a subscription for a test user in apple device 
Then apple should call our [POST] apple/pubsub api endpoint which will trigger lambda **mobile-purchases-applepubsub-PROD**
Then a message is published to **mobile-purchases-PROD-apple-subscriptions-to-fetch** SQS queue 
The message will be processed by the **mobile-purchases-apple-update-subscriptions-PROD** lambda which will call apple to validate receipt. 
The result of this Lambda call should be successful and only a warning message should be displayed in the lambda logs. 

## How can we measure success?
The expectation is that the number of 500 InternalServerErrors should go down in the **mobile-purchases-PROD** metrics.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
