### PR TITLE
Add logging of duplicate items

### DIFF
--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -84,6 +84,10 @@ export async function parseAndStoreLink<A, B>(
         }
     } catch (error) {
         console.error("Internal Server Error", error);
+        const message = error.message
+        if (typeof message === "string" && message.includes("Provided list of item keys contains duplicates")) {
+            console.error("Request body: " + (httpRequest.body ?? ""))
+        }
         return HTTPResponses.INTERNAL_ERROR
     }
 }


### PR DESCRIPTION
Still seeing `ValidationException`'s due to duplicate keys after merging #564 

This adds additional logging which should help debugging the issue.