### PR TITLE
refactor apple.ts

### DIFF
--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -1,35 +1,10 @@
 import 'source-map-support/register'
-import {Platform} from "../models/platform";
+
 import {parseAndStoreLink, SubscriptionCheckData} from "./link";
 import {UserSubscription} from "../models/userSubscription";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
-
-type AppleSubscription = {
-    receipt: string
-    originalTransactionId: string
-}
-
-type AppleLinkPayload = {
-    platform: Platform.DailyEdition | Platform.Ios | Platform.IosPuzzles | Platform.IosEdition,
-    subscriptions: AppleSubscription[]
-}
-
-function deduplicate<T, U>(list: T[], selector: (item: T) => U): T[] {
-    return list.reduce<T[]>(
-        (agg, item) =>
-            agg.some((x) => selector(x) === selector(item)) ?
-                agg : agg.concat([item]), 
-        []
-    )
-}
-
-export function parseAppleLinkPayload(request: APIGatewayProxyEvent): AppleLinkPayload {
-    const parsed = JSON.parse(request.body ?? "") as AppleLinkPayload;
-    return {
-        ...parsed,
-        subscriptions: deduplicate(parsed.subscriptions, x => x.originalTransactionId)
-    }
-}
+import {parseAppleLinkPayload} from "./apple-utils"
+import {AppleLinkPayload} from "./apple-utils"
 
 function toUserSubscription(userId: string, payload: AppleLinkPayload): UserSubscription[] {
     const now = new Date().toISOString()

--- a/typescript/tests/link/apple.test.ts
+++ b/typescript/tests/link/apple.test.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
-import { parseAppleLinkPayload } from "../../src/link/apple"
+import { parseAppleLinkPayload } from "../../src/link/apple-utils"
 
 describe("The apple link service", () => {
   test("Should deduplicate originalTransactionIds", () => {


### PR DESCRIPTION
## What does this change?

In preparation for ( https://github.com/guardian/mobile-purchases/pull/889 ) and to simply understanding of it, here we perform a small invariant refactoring of the apple.ts file (essentially splitting the file into two pieces). The purpose is to prevent `apple.test.ts` from seeing apple.ts' import section, which will cause a problem in the other PR.  