### PR TITLE
Add logs to debug subscription table export s3 upload error

### DIFF
--- a/typescript/src/export/exportSubscriptions.ts
+++ b/typescript/src/export/exportSubscriptions.ts
@@ -15,9 +15,11 @@ export async function handler(): Promise<any> {
     let stream = null;
     switch (className) {
         case "ReadSubscription":
+            console.log("Reading subscription from subscriptions");
             stream = new DynamoStream(dynamoMapper.scan(ReadSubscription));
             break;
         case "ReadUserSubscription":
+            console.log("Reading user subscription from user subscription");
             stream = new DynamoStream(dynamoMapper.scan(ReadUserSubscription));
             break;
         default:
@@ -30,6 +32,7 @@ export async function handler(): Promise<any> {
     const yesterday = plusDays(new Date(), -1).toISOString().substr(0,10);
     const prefix = (Stage === "PROD") ? "data" : "code-data";
     const filename = `${prefix}/date=${yesterday}/${yesterday}.json.gz`;
+    console.log(`uploading ${filename} to s3`);
     const managedUpload = s3.upload({
         Bucket: bucket,
         Key: filename,


### PR DESCRIPTION
## What does this change?
Adds logs to our subscription export lambda to debug an error when uploading to s3, to decide if the error is from dynamo or s3.

## How to test
Run the lambda manually in the console and see the messages in the logs
