### PR TITLE
save validity, log it, then check it

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -90,26 +90,28 @@ function parseAppleReceiptInfo(payload: unknown):  Result<string, AppleReceiptIn
     if(!isObject(payload)) {
         return err("The apple receipt info field that Apple gave us isn't an object")
     }
-    console.log(`The keys of the apple receipt info: ${Object.keys(payload)}`);
-    if(
+    let valid = (
         typeof payload.transaction_id === "string" &&
-        typeof payload.product_id === "string" &&
-        typeof payload.original_transaction_id === "string" &&
-        (typeof payload.item_id === "string" || typeof payload.item_id === "undefined") &&
-        (typeof payload.app_item_id === "string" || typeof payload.app_item_id === "undefined") &&
-        typeof payload.web_order_line_item_id === "string" &&
-        (typeof payload.unique_identifier === "string" || typeof payload.unique_identifier === "undefined") &&
-        (typeof payload.unique_vendor_identifier === "string" || typeof payload.unique_vendor_identifier === "undefined") &&
-        typeof payload.quantity === "string" &&
-        typeof payload.purchase_date_ms === "string" &&
-        typeof payload.original_purchase_date_ms === "string" &&
-        typeof payload.expires_date === "string" &&
-        typeof payload.expires_date_ms === "string" &&
-        typeof payload.is_in_intro_offer_period === "string" &&
-        typeof payload.is_trial_period === "string" &&
-        (typeof payload.bvrs === "string" || typeof payload.bvrs === "undefined") &&
-        (typeof payload.version_external_identifier === "string" || typeof payload.version_external_identifier === "undefined")
-    ) {
+            typeof payload.product_id === "string" &&
+            typeof payload.original_transaction_id === "string" &&
+            (typeof payload.item_id === "string" || typeof payload.item_id === "undefined") &&
+            (typeof payload.app_item_id === "string" || typeof payload.app_item_id === "undefined") &&
+            typeof payload.web_order_line_item_id === "string" &&
+            (typeof payload.unique_identifier === "string" || typeof payload.unique_identifier === "undefined") &&
+            (typeof payload.unique_vendor_identifier === "string" || typeof payload.unique_vendor_identifier === "undefined") &&
+            typeof payload.quantity === "string" &&
+            typeof payload.purchase_date_ms === "string" &&
+            typeof payload.original_purchase_date_ms === "string" &&
+            typeof payload.expires_date === "string" &&
+            typeof payload.expires_date_ms === "string" &&
+            typeof payload.is_in_intro_offer_period === "string" &&
+            typeof payload.is_trial_period === "string" &&
+            (typeof payload.bvrs === "string" || typeof payload.bvrs === "undefined") &&
+            (typeof payload.version_external_identifier === "string" || typeof payload.version_external_identifier === "undefined")
+    )
+    console.log(`The keys of the apple receipt info (valid=$valid): ${Object.keys(payload)}`);
+
+    if(valid) {
         return ok({
             transaction_id: payload.transaction_id,
             product_id: payload.product_id,


### PR DESCRIPTION
We think we are seeing some failures on the validity check for the receipt, but it is difficult to match those failures up with the preceding loglines. So this saves the value of the validity check first, logs it, then uses it.