### PR TITLE
Bump scala to version 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,14 +108,13 @@ def commonSettings(module: String): immutable.Seq[Def.Setting[_]] = {
     organization := "com.gu",
     description := "Validate Receipts",
     version := "1.0",
-    scalaVersion := "2.12.17",
+    scalaVersion := "2.13.0",
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding", "UTF-8",
       "-target:jvm-1.8",
       "-Ywarn-dead-code",
       "-Xfatal-warnings",
-      "-Ypartial-unification"
     )
 
   )

--- a/build.sbt
+++ b/build.sbt
@@ -108,11 +108,10 @@ def commonSettings(module: String): immutable.Seq[Def.Setting[_]] = {
     organization := "com.gu",
     description := "Validate Receipts",
     version := "1.0",
-    scalaVersion := "2.13.0",
+    scalaVersion := "2.13.10",
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding", "UTF-8",
-      "-target:jvm-1.8",
       "-Ywarn-dead-code",
       "-Xfatal-warnings",
     )

--- a/scala/common/src/main/scala/com/gu/mobilepurchases/shared/cloudwatch/Cloudwatch.scala
+++ b/scala/common/src/main/scala/com/gu/mobilepurchases/shared/cloudwatch/Cloudwatch.scala
@@ -29,8 +29,8 @@ trait CloudWatchPublisher {
 trait CloudWatch extends CloudWatchMetrics with CloudWatchPublisher
 
 sealed class Timer(metricName: String, cloudWatch: CloudWatchMetrics, start: Instant = Instant.now()) {
-  def succeed = cloudWatch.queueMetric(s"$metricName-success", Duration.between(start, Instant.now()).toMillis, StandardUnit.Milliseconds, start)
-  def fail = cloudWatch.queueMetric(s"$metricName-fail", Duration.between(start, Instant.now()).toMillis, StandardUnit.Milliseconds, start)
+  def succeed = cloudWatch.queueMetric(s"$metricName-success", Duration.between(start, Instant.now()).toMillis.toDouble, StandardUnit.Milliseconds, start)
+  def fail = cloudWatch.queueMetric(s"$metricName-fail", Duration.between(start, Instant.now()).toMillis.toDouble, StandardUnit.Milliseconds, start)
 
 }
 
@@ -55,7 +55,7 @@ class CloudWatchImpl(stage: String, lambdaname: String, cw: AmazonCloudWatchAsyn
       val request: PutMetricDataRequest = new PutMetricDataRequest()
         .withNamespace(s"mobile-purchases/$stage/$lambdaname")
         .withMetricData(bufferOfMetrics)
-      val promise: Promise[PutMetricDataResult] = Promise[PutMetricDataResult]
+      val promise: Promise[PutMetricDataResult] = Promise[PutMetricDataResult]()
       val value: AsyncHandler[PutMetricDataRequest, PutMetricDataResult] = new AsyncHandler[PutMetricDataRequest, PutMetricDataResult] {
         override def onError(exception: Exception): Unit = promise.failure(exception)
         override def onSuccess(request: PutMetricDataRequest, result: PutMetricDataResult): Unit = {

--- a/scala/google-oauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
+++ b/scala/google-oauth/src/main/scala/com.gu.mobilepurchases.googleoauth/lambda/GoogleOAuth.scala
@@ -36,7 +36,7 @@ object GoogleOAuth {
 
   def refreshToken: Try[AccessToken] = Try {
     val credentials = GoogleCredentials
-      .fromStream(new ByteArrayInputStream(fetchConfiguration.getString("google.serviceAccountJson").getBytes))
+      .fromStream(new ByteArrayInputStream(fetchConfiguration().getString("google.serviceAccountJson").getBytes))
       .createScoped("https://www.googleapis.com/auth/androidpublisher")
     credentials.refresh()
     credentials.getAccessToken


### PR DESCRIPTION
Bump scala to version `2.13.10`. 

Notes:

- `-Ypartial-unification` is deprecated.
- No need to specifically target `jvm-1.8`
- We can no longer rely on auto application. 