### PR TITLE
Live-2262 - updated jackson-datand to 2.9.10.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val awsVersion: String = "1.11.375"
 val simpleConfigurationVersion: String = "1.4.3"
 
 // Force a more recent version of jackson databind
-val jacksonData: String = "2.9.10.5"
+val jacksonData: String = "2.9.10.8"
 
 val scalaRoot = file("scala")
 


### PR DESCRIPTION
## What does this change?
This updates jackson-datand to 2.9.10.8, in order to mitigate security vulnerabilities identified in Snyk

## How to test
This branch was deployed to CODE and then tested Lambdas in AWS:
- mobile-purchases-iosuserpurchases-CODE
- mobile-purchases-googleoauth-CODE
- mobile-purchases-iosvalidatereceipts-CODE

## How can we measure success?
Vulnerabilities to not be displayed within Snyk

## Have we considered potential risks?
This is implemented a s a separate PR from the previous update of Jackson-Databind (2.9.10.6) in order to keep version control in case of any breaking changes and the ability to roll back easily.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
