### PR TITLE
Test out using the maximum memory for the subscriptions export lambda

### DIFF
--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -110,7 +110,7 @@ Resources:
           ExportBucket: !Ref SubscriptionExportBucket
           ClassName: ReadSubscription
       Description: Export subscription table to the datalake
-      MemorySize: 2048
+      MemorySize: 10240
       Timeout: 900
       Events:
         Schedule:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "clean": "rm -r tsc-target",
     "build": "webpack",
-    "test": "jest"
+    "test": "jest",
+    "test-lambda": "tsc && node ./tsc-target/src/test-launcher/test-launcher.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What does this change?
Test out using the maximum memory for the subscriptions export lambda to see if it fixes an issue with uploading to s3