### PR TITLE
Return 500 If PubSub Secret Is Missing

### DIFF
--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -34,6 +34,11 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
 ): Promise<APIGatewayProxyResult> {
     const secret = process.env.Secret;
     return catchingServerErrors(async () => {
+        if (secret === undefined) {
+            console.error("PubSub secret in env is 'undefined'");
+            return HTTPResponses.INTERNAL_ERROR
+        }
+
         if (request.queryStringParameters?.secret === secret) {
             const notification = parsePayload(request.body);
             if (notification instanceof Error) {


### PR DESCRIPTION
## Why?

I think there's a subtle bug that can occur if the secret isn't available in the env for whatever reason. We should return `500` and log an error in that case.

## Changes

- Log an error message and return `500` if the secret is `undefined` in the env
