### PR TITLE
Make sure original_transaction_id is parsed correctly

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -273,7 +273,7 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
         typeof payload.bid === "string" &&
         typeof payload.bvrs === "string" &&
         typeof payload.notification_type === "string" &&
-        (typeof payload.original_transaction_id === "string" || typeof payload.original_transaction_id === "undefined") &&
+        (typeof payload.original_transaction_id === "string" || typeof payload.original_transaction_id === "undefined" || typeof payload.original_transaction_id === "number") &&
         (typeof payload.cancellation_date === "string" || typeof payload.cancellation_date === "undefined") &&
         (typeof payload.web_order_line_item_id === "string" || typeof payload.web_order_line_item_id === "undefined" ) &&
         typeof payload.auto_renew_status === "string" &&
@@ -286,7 +286,7 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
             bid: payload.bid,
             bvrs: payload.bvrs,
             notification_type: payload.notification_type,
-            original_transaction_id: payload.original_transaction_id,
+            original_transaction_id: typeof payload.original_transaction_id === "number" ? payload.original_transaction_id.toString() : payload.original_transaction_id,
             cancellation_date: payload.cancellation_date,
             web_order_line_item_id: payload.web_order_line_item_id,
             auto_renew_status: payload.auto_renew_status,


### PR DESCRIPTION
## What does this change?
Analysts noticed that from the 25/03/22 numbers of subscriptions was dramatically dropping. When looking at the size of the files in the raw ophan bucket for mobile_subscriptions_events I could see that the file size was dramatically smaller, coinciding with the data the analysts saw.

When looking into the kibana logs, on 22/03/22 we started seeing parsing errors for the payload:

<img width="1309" alt="Screenshot 2022-04-04 at 17 13 30" src="https://user-images.githubusercontent.com/19835654/161587647-48a07857-6a56-4be5-b80c-9f6206063fe3.png">

When investigating it became clear that the `original_transaction_id`  for the `StatusUpdateNotification` payload was an optional field of `string`

In Apples documentations this however is now a `number`, we also suspect that once the field was optional for Apple but now they have changed it to be non-optional and so we fail to parse the payload.

This PR makes sure we still handle our current model of the type being a string, whilst also allowing us to accept number as a type too. 

In the future we should have better alarms in place to shout at us.