### PR TITLE
Remove lambda artifacts from riffraff deploy

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -99,12 +99,6 @@ deployments:
       functionNames: [mobile-purchases-delete-user-subscription-]
       fileName: delete-user-subscription.zip
 
-  mobile-purchases-soft-opt-in-acquisitions:
-    template: lambda
-    parameters:
-      functionNames: [mobile-purchases-soft-opt-in-acquisitions-]
-      fileName: soft-opt-in-acquisitions.zip
-
   mobile-purchases-exports-cloudformation:
     type: cloud-formation
     parameters:


### PR DESCRIPTION
We recently merged code for a new lambda into main, but are keeping it behind a feature flag for now. It is currently only deployed in CODE. The deploy to main was breaking as riffraff was trying to upload the artefacts to the lambda but it doesn't exist. Removing it for now.