### PR TITLE
Bump google-auth-library-oauth2-http to 1.15.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val googleOauth = project.in(scalaRoot / "google-oauth").enablePlugins(Asse
   .settings(
     commonAssemblySettings("google-oauth"),
     libraryDependencies ++= List(
-    "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0",
+    "com.google.auth" % "google-auth-library-oauth2-http" % "0.27.0",
     "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonData
     )

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val googleOauth = project.in(scalaRoot / "google-oauth").enablePlugins(Asse
   .settings(
     commonAssemblySettings("google-oauth"),
     libraryDependencies ++= List(
-    "com.google.auth" % "google-auth-library-oauth2-http" % "0.27.0",
+    "com.google.auth" % "google-auth-library-oauth2-http" % "1.15.0",
     "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonData
     )


### PR DESCRIPTION
## What does this change?

Bump com.google.auth.google-auth-library-oauth2-http from 0.20.0 to 1.15.0

Breaking changes
@ 1.0.0 updated Java min version to 1.8
