### PR TITLE
Deploy new stream specification to prod 2

### DIFF
--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -103,7 +103,7 @@ Resources:
         Enabled: true
         AttributeName: ttl
       StreamSpecification:
-        StreamViewType: KEYS_ONLY
+        StreamViewType: NEW_AND_OLD_IMAGES
       GlobalSecondaryIndexes:
         - IndexName: ios-endTimestamp-revalidation-index
           KeySchema:


### PR DESCRIPTION
Part of the [soft opt ins for IAP's work](https://github.com/guardian/mobile-purchases/pull/952).

As part of the Soft Opt-Ins for IAP's cancellation work, we have to alter a currently active dynamoDB stream. We need to follow an iterative deployment process to production to alter a currently active stream, detailed below:

1. Update the dependent stack(s) (e.g., 'mobile-purchases-${Stage}') to use a temporary value for the DynamoDB stream ARN or remove the dependency temporarily.
2. Update the original stack with the new StreamSpecification for the DynamoDB table.
3. Update the dependent stack(s) again to use the correct DynamoDB stream ARN from the original stack.

This PR adjusts the specification of the currently active dynamoDB stream. It is step 2 in the above process.

**IMPORTANT** 

[This PR](https://github.com/guardian/mobile-purchases/pull/953) must be merged before! 

**The dynamo.cloudformation.yaml must be uploaded manually to the mobile-purchases-dynamo- stack.**