### PR TITLE
Apple debug loggging

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -303,18 +303,19 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
     try {
         const notification: unknown = JSON.parse(body ?? "");
         if(isObject(notification) && notification?.environment === "Sandbox") {
-            let parseResultStr = "unknown"
-            try {
-                const parseResult = parseNotification(notification)
-                if(parseResult.kind === ResultKind.Err) {
-                    parseResultStr = parseResult.err
-                } else {
-                    parseResultStr = "ok"
-                }
-            } catch (e) {
-                parseResultStr = `exception: ${e}`
-            }
-            console.log(`debugLogPayload (parse result: ${parseResultStr}): ${JSON.stringify(debugLogPayload(notification))}`);
+            console.log(`debugLogPayload: ${JSON.stringify(debugLogPayload(notification))}`);
+            // let parseResultStr = "unknown"
+            // try {
+            //     const parseResult = parseNotification(notification)
+            //     if(parseResult.kind === ResultKind.Err) {
+            //         parseResultStr = parseResult.err
+            //     } else {
+            //         parseResultStr = "ok"
+            //     }
+            // } catch (e) {
+            //     parseResultStr = `exception: ${e}`
+            // }
+            // console.log(`debugLogPayload (parse result: ${parseResultStr}): ${JSON.stringify(debugLogPayload(notification))}`);
         }
         const parsedNotification = parseNotification(notification);
         if(parsedNotification.kind === ResultKind.Ok) {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -302,10 +302,21 @@ function debugLogPayload(data: unknown, depth: number = 4, whitelisted: boolean 
 export function parsePayload(body: Option<string>): Error | StatusUpdateNotification {
     try {
         const notification: unknown = JSON.parse(body ?? "");
-        const parsedNotification = parseNotification(notification);
         if(isObject(notification) && notification?.environment === "Sandbox") {
-            console.log(`debugLogPayload (parse result: ${ResultKind[parsedNotification.kind]}): ${JSON.stringify(debugLogPayload(notification))}`);
+            let parseResultStr = "unknown"
+            try {
+                const parseResult = parseNotification(notification)
+                if(parseResult.kind === ResultKind.Err) {
+                    parseResultStr = parseResult.err
+                } else {
+                    parseResultStr = "ok"
+                }
+            } catch (e) {
+                parseResultStr = `exception: ${e}`
+            }
+            console.log(`debugLogPayload (parse result: ${parseResultStr}): ${JSON.stringify(debugLogPayload(notification))}`);
         }
+        const parsedNotification = parseNotification(notification);
         if(parsedNotification.kind === ResultKind.Ok) {
             return parsedNotification.value;
         }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -86,7 +86,7 @@ const parseArray = <A>(parseA: (a: unknown) => Result<string, A>) => (array: unk
     return err("Is not an array");
 };
 
-const fieldWhiteList = [ "environment", "product_id", "notification_type",
+const fieldAllowList = [ "environment", "product_id", "notification_type",
                          "auto_renew_status", "status", "purchase_date" ];
 
 function debugCleanPayload(data: unknown, depth: number = 4, whitelisted: boolean = false): object | string {
@@ -99,7 +99,7 @@ function debugCleanPayload(data: unknown, depth: number = 4, whitelisted: boolea
         } else {
             let result: Record<string, unknown> = {}
             for(let k in data)
-                result[k] = debugCleanPayload(data[k], depth - 1, fieldWhiteList.includes(k))
+                result[k] = debugCleanPayload(data[k], depth - 1, fieldAllowList.includes(k))
             return result
         }
     } else if(whitelisted) return `${data}`

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -285,7 +285,7 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
 
 const fieldWhiteList = [ "environment" ];
 
-function debugLogPayload(notification: unknown, depth: number = 1): string {
+function debugLogPayload(notification: unknown, depth: number = 3): string {
     let result: string[] = []
     if(isObject(notification)) {
         for(let k in notification) {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -287,7 +287,7 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
     try {
         const notification: unknown = JSON.parse(body ?? "");
         if(isObject(notification)) {
-            console.log(`parsePayload environment: ${notification?.environment}`);
+            console.log(`parsePayload environment: ${notification?.environment}; notification_type: ${notification?.notification_type}`);
         }
         //     if(notification?.environment === "Sandbox") {
         //         console.log(`parsePayload: sandbox body: ${body}`)

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -303,19 +303,18 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
     try {
         const notification: unknown = JSON.parse(body ?? "");
         if(isObject(notification) && notification?.environment === "Sandbox") {
-            console.log(`debugLogPayload: ${JSON.stringify(debugLogPayload(notification))}`);
-            // let parseResultStr = "unknown"
-            // try {
-            //     const parseResult = parseNotification(notification)
-            //     if(parseResult.kind === ResultKind.Err) {
-            //         parseResultStr = parseResult.err
-            //     } else {
-            //         parseResultStr = "ok"
-            //     }
-            // } catch (e) {
-            //     parseResultStr = `exception: ${e}`
-            // }
-            // console.log(`debugLogPayload (parse result: ${parseResultStr}): ${JSON.stringify(debugLogPayload(notification))}`);
+            let parseResultStr = "unknown"
+            try {
+                const parseResult = parseNotification(notification)
+                if(parseResult.kind === ResultKind.Err) {
+                    parseResultStr = parseResult.err
+                } else {
+                    parseResultStr = "ok"
+                }
+            } catch (e) {
+                parseResultStr = `exception: ${e}`
+            }
+            console.log(`debugLogPayload (parse result: ${parseResultStr}): ${JSON.stringify(debugLogPayload(notification))}`);
         }
         const parsedNotification = parseNotification(notification);
         if(parsedNotification.kind === ResultKind.Ok) {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -284,7 +284,7 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
 }
 
 const fieldWhiteList = [ "environment", "product_id", "notification_type",
-                         "auto_renew_status", "status" ];
+                         "auto_renew_status", "status", "purchase_date" ];
 
 function debugLogPayload(data: unknown, depth: number = 4, whitelisted: boolean = false): object | string {
     if(isObject(data) && depth > 0) {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -287,7 +287,8 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
     try {
         const notification: unknown = JSON.parse(body ?? "");
         if(isObject(notification)) {
-            console.log(`parsePayload environment: ${notification?.environment}; notification_type: ${notification?.notification_type}`);
+            const product_id = (isObject(notification.unified_receipt) && typeof(notification.unified_receipt.product_id === "string")) ? notification?.unified_receipt?.product_id : "<unified_receipt is not an object>";
+            console.log(`parsePayload environment: ${notification?.environment}; notification_type: ${notification?.notification_type}; product_id: ${product_id}`);
         }
         //     if(notification?.environment === "Sandbox") {
         //         console.log(`parsePayload: sandbox body: ${body}`)

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -114,47 +114,45 @@ function parseAppleReceiptInfo(payload: unknown):  Result<string, AppleReceiptIn
     if(!isObject(payload)) {
         return err("The apple receipt info field that Apple gave us isn't an object")
     }
-    console.log(`The keys of the apple receipt info: ${Object.keys(payload)}`);
-    if(
-        typeof payload.transaction_id === "string" &&
-        typeof payload.product_id === "string" &&
-        typeof payload.original_transaction_id === "string" &&
-        (typeof payload.item_id === "string" || typeof payload.item_id === "undefined") &&
-        (typeof payload.app_item_id === "string" || typeof payload.app_item_id === "undefined") &&
-        typeof payload.web_order_line_item_id === "string" &&
-        (typeof payload.unique_identifier === "string" || typeof payload.unique_identifier === "undefined") &&
-        (typeof payload.unique_vendor_identifier === "string" || typeof payload.unique_vendor_identifier === "undefined") &&
-        typeof payload.quantity === "string" &&
-        typeof payload.purchase_date_ms === "string" &&
-        typeof payload.original_purchase_date_ms === "string" &&
-        typeof payload.expires_date === "string" &&
-        typeof payload.expires_date_ms === "string" &&
-        typeof payload.is_in_intro_offer_period === "string" &&
-        typeof payload.is_trial_period === "string" &&
-        (typeof payload.bvrs === "string" || typeof payload.bvrs === "undefined") &&
-        (typeof payload.version_external_identifier === "string" || typeof payload.version_external_identifier === "undefined")
-    ) {
-        return ok({
-            transaction_id: payload.transaction_id,
-            product_id: payload.product_id,
-            original_transaction_id: payload.original_transaction_id,
-            item_id: payload.item_id,
-            app_item_id: payload.app_item_id,
-            web_order_line_item_id: payload.web_order_line_item_id,
-            unique_identifier: payload.unique_identifier,
-            unique_vendor_identifier: payload.unique_vendor_identifier,
-            quantity: payload.quantity,
-            purchase_date_ms: payload.purchase_date_ms,
-            original_purchase_date_ms: payload.original_purchase_date_ms,
-            expires_date: payload.expires_date,
-            expires_date_ms: payload.expires_date_ms,
-            is_in_intro_offer_period: payload.is_in_intro_offer_period,
-            is_trial_period: payload.is_trial_period,
-            bvrs: payload.bvrs,
-            version_external_identifier: payload.version_external_identifier
-        })
-    }
-    return err(`Apple Receipt Info object from Apple cannot be parsed: ${debugLogPayload(payload)}`)
+    // console.log(`The keys of the apple receipt info: ${Object.keys(payload)}`);
+    if(typeof payload.transaction_id !== "string") return err("missing field: transaction_id")
+    if(typeof payload.product_id !== "string") return err("missing field: product_id")
+    if(typeof payload.original_transaction_id !== "string") return err("missing field: original_transaction_id")
+    if(typeof payload.item_id !== "string" && typeof payload.item_id !== "undefined") return err(`incorrect optional field: item_id ${typeof payload.item_id}`)
+    if(typeof payload.app_item_id !== "string" && typeof payload.app_item_id !== "undefined") return err(`incorrect optional field: app_item_id ${typeof(payload.app_item_id)}`)
+    if(typeof payload.web_order_line_item_id !== "string") return err("missing field: web_order_line_item_id")
+    if(typeof payload.unique_identifier !== "string" && typeof payload.unique_identifier !== "undefined") return err(`incorrect optional field: unique_identifier ${typeof(payload.unique_identifier)}`)
+    if(typeof payload.unique_vendor_identifier !== "string" && typeof payload.unique_vendor_identifier !== "undefined") return err(`incorrect optional field: unique_vendor_identifier ${typeof(payload.unique_vendor_identifier)}`)
+    if(typeof payload.quantity !== "string") return err("missing field: quantity")
+    if(typeof payload.purchase_date_ms !== "string") return err("missing field: purchase_date_ms")
+    if(typeof payload.original_purchase_date_ms !== "string") return err("missing field: original_purchase_date_ms")
+    if(typeof payload.expires_date !== "string") return err("missing field: expires_date")
+    if(typeof payload.expires_date_ms !== "string") return err("missing field: expires_date_ms")
+    if(typeof payload.is_in_intro_offer_period !== "string") return err("missing field: is_in_intro_offer_period")
+    if(typeof payload.is_trial_period !== "string") return err("missing field: is_trial_period")
+    if(typeof payload.bvrs !== "string" && typeof payload.bvrs !== "undefined") return err(`incorrect optional field: bvrs ${typeof(payload.bvrs)}`)
+    if(typeof payload.version_external_identifier !== "string" && typeof payload.version_external_identifier !== "undefined") return err(`incorrect optional field: version_external_identifier ${typeof(payload.version_external_identifier)}`)
+
+    return ok({
+        transaction_id: payload.transaction_id,
+        product_id: payload.product_id,
+        original_transaction_id: payload.original_transaction_id,
+        item_id: payload.item_id,
+        app_item_id: payload.app_item_id,
+        web_order_line_item_id: payload.web_order_line_item_id,
+        unique_identifier: payload.unique_identifier,
+        unique_vendor_identifier: payload.unique_vendor_identifier,
+        quantity: payload.quantity,
+        purchase_date_ms: payload.purchase_date_ms,
+        original_purchase_date_ms: payload.original_purchase_date_ms,
+        expires_date: payload.expires_date,
+        expires_date_ms: payload.expires_date_ms,
+        is_in_intro_offer_period: payload.is_in_intro_offer_period,
+        is_trial_period: payload.is_trial_period,
+        bvrs: payload.bvrs,
+        version_external_identifier: payload.version_external_identifier
+    })
+//    return err(`Apple Receipt Info object from Apple cannot be parsed: ${debugLogPayload(payload)}`)
 }
 
 function parseBillingRetryPeriod(status: unknown): Result<string, binaryStatus | undefined> {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -285,7 +285,7 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
 
 const fieldWhiteList = [ "environment" ];
 
-function debugLogPayload(data: unknown, depth: number = 3, whitelisted: boolean = false): object | string {
+function debugLogPayload(data: unknown, depth: number = 4, whitelisted: boolean = false): object | string {
     if(isObject(data) && depth > 0) {
         if(Array.isArray(data))
             return { array_length: data.length, sample: debugLogPayload(data[0], depth - 1) }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -283,12 +283,16 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
     return err("Notification from Apple cannot be parsed")
 }
 
+const fieldWhiteList = [ "environment" ];
+
 function debugLogPayload(notification: unknown, depth: number = 1): string {
     let result: string[] = []
     if(isObject(notification)) {
         for(let k in notification) {
             if(depth > 0 && isObject(notification[k])) {
                 result.push(`${k}: { ${debugLogPayload(notification[k], depth - 1)} }`)
+            } else if(fieldWhiteList.includes(k)) {
+                result.push(`${k}: "${notification[k]}"`)
             } else {
                 result.push(`${k}: <${typeof(notification[k])}>`)
             }
@@ -302,8 +306,9 @@ function debugLogPayload(notification: unknown, depth: number = 1): string {
 export function parsePayload(body: Option<string>): Error | StatusUpdateNotification {
     try {
         const notification: unknown = JSON.parse(body ?? "");
-        console.log(debugLogPayload(notification));
-        // if(isObject(notification)) {
+        if(isObject(notification) && notification?.environment === "Sandbox") {
+            console.log(debugLogPayload(notification));
+        }
         //     const product_id = (isObject(notification.unified_receipt) && typeof(notification.unified_receipt.product_id === "string")) ? notification?.unified_receipt?.product_id : "<unified_receipt is not an object>";
         //     console.log(`parsePayload environment: ${notification?.environment}; notification_type: ${notification?.notification_type}; product_id: ${product_id}`);
         // }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -246,23 +246,18 @@ function parseUnifiedReceipt(payload: unknown):  Result<string, UnifiedReceiptIn
     if(pendingRenewalInfo.kind === ResultKind.Err) {
         return pendingRenewalInfo
     }
-    if(
-        typeof payload.environment === "string" &&
-        typeof payload.latest_receipt === "string" &&
-        typeof payload.status === "number" &&
-        latestReceiptInfo.kind === ResultKind.Ok &&
-        pendingRenewalInfo.kind === ResultKind.Ok
 
-    ) {
-        return ok({
-            environment: payload.environment,
-            latest_receipt: payload.latest_receipt,
-            status: payload.status,
-            latest_receipt_info: latestReceiptInfo.value,
-            pending_renewal_info: pendingRenewalInfo.value
-        })
-    }
-    return err("Unified Receipt object from Apple cannot be parsed")
+    if(typeof payload.environment !== "string") return err("parseUnifiedReceipt: missing field: environment")
+    if(typeof payload.latest_receipt !== "string") return err("parseUnifiedReceipt: missing field: latest_receipt")
+    if(typeof payload.status !== "number") return err("parseUnifiedReceipt: missing field: status")
+
+    return ok({
+        environment: payload.environment,
+        latest_receipt: payload.latest_receipt,
+        status: payload.status,
+        latest_receipt_info: latestReceiptInfo.value,
+        pending_renewal_info: pendingRenewalInfo.value
+    })
 }
 
 function parseNotification(payload: unknown): Result<string, StatusUpdateNotification>  {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -307,7 +307,7 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
     try {
         const notification: unknown = JSON.parse(body ?? "");
         if(isObject(notification) && notification?.environment === "Sandbox") {
-            console.log(debugLogPayload(notification));
+            console.log(`debugLogPayload: ${debugLogPayload(notification)}`);
         }
         //     const product_id = (isObject(notification.unified_receipt) && typeof(notification.unified_receipt.product_id === "string")) ? notification?.unified_receipt?.product_id : "<unified_receipt is not an object>";
         //     console.log(`parsePayload environment: ${notification?.environment}; notification_type: ${notification?.notification_type}; product_id: ${product_id}`);

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -302,12 +302,12 @@ function debugLogPayload(data: unknown, depth: number = 4, whitelisted: boolean 
 export function parsePayload(body: Option<string>): Error | StatusUpdateNotification {
     try {
         const notification: unknown = JSON.parse(body ?? "");
-        if(isObject(notification) && notification?.environment === "Sandbox") {
+        if(isObject(notification)) {
             let parseResultStr = "unknown"
             try {
                 const parseResult = parseNotification(notification)
                 if(parseResult.kind === ResultKind.Err) {
-                    parseResultStr = parseResult.err
+                    parseResultStr = `error: ${parseResult.err}`
                 } else {
                     parseResultStr = "ok"
                 }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -287,9 +287,12 @@ const fieldWhiteList = [ "environment" ];
 
 function debugLogPayload(data: unknown, depth: number = 4, whitelisted: boolean = false): object | string {
     if(isObject(data) && depth > 0) {
-        if(Array.isArray(data))
-            return { array_length: data.length, sample: debugLogPayload(data[0], depth - 1) }
-        else {
+        if(Array.isArray(data)) {
+            let res = []
+            for(let item of data)
+                res.push(debugLogPayload(item, depth - 1))
+            return res
+        } else {
             let result: Record<string, unknown> = {}
             for(let k in data)
                 result[k] = debugLogPayload(data[k], depth - 1, fieldWhiteList.includes(k))

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -286,6 +286,13 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
 export function parsePayload(body: Option<string>): Error | StatusUpdateNotification {
     try {
         const notification: unknown = JSON.parse(body ?? "");
+        if(isObject(notification)) {
+            if(notification?.environment === "Sandbox") {
+                console.log(`parsePayload: sandbox body: ${body}`)
+            } else {
+                console.log(`parsePayload environment: ${notification?.environment}`);
+            }
+        }
         const parsedNotification = parseNotification(notification);
         if(parsedNotification.kind === ResultKind.Ok) {
             return parsedNotification.value;

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -283,13 +283,30 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
     return err("Notification from Apple cannot be parsed")
 }
 
+function debugLogPayload(notification: unknown, depth: number = 1): string {
+    let result: string[] = []
+    if(isObject(notification)) {
+        for(let k in notification) {
+            if(depth > 0 && isObject(notification[k])) {
+                result.push(`${k}: { ${debugLogPayload(notification[k], depth - 1)} }`)
+            } else {
+                result.push(`${k}: <${typeof(notification[k])}>`)
+            }
+        }
+    } else {
+        result.push("<notification is not an object>");
+    }
+    return result.join(", ")
+}
+
 export function parsePayload(body: Option<string>): Error | StatusUpdateNotification {
     try {
         const notification: unknown = JSON.parse(body ?? "");
-        if(isObject(notification)) {
-            const product_id = (isObject(notification.unified_receipt) && typeof(notification.unified_receipt.product_id === "string")) ? notification?.unified_receipt?.product_id : "<unified_receipt is not an object>";
-            console.log(`parsePayload environment: ${notification?.environment}; notification_type: ${notification?.notification_type}; product_id: ${product_id}`);
-        }
+        console.log(debugLogPayload(notification));
+        // if(isObject(notification)) {
+        //     const product_id = (isObject(notification.unified_receipt) && typeof(notification.unified_receipt.product_id === "string")) ? notification?.unified_receipt?.product_id : "<unified_receipt is not an object>";
+        //     console.log(`parsePayload environment: ${notification?.environment}; notification_type: ${notification?.notification_type}; product_id: ${product_id}`);
+        // }
         //     if(notification?.environment === "Sandbox") {
         //         console.log(`parsePayload: sandbox body: ${body}`)
         //     } else {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -302,19 +302,10 @@ function debugLogPayload(data: unknown, depth: number = 4, whitelisted: boolean 
 export function parsePayload(body: Option<string>): Error | StatusUpdateNotification {
     try {
         const notification: unknown = JSON.parse(body ?? "");
-        if(isObject(notification) && notification?.environment === "Sandbox") {
-            console.log(`debugLogPayload: ${JSON.stringify(debugLogPayload(notification))}`);
-        }
-        //     const product_id = (isObject(notification.unified_receipt) && typeof(notification.unified_receipt.product_id === "string")) ? notification?.unified_receipt?.product_id : "<unified_receipt is not an object>";
-        //     console.log(`parsePayload environment: ${notification?.environment}; notification_type: ${notification?.notification_type}; product_id: ${product_id}`);
-        // }
-        //     if(notification?.environment === "Sandbox") {
-        //         console.log(`parsePayload: sandbox body: ${body}`)
-        //     } else {
-        //         console.log(`parsePayload environment: ${notification?.environment}`);
-        //     }
-        // }
         const parsedNotification = parseNotification(notification);
+        if(isObject(notification) && notification?.environment === "Sandbox") {
+            console.log(`debugLogPayload (parse result: ${parsedNotification.kind}): ${JSON.stringify(debugLogPayload(notification))}`);
+        }
         if(parsedNotification.kind === ResultKind.Ok) {
             return parsedNotification.value;
         }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -287,12 +287,14 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
     try {
         const notification: unknown = JSON.parse(body ?? "");
         if(isObject(notification)) {
-            if(notification?.environment === "Sandbox") {
-                console.log(`parsePayload: sandbox body: ${body}`)
-            } else {
-                console.log(`parsePayload environment: ${notification?.environment}`);
-            }
+            console.log(`parsePayload environment: ${notification?.environment}`);
         }
+        //     if(notification?.environment === "Sandbox") {
+        //         console.log(`parsePayload: sandbox body: ${body}`)
+        //     } else {
+        //         console.log(`parsePayload environment: ${notification?.environment}`);
+        //     }
+        // }
         const parsedNotification = parseNotification(notification);
         if(parsedNotification.kind === ResultKind.Ok) {
             return parsedNotification.value;

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -283,7 +283,8 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
     return err("Notification from Apple cannot be parsed")
 }
 
-const fieldWhiteList = [ "environment" ];
+const fieldWhiteList = [ "environment", "product_id", "notification_type",
+                         "auto_renew_status", "status" ];
 
 function debugLogPayload(data: unknown, depth: number = 4, whitelisted: boolean = false): object | string {
     if(isObject(data) && depth > 0) {
@@ -307,17 +308,20 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
         const notification: unknown = JSON.parse(body ?? "");
         if(isObject(notification)) {
             let parseResultStr = "unknown"
+            let parseResultValid = false
             try {
                 const parseResult = parseNotification(notification)
                 if(parseResult.kind === ResultKind.Err) {
                     parseResultStr = `error: ${parseResult.err}`
                 } else {
                     parseResultStr = "ok"
+                    parseResultValid = true
                 }
             } catch (e) {
                 parseResultStr = `exception: ${e}`
             }
-            console.log(`debugLogPayload (parse result: ${parseResultStr}): ${JSON.stringify(debugLogPayload(notification))}`);
+            if(!parseResultValid)
+                console.log(`debugLogPayload (parse result: ${parseResultStr}): ${JSON.stringify(debugLogPayload(notification))}`)
         }
         const parsedNotification = parseNotification(notification);
         if(parsedNotification.kind === ResultKind.Ok) {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -304,7 +304,7 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
         const notification: unknown = JSON.parse(body ?? "");
         const parsedNotification = parseNotification(notification);
         if(isObject(notification) && notification?.environment === "Sandbox") {
-            console.log(`debugLogPayload (parse result: ${parsedNotification.kind}): ${JSON.stringify(debugLogPayload(notification))}`);
+            console.log(`debugLogPayload (parse result: ${ResultKind[parsedNotification.kind]}): ${JSON.stringify(debugLogPayload(notification))}`);
         }
         if(parsedNotification.kind === ResultKind.Ok) {
             return parsedNotification.value;


### PR DESCRIPTION
The aim of this PR is to provide detailed logging when an incoming notifiction from Apple fails to parse.

As we are unable to distinguish between production purchases, and 'sandbox' purchases done by readers through the Beta version of the app, we are filtering the logging through a process which fwill hide the values of the fields, and only print out the type of them. An exception is made for a list of fields which are OK to print, because we know they don't contain any personal information:

```typescript
const fieldAllowList = [ "environment", "product_id", "notification_type",
                         "auto_renew_status", "status", "purchase_date" ];
```

The output that is produced is constructed as a valid Json object, meaning that once you extract it and pretty print, you get something quite readable (this example is trimmed):

```json
{
  "auto_renew_product_id": "<string>",
  "bid": "<string>",
  "unified_receipt": {
    "pending_renewal_info": [
      {
        "original_transaction_id": "<string>",
        "auto_renew_status": "1",
        "product_id": "uk.co.guardian.gla.1month.2018May.withFreeTrial",
        "auto_renew_product_id": "<string>"
      }
    ],
    "latest_receipt_info": [ "... etc ..." ]
}

```

This is particluarly useful as have taken the output of this logging, and put it back into the lambda in the testing mode, to identify exactly which fields are missing.

The purpose of splitting out the type guards from one if statement:
```typescript
if(
        typeof payload.transaction_id === "string" &&
        typeof payload.product_id === "string" &&
        typeof payload.original_transaction_id === "string" && // ...
```

 into multiple:

```typescript
    if(typeof payload.transaction_id !== "string") return err("missing field: transaction_id")
    if(typeof payload.product_id !== "string") return err("missing field: product_id")
    if(typeof payload.original_transaction_id !== "string") return err("missing field: original_transaction_id")
    if(typeof payload.item_id !== "string" && typeof payload.item_id !== "undefined") return err(`incorrect optional field: item_id ${typeof payload.item_id}`)
```

is so that we can return a unique error message for each missing field, which is hugely helpful in debugging, but still maintains the type safety introduced by the type guards.

![image](https://user-images.githubusercontent.com/2242307/140743320-25c266bd-a10f-4e7e-a0e6-b3c3fb84c42b.png)
