### PR TITLE
Add a manual trigger to snyk check.  Reset the schedule back to 9:00am

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,8 +2,9 @@ name: Snyk
 
 on:
     schedule:
-        - cron: "0 15 * * 1-5"
-
+        - cron: "0 9 * * 1-5"
+    workflow_dispatch:
+    
 jobs:
     snyk:
         name: Snyk


### PR DESCRIPTION
## What does this change?
 
Add a manual trigger to run snyk check.

## How to test

It only changes github setting files in the project.  No change to the mobile-purchases logic.

## How can we measure success?

Github allows us to manually trigger the snyk check.

## Have we considered potential risks?

No.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
