### PR TITLE
add support for salesforce user api key

### DIFF
--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -75,9 +75,9 @@ async function getSubscriptions(subscriptionIds: string[]) : Promise<Subscriptio
 
 async function apiKeysConfig(): Promise<string[]> {
     // returning an array just in case we get more than one client one day
-    const apiKey1Default = await getConfigValue<string>("user.api-key.0");
-    const apiKey2Salesforce = await getConfigValue<string>("user.api-key.1.salesforce");
-    return [apiKey1Default, apiKey2Salesforce]
+    const apiKey0Default = await getConfigValue<string>("user.api-key.0");
+    const apiKey1Salesforce = await getConfigValue<string>("user.api-key.1.salesforce");
+    return [apiKey0Default, apiKey1Salesforce]
 }
 
 export async function handler(httpRequest: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {


### PR DESCRIPTION
## What does this change?

Saleforce has requested access to the endpoint `user/subscriptions/{userid}`. There are two ways to access to it, either using an identity user authentication token (possibly one of the new Okta tokens), or using a predefined API key. We also have one of those keys available for general use, but we will be defining a new one just for salesforce. This implies making sure that the authentication work correctly with more than one key, in this case with a second key. 

This is a small change because the code already was written with this extension in mind. 

The new Saleforce key will only be valid for `user/subscriptions/{userid}`, and not the rest of mobile-purchases. 