### PR TITLE
Deduplicate link requests

### DIFF
--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -17,7 +17,7 @@ type AppleLinkPayload = {
 function deduplicate<T, U>(list: T[], selector: (item: T) => U): T[] {
     return list.reduce<T[]>(
         (agg, item) =>
-            agg.some((x) => selector(x) == selector(item)) ?
+            agg.some((x) => selector(x) === selector(item)) ?
                 agg : agg.concat([item]), 
         []
     )

--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -14,16 +14,28 @@ type AppleLinkPayload = {
     subscriptions: AppleSubscription[]
 }
 
-function parseAppleLinkPayload(request: APIGatewayProxyEvent): AppleLinkPayload {
-    return JSON.parse(request.body ?? "") as AppleLinkPayload;
+function deduplicate<T, U>(list: T[], selector: (item: T) => U): T[] {
+    return list.reduce<T[]>(
+        (agg, item) =>
+            agg.some((x) => selector(x) == selector(item)) ?
+                agg : agg.concat([item]), 
+        []
+    )
+}
+
+export function parseAppleLinkPayload(request: APIGatewayProxyEvent): AppleLinkPayload {
+    const parsed = JSON.parse(request.body ?? "") as AppleLinkPayload;
+    return {
+        ...parsed,
+        subscriptions: deduplicate(parsed.subscriptions, x => x.originalTransactionId)
+    }
 }
 
 function toUserSubscription(userId: string, payload: AppleLinkPayload): UserSubscription[] {
     const now = new Date().toISOString()
-    const originalTransactionIds = payload.subscriptions.map(sub => sub.originalTransactionId)
-    return Array.from(new Set(originalTransactionIds)).map((originalTransactionId) => new UserSubscription(
+    return payload.subscriptions.map(sub => new UserSubscription(
         userId,
-        originalTransactionId,
+        sub.originalTransactionId,
         now
     ));
 }

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -84,7 +84,7 @@ export async function parseAndStoreLink<A, B>(
         }
     } catch (error) {
         console.error("Internal Server Error", error);
-        const message = error.message
+        const message = (error as Error).message
         if (typeof message === "string" && message.includes("Provided list of item keys contains duplicates")) {
             console.error("Request body: " + (httpRequest.body ?? ""))
         }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -310,7 +310,7 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
         throw Error(`The payload could not be parsed due to ${parsedNotification.err}`)
     } catch (e) {
         console.log("Error during the parsing of the HTTP Payload body: " + e);
-        return e;
+        return e as Error;
     }
 }
 

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -37,7 +37,7 @@ export function parsePayload(body: Option<string>): Error | DeveloperNotificatio
         return parsedNotification;
     } catch (e) {
         console.log("Error during the parsing of the HTTP Payload body: " + e);
-        return e;
+        return e as Error;
     }
 }
 

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -31,7 +31,7 @@ export async function getUserId(headers: HttpRequestHeaders): Promise<Option<str
         // The REST client used here throws on 403s, so we have to try...catch
         // instead of handling this case in the response object above
         // https://github.com/microsoft/typed-rest-client#rest
-        if (error.statusCode === 403) {
+        if ((error as any).statusCode === 403) {
             console.warn('Identity API returned 403');
             return null;
         } else {

--- a/typescript/tests/link/apple.test.ts
+++ b/typescript/tests/link/apple.test.ts
@@ -1,0 +1,16 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { parseAppleLinkPayload } from "../../src/link/apple"
+
+describe("The apple link service", () => {
+  test("Should deduplicate originalTransactionIds", () => {
+    const raw = `{
+      "platform":"ios-puzzles",
+      "subscriptions":[
+        {"originalTransactionId":"12345","receipt":"duplicate-receipt"},
+        {"originalTransactionId":"12345","receipt":"duplicate-receipt"}
+      ]
+    }`
+    const parsed = parseAppleLinkPayload({ body: raw } as APIGatewayProxyEvent)
+    expect(parsed.subscriptions.length).toStrictEqual(1)
+  });
+});


### PR DESCRIPTION
## What does this change?

De-duplicates receipts sent from iOS apps. This should hopefully fix the error `Internal Server Error ValidationException: Provided list of item keys contains duplicates`. 

We now filter out duplicate original transaction ids earlier in the process so that the dynamodb get doesn't include duplicates (see https://github.com/guardian/mobile-purchases/blob/master/typescript/src/link/link.ts#L19)

I think the live app does this client side (https://github.com/guardian/ios-live/blob/1f48fc91115ac5e6725017a9f8cc4c88d43fb33b/GLA/GLA/Classes/User%2BSubscriptionLink.swift#L82) but the puzzles app currently doesn't.


