### PR TITLE
Update log4j dependency to fix security vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ def commonAssemblySettings(module: String): immutable.Seq[Def.Setting[_]] = comm
 )
 def commonSettings(module: String): immutable.Seq[Def.Setting[_]] = {
   val specsVersion: String = "4.0.3"
-  val log4j2Version: String = "2.11.0"
+  val log4j2Version: String = "2.15.0"
   val jacksonVersion: String = "2.9.6"
   val upgradeTransitiveDependencies = Seq(
     "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
@@ -120,7 +120,7 @@ def commonSettings(module: String): immutable.Seq[Def.Setting[_]] = {
     libraryDependencies ++= Seq(
       "commons-io" % "commons-io" % "2.6",
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
       "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j2Version,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ def commonSettings(module: String): immutable.Seq[Def.Setting[_]] = {
     libraryDependencies ++= Seq(
       "commons-io" % "commons-io" % "2.6",
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",
+      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0",
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
       "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j2Version,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.1")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 val upgradeTransitivePluginDependencies = Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % "2.8.11",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.2",


### PR DESCRIPTION
## What does this change?
Update log4j dependency to fix security vulnerability - see [doc](https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo)

It also updates our dependency graph version so we can run the command `sbt dependencyBrowseTree` which a handy way to quickly view our dependency tree in a browser: https://github.com/sbt/sbt-dependency-graph

## How to test

Ran tests locally