### PR TITLE
LIVE-2680: Remove sensitive token and receipt info from logs

### DIFF
--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -89,7 +89,7 @@ function callValidateReceipt(receipt: string, forceSandbox: boolean = false): Pr
             const statusCode = response.message.statusCode;
             const statusText = response.message.statusMessage;
             if (statusCode && (statusCode < 200 || statusCode >= 300)) {
-                console.error(`Impossible to validate the receipt, got ${statusCode} ${statusText} from ${endpoint} for ${receipt}`);
+                console.error(`Impossible to validate the receipt, got ${statusCode} ${statusText} from ${endpoint}`);
                 throw new ProcessingError("Impossible to validate receipt", true);
             }
             return response

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -61,7 +61,7 @@ export async function handler(request: APIGatewayProxyEvent): Promise<APIGateway
                 console.log(`Purchase expired a very long time ago`);
                 return HTTPResponses.NOT_FOUND;
             } else {
-                console.log(`Serving an Internal Server Error due to: ${error}`);
+                console.log(`Serving an Internal Server Error due to: ${error.toString().split('/tokens/')[0]}`);
                 return HTTPResponses.INTERNAL_ERROR;
             }
         }


### PR DESCRIPTION
## What does this change?
Prevents us logging out sensitive receipt and token information in error logs, which is a potential security risk.

## How to test
Send dummy data in a test environment and check that we no longer see the token information.

## How can we measure success?
Security risks are reduced.