### PR TITLE
Ignore duplicate original transaction ids

### DIFF
--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -19,10 +19,12 @@ function parseAppleLinkPayload(request: APIGatewayProxyEvent): AppleLinkPayload 
 }
 
 function toUserSubscription(userId: string, payload: AppleLinkPayload): UserSubscription[] {
-    return payload.subscriptions.map(sub => new UserSubscription(
+    const now = new Date().toISOString()
+    const originalTransactionIds = payload.subscriptions.map(sub => sub.originalTransactionId)
+    return Array.from(new Set(originalTransactionIds)).map((originalTransactionId) => new UserSubscription(
         userId,
-        sub.originalTransactionId,
-        new Date().toISOString()
+        originalTransactionId,
+        now
     ));
 }
 


### PR DESCRIPTION
Filter out duplicate original transaction ids because dynamodb batch write doesn't allow you to write the same value for a range key multiple times in one transaction.

I don't know where the duplicates are coming from but this should mask the issue that we currently see:
`Internal Server Error ValidationException: Provided list of item keys contains duplicates`