### PR TITLE
move identity api user consent url to parameter store

### DIFF
--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -90,10 +90,9 @@ function consentPayload(): any {
 }
 
 async function postSoftOptInConsentToIdentityAPI(identityId: string, identityApiKey: string): Promise<boolean> {
-    var url = `https://idapi.code.dev-theguardian.com/users/${identityId}/consents`
-    if (Stage === "PROD") {
-        url = `https://idapi.theguardian.com/users/${identityId}/consents`
-    }
+    const domain = await getConfigValue<string>("mp-soft-opt-in-identity-user-consent-domain-url");
+    const url = `${domain}/users/${identityId}/consents`;
+
     const params = {
         method: 'PATCH',
         body: JSON.stringify(consentPayload()),


### PR DESCRIPTION

We have created two entries in the parameter store for the primary url for identity user consent.

```
key  : /mobile-purchases/CODE/mobile/mp-soft-opt-in-identity-user-consent-domain-url
value: https://idapi.code.dev-theguardian.com

key  : /mobile-purchases/PROD/mobile/mp-soft-opt-in-identity-user-consent-domain-url
value: https://idapi.theguardian.com
```

We can then refactor the code with a call to `getConfigValue`. 