### PR TITLE
Update the exportHistoricalData handler's output 

### DIFF
--- a/typescript/src/export/exportHistoricalData.ts
+++ b/typescript/src/export/exportHistoricalData.ts
@@ -114,5 +114,5 @@ export async function handler(params: {date: string, maxMessagesToFetch?: number
     await deleteAllSqsMessages(sqsUrl, msgToDelete);
     console.log(`Deleted ${msgToDelete.length} messages from the SQS queue`);
 
-    return {date: yesterday, recordCount: totalMsgCount};
+    return {date: yesterday, recordCount: totalMsgCount, processedCount: processedMsgCount};
 }

--- a/typescript/src/export/exportHistoricalData.ts
+++ b/typescript/src/export/exportHistoricalData.ts
@@ -114,5 +114,5 @@ export async function handler(params: {date: string, maxMessagesToFetch?: number
     await deleteAllSqsMessages(sqsUrl, msgToDelete);
     console.log(`Deleted ${msgToDelete.length} messages from the SQS queue`);
 
-    return {recordCount: totalMsgCount};
+    return {date: yesterday, recordCount: totalMsgCount};
 }


### PR DESCRIPTION
## What does this change?

Update the exportHistoricalData handler's output to indicate which date was actually extracted as well as how many messages were actually processed. This is useful when running the lambda manually. 

Before:

```
{
  "recordCount": 7912
}
```

After:

```
{
  "date": "2023-02-13",
  "recordCount": 7912,
  "processedCount": 7912
}
```