### PR TITLE
Prune duplicates in Snyk config to avoid API hanging.

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,5 +13,6 @@ jobs:
       DEBUG: true
       ORG: the-guardian-cuu
       SKIP_NODE: false
+      PRUNE_DUPLICATES: true
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

Fixing the Snyk integration which seems to hang when pushing deps to the API: https://github.com/guardian/mobile-purchases/actions/runs/3541037399/jobs/5988554930#step:13:19217 

## How to test

This workflow can be triggered manually under actions (it should give us a green tick).
