### PR TITLE
Upgrade simple config from 1.5.5 to 1.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import scala.collection.immutable
 
 val testAndCompileDependencies: String = "test->test;compile->compile"
 val awsVersion: String = "1.11.375"
-val simpleConfigurationVersion: String = "1.5.5"
+val simpleConfigurationVersion: String = "1.5.7"
 
 val jacksonData: String = "2.13.3"
 

--- a/scala/google-oauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
+++ b/scala/google-oauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
@@ -48,7 +48,7 @@ object GoogleOAuth {
       case Success(identity) => ConfigurationLoader.load(identity, credentialsProvider) {
         case AwsIdentity(_, _, stage, _) => SSMConfigurationLocation(s"/mobile-purchases/$stage/google-oauth-lambda", "eu-west-1")
       }
-      case Failure(_) => throw new Exception("Could not retrieve configuration")
+      case Failure(cause) => throw new Exception(s"Could not fetch configuration, cause: ${cause.getMessage}")
     }
   }
 

--- a/scala/google-oauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
+++ b/scala/google-oauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
@@ -1,7 +1,6 @@
 package com.gu.mobilepurchases.googleoauth.lambda
 
 import java.io.{ ByteArrayInputStream, InputStream, OutputStream }
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.PutObjectResult
@@ -10,7 +9,7 @@ import com.gu.conf.{ ConfigurationLoader, SSMConfigurationLocation }
 import com.gu.{ AppIdentity, AwsIdentity }
 import com.typesafe.config.Config
 import org.apache.logging.log4j.LogManager
-
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import scala.util.{ Failure, Success, Try }
 
 object GoogleOAuth {
@@ -44,9 +43,12 @@ object GoogleOAuth {
   }
 
   def fetchConfiguration(): Config = {
-    val identity = AppIdentity.whoAmI(defaultAppName = "google-oauth-lambda")
-    ConfigurationLoader.load(identity) {
-      case AwsIdentity(_, _, stage, _) => SSMConfigurationLocation(s"/mobile-purchases/$stage/google-oauth-lambda")
+    val credentialsProvider = DefaultCredentialsProvider.create()
+    AppIdentity.whoAmI(defaultAppName = "google-oauth-lambda", credentialsProvider) match {
+      case Success(identity) => ConfigurationLoader.load(identity, credentialsProvider) {
+        case AwsIdentity(_, _, stage, _) => SSMConfigurationLocation(s"/mobile-purchases/$stage/google-oauth-lambda", "eu-west-1")
+      }
+      case Failure(_) => throw new Exception("Could not retrieve configuration")
     }
   }
 


### PR DESCRIPTION
## What does this change?

We are currently in the process of trying to get rid of a high vulnerability in io.netty:netty-codec, which is a dependency of com.gu:simple-configuration.

As a stepping stone we upgrade com.gu:simple-configuration from 1.5.5 to 1.5.7.
