### PR TITLE
Okta Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
     "@aws/dynamodb-expressions": "^0.7.3",
     "@guardian/types": "^6.0.0",
+    "@okta/jwt-verifier": "^2.6.0",
     "@types/aws-lambda": "8.10.93",
     "@types/node": "^16.0.0",
     "aws-sdk": "^2.1097.0",

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -71,11 +71,17 @@ export async function parseAndStoreLink<A, B>(
             const payload: A = parsePayload(httpRequest);
             const userId = await getUserId(httpRequest.headers);
             if (userId) {
-                const insertCount = await persistUserSubscriptionLinks(toUserSubscription(userId, payload));
-                const sqsCount = await enqueueUnstoredPurchaseToken(toSqsPayload(payload));
-                console.log(`Put ${insertCount} links in the DB, and sent ${sqsCount} subscription refs to SQS`);
+                if (userId == "1234567890") {
+                    // See comment in guIdentityApi explaining the reason for this magic number
+                    // This is a temporary measure.
+                    return HTTPResponses.FORBIDDEN
+                } else {
+                    const insertCount = await persistUserSubscriptionLinks(toUserSubscription(userId, payload));
+                    const sqsCount = await enqueueUnstoredPurchaseToken(toSqsPayload(payload));
+                    console.log(`Put ${insertCount} links in the DB, and sent ${sqsCount} subscription refs to SQS`);
+                    return HTTPResponses.OK;
+                }
 
-                return HTTPResponses.OK;
             } else {
                 return HTTPResponses.UNAUTHORISED;
             }

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -1,5 +1,4 @@
 import {HTTPResponses} from '../models/apiGatewayHttp';
-
 import {UserSubscription} from "../models/userSubscription";
 import {ReadSubscription} from "../models/subscription";
 import {dynamoMapper, sqs} from "../utils/aws";
@@ -8,6 +7,7 @@ import {SubscriptionReference} from "../models/subscriptionReference";
 import {SendMessageBatchRequestEntry} from "aws-sdk/clients/sqs";
 import {ProcessingError} from "../models/processingError";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import {UserIdResolution} from "../utils/guIdentityApi"
 
 export interface SubscriptionCheckData {
     subscriptionId: string
@@ -67,23 +67,21 @@ export async function parseAndStoreLink<A, B>(
 ): Promise<APIGatewayProxyResult> {
     try {
         if (httpRequest.headers && getAuthToken(httpRequest.headers)) {
-
             const payload: A = parsePayload(httpRequest);
-            const userId = await getUserId(httpRequest.headers);
-            if (userId) {
-                if (userId == "1234567890") {
-                    // See comment in guIdentityApi explaining the reason for this magic number
-                    // This is a temporary measure.
-                    return HTTPResponses.FORBIDDEN
-                } else {
-                    const insertCount = await persistUserSubscriptionLinks(toUserSubscription(userId, payload));
+            const resolution: UserIdResolution = await getUserId(httpRequest.headers);
+            switch(resolution.status) {
+                case "success": {
+                    const insertCount = await persistUserSubscriptionLinks(toUserSubscription((resolution.userId as string), payload));
                     const sqsCount = await enqueueUnstoredPurchaseToken(toSqsPayload(payload));
                     console.log(`Put ${insertCount} links in the DB, and sent ${sqsCount} subscription refs to SQS`);
                     return HTTPResponses.OK;
                 }
-
-            } else {
-                return HTTPResponses.UNAUTHORISED;
+                case "incorrect-scope": {
+                    return HTTPResponses.FORBIDDEN;
+                }
+                case "incorrect-token": {
+                    return HTTPResponses.UNAUTHORISED;
+                }
             }
         } else {
             return HTTPResponses.INVALID_REQUEST

--- a/typescript/src/models/apiGatewayHttp.ts
+++ b/typescript/src/models/apiGatewayHttp.ts
@@ -16,6 +16,7 @@ export const HTTPResponses: {[key: string]: APIGatewayProxyResult} = {
     OK: {statusCode: 200, body: "{\"status\": 200, \"message\": \"OK\"}"},
     INVALID_REQUEST: {statusCode: 400, body: "{\"status\": 400, \"message\": \"INVALID_REQUEST\"}"},
     UNAUTHORISED: {statusCode: 401, body: "{\"status\": 401, \"message\": \"UNAUTHORISED\"}"},
+    FORBIDDEN: {statusCode: 403, body: "{\"status\": 403, \"message\": \"FORBIDDEN\"}"},
     NOT_FOUND: {statusCode: 404, body: "{\"status\": 404, \"message\": \"NOT_FOUND\"}"},
     INTERNAL_ERROR: {statusCode: 500, body: "{\"status\": 500, \"message\": \"INTERNAL_SERVER_ERROR\"}"},
 };

--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -95,15 +95,18 @@ export async function handler(httpRequest: APIGatewayProxyEvent): Promise<APIGat
         } else {
             const resolution: UserIdResolution = await getUserId(httpRequest.headers);
             switch(resolution.status) {
-                case "success": {
-                    userId = (resolution.userId as string)
-                    break;
+                case "incorrect-token": {
+                    return HTTPResponses.UNAUTHORISED;
                 }
                 case "incorrect-scope": {
                     return HTTPResponses.FORBIDDEN;
                 }
-                case "incorrect-token": {
-                    return HTTPResponses.UNAUTHORISED;
+                case "missing-identity-id": {
+                    return HTTPResponses.INVALID_REQUEST;
+                }
+                case "success": {
+                    userId = (resolution.userId as string)
+                    break;
                 }
             }
         }

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -122,6 +122,13 @@ async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<UserIdRes
     we are extending the return type of the getUserId functions, to become a { UserIdResolution }
 */
 
+/*
+    Date: 07th Jan 2022
+
+    We we complete the transition to Okta, we will have to keep the UserIdResolution type,
+    But we will be able to get rid of getUserId_OldIdentity without any other change.
+*/
+
 export async function getUserId(headers: HttpRequestHeaders): Promise<UserIdResolution> {
     const resolution = await getUserId_OldIdentity(headers);
     if (resolution.status == "success") {

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -114,8 +114,12 @@ async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<UserIdRes
 /*
     Date: 07th Jan 2022
 
-    We we complete the transition to Okta, we will have to keep the UserIdResolution type,
+    When we complete the transition to Okta, we will have to keep the UserIdResolution type,
     But we will be able to get rid of getUserId_OldIdentity without any other change.
+
+    Note that the reason we perform the old Identity authentication before the Okta authentication
+    is because the Okta authentication fails in more ways than the old authentication and in order to keep 
+    the code simple while returning the right code, it need to be done in that order.
 */
 
 export async function getUserId(headers: HttpRequestHeaders): Promise<UserIdResolution> {

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -17,21 +17,6 @@ interface OktaJwtVerifierReturn {
     }
 }
 
-/*
-    Date: 31st Dec 2022
-
-    Function getUserId_OldIdentity used to perform the resolution of a authorization token and used to
-    return null or a string (the userId). That value was handled by the caller { function: parseAndStoreLink }.
-    In the case of null we would return a { HTTPResponses.UNAUTHORISED, 401 }
-
-    When we moved to the Okta authentication, we needed to make the difference between failures
-    due to an incorrect token and failures due to incorrect scopes. In the case of an incorrect
-    token we need to return { HTTPResponses.UNAUTHORISED, 401 } but in the case of incorrect scope
-    we need to return { HTTPResponses.FORBIDDEN, 403 }.
-
-    To be able to convey to { function: parseAndStoreLink } which case occured during the authentication,
-    we are extending the return type of the getUserId functions, to become a { UserIdResolution }
-*/
 export interface UserIdResolution {
     status: "incorrect-token" | "incorrect-scope" | "success",
     userId: null | string
@@ -118,9 +103,26 @@ async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<UserIdRes
     }
 }
 
+// Function getUserId is the front that implements the common interface behind which 
+// the old (Identity) and the new (Okta) authentication methods.
+
+/*
+    Date: 31st Dec 2022
+
+    Function getUserId_OldIdentity used to perform the resolution of a authorization token and used to
+    return null or a string (the userId). That value was handled by the caller { function: parseAndStoreLink }.
+    In the case of null we would return a { HTTPResponses.UNAUTHORISED, 401 }
+
+    When we moved to the Okta authentication, we needed to make the difference between failures
+    due to an incorrect token and failures due to incorrect scopes. In the case of an incorrect
+    token we need to return { HTTPResponses.UNAUTHORISED, 401 } but in the case of incorrect scope
+    we need to return { HTTPResponses.FORBIDDEN, 403 }.
+
+    To be able to convey to { function: parseAndStoreLink } which case occured during the authentication,
+    we are extending the return type of the getUserId functions, to become a { UserIdResolution }
+*/
+
 export async function getUserId(headers: HttpRequestHeaders): Promise<UserIdResolution> {
-    // This function is the front that implement the common interface behind which 
-    // there is the old (Identity) and new (Okta) authentication methods.
     const resolution = await getUserId_OldIdentity(headers);
     if (resolution.status == "success") {
         return resolution;

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -11,11 +11,18 @@ interface IdentityResponse {
     user: UserId
 }
 
+interface OktaJwtVerifierReturn {
+    claims : {
+        scp: [string],
+        sub: string,
+    }
+}
+
 export function getAuthToken(headers: HttpRequestHeaders): string | undefined {
     return (headers["Authorization"] ?? headers["authorization"])?.replace("Bearer ", "");
 }
 
-export async function getUserId(headers: HttpRequestHeaders): Promise<Option<string>> {
+async function getUserId_OldIdentity(headers: HttpRequestHeaders): Promise<Option<string>> {
     const url = "https://id.guardianapis.com/user/me";
     const identityToken = getAuthToken(headers);
 
@@ -38,4 +45,66 @@ export async function getUserId(headers: HttpRequestHeaders): Promise<Option<str
             throw error;
         }
     }
+}
+
+async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<Option<string>> {
+    try {
+        const OktaJwtVerifier = require('@okta/jwt-verifier');
+
+        const ISSUER      = 'https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7'
+        const CLIENT_ID   = "0oa4iyjx692Aj8SlZ0x7"
+        const expectedAud = "https://profile.code.dev-theguardian.com/";
+        
+        const oktaJwtVerifier = new OktaJwtVerifier({
+            issuer: ISSUER,
+            clientId: CLIENT_ID,
+            assertClaims: {'scp.includes': ['email']}
+          });
+        
+        const accessTokenString = getAuthToken(headers);
+
+        // Date: 28th December 2022
+        // Author: Pascal 
+          
+        // We want: 
+        //       401 for an invalid/expired access token.
+        //       403 for an invalid scope, and 
+
+        // If the authentication fails, mostly because the access token is invalid, then oktaJwtVerifier.verifyAccessToken
+        // throw an error. That error would bubble up to a servor error (500), which is not what we want. 
+        // In that case we just catch the error and return a null, which the function { parseAndStoreLink } which called us
+        // will return as a HTTPResponses.UNAUTHORISED, meaning a 401
+
+        // If fail the scope check then for the moment, we return a magic value and let { parseAndStoreLink } deal with it. 
+        // The reason for simply not returning the right type, is that we are calling not only the new but also version 
+        // of this (for backward compatibility with the old identity authentication), and at this stage I am not updating 
+        // all signatures. So overloading it is.
+        
+        try {
+            return await oktaJwtVerifier.verifyAccessToken(accessTokenString, expectedAud)
+            .then((payload: OktaJwtVerifierReturn) => {
+                if (payload.claims.scp.includes('email')) { 
+                    // We have found the email address claim, so we are going to return the email address which is the id we want.
+                    return payload.claims.sub; 
+                } else {
+                    // We have passed authentication but we didn't pass the scope check
+                    return "1234567890";
+                }
+            }); 
+        } catch (error) {
+            return null;
+        }
+    } catch (error) {
+        throw error;
+    }
+}
+
+export async function getUserId(headers: HttpRequestHeaders): Promise<Option<string>> {
+    // This function is the front that implement the common interface behind which there is the old (Identity) 
+    // and new (Okta) authentication methods
+    const userId1 = await getUserId_OldIdentity(headers);
+    if (userId1) {
+        return userId1
+    }
+    return await getUserId_NewOkta(headers);
 }

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -70,11 +70,12 @@ async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<UserIdRes
         const ISSUER      = 'https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7'
         const CLIENT_ID   = "0oa4iyjx692Aj8SlZ0x7"
         const expectedAud = "https://profile.code.dev-theguardian.com/";
+        const scope       = "guardian.mobile-purchases-api.update.self"
         
         const oktaJwtVerifier = new OktaJwtVerifier({
             issuer: ISSUER,
             clientId: CLIENT_ID,
-            assertClaims: {'scp.includes': ['email']}
+            assertClaims: {'scp.includes': [scope]}
           });
         
         const accessTokenString = getAuthToken(headers);
@@ -82,7 +83,7 @@ async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<UserIdRes
         try {
             return await oktaJwtVerifier.verifyAccessToken(accessTokenString, expectedAud)
             .then((payload: OktaJwtVerifierReturn) => {
-                if (payload.claims.scp.includes('email')) { 
+                if (payload.claims.scp.includes(scope)) { 
                     // We have found the email address claim
                     // The claims attribute maps to
                     /*

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -1,5 +1,6 @@
 import {HttpRequestHeaders} from "../models/apiGatewayHttp";
 import {restClient} from "./restClient";
+import {Stage} from "../utils/appIdentity";
 
 interface UserId {
     id: string
@@ -51,15 +52,19 @@ async function getUserId_OldIdentity(headers: HttpRequestHeaders): Promise<UserI
 async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<UserIdResolution> {
     try {
         const OktaJwtVerifier = require('@okta/jwt-verifier');
-
-        const ISSUER      = 'https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7'
-        const CLIENT_ID   = "0oa4iyjx692Aj8SlZ0x7"
-        const expectedAud = "https://profile.code.dev-theguardian.com/";
-        const scope       = "guardian.mobile-purchases-api.update.self"
         
+        var ISSUER      = 'https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7'
+        var expectedAud = "https://profile.code.dev-theguardian.com/";
+        var scope       = "guardian.mobile-purchases-api.update.self"
+
+        if (Stage === "PROD") {
+            ISSUER      = 'https://profile.theguardian.com/oauth2/aus3xgj525jYQRowl417'
+            expectedAud = "https://profile.theguardian.com/";
+            scope       = "guardian.mobile-purchases-api.update.self"
+        }
+
         const oktaJwtVerifier = new OktaJwtVerifier({
             issuer: ISSUER,
-            clientId: CLIENT_ID,
           });
         
         const accessTokenString = getAuthToken(headers);

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -75,7 +75,6 @@ async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<UserIdRes
         const oktaJwtVerifier = new OktaJwtVerifier({
             issuer: ISSUER,
             clientId: CLIENT_ID,
-            assertClaims: {'scp.includes': [scope]}
           });
         
         const accessTokenString = getAuthToken(headers);

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -14,7 +14,7 @@ interface IdentityResponse {
 interface OktaJwtVerifierReturn {
     claims : {
         scp: [string],
-        sub: string,
+        legacy_identity_id: string,
     }
 }
 
@@ -84,8 +84,28 @@ async function getUserId_NewOkta(headers: HttpRequestHeaders): Promise<Option<st
             return await oktaJwtVerifier.verifyAccessToken(accessTokenString, expectedAud)
             .then((payload: OktaJwtVerifierReturn) => {
                 if (payload.claims.scp.includes('email')) { 
-                    // We have found the email address claim, so we are going to return the email address which is the id we want.
-                    return payload.claims.sub; 
+                    // We have found the email address claim
+                    // The claims attribute maps to
+                    /*
+                        {
+                            ver: 1,
+                            jti: 'EDITED',
+                            iss: 'https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7',
+                            aud: 'https://profile.code.dev-theguardian.com/',
+                            iat: 1672252869,
+                            exp: 1672256469,
+                            cid: '0oa4iyjx692Aj8SlZ0x7',
+                            uid: '00u38ar4186TSK9j00x7',
+                            scp: [ 'email', 'openid', 'profile' ],
+                            auth_time: 1671029934,
+                            sub: 'EDITED',
+                            identity_username: '',
+                            email_validated: true,
+                            legacy_identity_id: 'EDITED'
+                        }
+                    */
+                    // Let's use the legacy_identity_id
+                    return payload.claims.legacy_identity_id; 
                 } else {
                     // We have passed authentication but we didn't pass the scope check
                     return "1234567890";

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,6 +719,14 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@okta/jwt-verifier@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@okta/jwt-verifier/-/jwt-verifier-2.6.0.tgz#a9a8b3a7e3127de2f729d3a0a4dc1c636d8d7752"
+  integrity sha512-olqN2MWTnVDrLq270x9H4Dz6kOAjg6PsA9Ft9ynP1+CUBEKaCWQKdrXD23nmyDeZaYntVTXPTek7zLzLL5QQ/A==
+  dependencies:
+    jwks-rsa "1.12.3"
+    njwt "^1.2.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -783,6 +791,21 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
@@ -803,6 +826,40 @@
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
+"@types/express-jwt@0.0.42":
+  version "0.0.42"
+  resolved "https://registry.yarnpkg.com/@types/express-jwt/-/express-jwt-0.0.42.tgz#4f04e1fadf9d18725950dc041808a4a4adf7f5ae"
+  integrity sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==
+  dependencies:
+    "@types/express" "*"
+    "@types/express-unless" "*"
+
+"@types/express-serve-static-core@^4.17.31":
+  version "4.17.31"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
+  integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express-unless@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/express-unless/-/express-unless-2.0.1.tgz#7d5728315caf95a315a6bcc19ac99f6a8becbe49"
+  integrity sha512-PJLiNw03EjkWDkQbhNjIXXDLObC3eMQhFASDV+WakFbT8eL7YdjlbV6MXd3Av5Lejq499d6pFuV1jyK+EHyG3Q==
+  dependencies:
+    express-unless "*"
+
+"@types/express@*":
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.15.tgz#9290e983ec8b054b65a5abccb610411953d417ff"
+  integrity sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.31"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
@@ -853,10 +910,20 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/mime@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
 "@types/node@*", "@types/node@^16.0.0":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
   integrity sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
+
+"@types/node@^15.0.1":
+  version "15.14.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
+  integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -867,6 +934,24 @@
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
   integrity sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
+
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/serve-static@*":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
+  integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
+  dependencies:
+    "@types/mime" "*"
+    "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
@@ -1192,6 +1277,13 @@ aws-sdk@^2.1097.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -1341,6 +1433,11 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
@@ -1705,6 +1802,13 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.5:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 electron-to-chromium@^1.3.723:
   version "1.3.763"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.763.tgz#93f6f02506d099941f557b9db9ba50b30215bf15"
@@ -1923,6 +2027,11 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
+express-unless@*:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/express-unless/-/express-unless-2.1.3.tgz#f951c6cca52a24da3de32d42cfd4db57bc0f9a2e"
+  integrity sha512-wj4tLMyCVYuIIKHGt0FhCtIViBcwzWejX0EjNxveAa6dG+0XBCQhMbx+PnkLkFCxLC69qoFrxds4pIyL88inaQ==
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -2003,6 +2112,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@^1.14.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -2940,6 +3054,55 @@ json5@2.x, json5@^2.1.2:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jwks-rsa@1.12.3:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-1.12.3.tgz#40232f85d16734cb82837f38bb3e350a34435400"
+  integrity sha512-cFipFDeYYaO9FhhYJcZWX/IyZgc0+g316rcHnDpT2dNRNIE/lMOmWKKqp09TkJoYlNFzrEVODsR4GgXJMgWhnA==
+  dependencies:
+    "@types/express-jwt" "0.0.42"
+    axios "^0.21.1"
+    debug "^4.1.0"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    jsonwebtoken "^8.5.1"
+    limiter "^1.1.5"
+    lru-memoizer "^2.1.2"
+    ms "^2.1.2"
+    proxy-from-env "^1.1.0"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2982,6 +3145,11 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+limiter@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
+  integrity sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -3008,6 +3176,46 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
+
 lodash@4.x, lodash@^4.17.13, lodash@^4.17.19, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -3019,6 +3227,22 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@~4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  integrity sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==
+  dependencies:
+    pseudomap "^1.0.1"
+    yallist "^2.0.0"
+
+lru-memoizer@^2.1.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-2.1.4.tgz#b864d92b557f00b1eeb322156a0409cb06dafac6"
+  integrity sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==
+  dependencies:
+    lodash.clonedeep "^4.5.0"
+    lru-cache "~4.0.0"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -3163,6 +3387,11 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+ms@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -3194,6 +3423,15 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+njwt@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/njwt/-/njwt-1.2.0.tgz#1badf085fba3fd00abb70ed6c8f00246c6f46fa4"
+  integrity sha512-i+cdqwxo7EUimJCHPSAEpQEWrz4ilsVefL+FRhWrjMqq8HHiQ8dwi9GUWUfj3Vt6XMY2PXSjMn9JeVB3/Jp6pg==
+  dependencies:
+    "@types/node" "^15.0.1"
+    ecdsa-sig-formatter "^1.0.5"
+    uuid "^8.3.2"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3459,10 +3697,20 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+pseudomap@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 psl@^1.1.33:
   version "1.8.0"
@@ -3643,7 +3891,7 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-safe-buffer@^5.1.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3706,7 +3954,7 @@ schema-utils@^3.0.0, schema-utils@^3.1.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4277,7 +4525,7 @@ uuid@^3.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -4511,6 +4759,11 @@ y18n@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+
+yallist@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
We upgrade the authentication mechanism used for the two mobile subscription links:

- https://mobile-purchases.mobile-aws.guardianapis.com/apple/linkToSubscriptions
- https://mobile-purchases.mobile-aws.guardianapis.com/google/linkToSubscriptions

to support the new Okta authentication. 

Note the two requirements:

1. The code should support both the old tokens and the new Okta token. 
2. In addition of returning 200 for valid requests and 401 for unauthorised requests, we now must also return 403 for forbidden requests corresponding to correct tokens but incorrect scopes. 

(2.) lead to the introduction of the type `UserIdResolution` which carries the information required to return the code code. 

