### PR TITLE
Remove temporary code that works with two streams

### DIFF
--- a/typescript/src/link/deleteLink.ts
+++ b/typescript/src/link/deleteLink.ts
@@ -23,24 +23,15 @@ async function deleteUserSubscription(subscriptionId: string): Promise<number> {
 
 export async function handler(event: DynamoDBStreamEvent): Promise<any> {
     const ttlEvents = event.Records.filter(dynamoEvent => {
-        /*
-            This is a temporary solution to handle both OLD_KEYS and OLD_AND_NEW_IMAGE
-            stream specifications to avoid anything breaking when deploying the new specification.
-         */
-        const hasKeys = dynamoEvent.dynamodb?.Keys?.subscriptionId;
-        const hasOldImage = dynamoEvent.dynamodb?.OldImage?.subscriptionId;
-
-        console.log(`DynamoDB stream specification, hasOldImage has value: ${hasOldImage}`)
-
         return dynamoEvent.eventName === "REMOVE" &&
             dynamoEvent.userIdentity?.type === "Service" &&
             dynamoEvent.userIdentity?.principalId === "dynamodb.amazonaws.com" &&
-            (hasKeys || hasOldImage)
+            dynamoEvent.dynamodb?.OldImage?.subscriptionId
     });
 
     const subscriptionsPromises = ttlEvents
         // @ts-ignore
-        .map(event => (event.dynamodb.Keys?.subscriptionId.S || event.dynamodb.OldImage?.subscriptionId.S) ?? "")
+        .map(event => event.dynamodb.OldImage.subscriptionId.S ?? "")
         .map(deleteUserSubscription);
 
 


### PR DESCRIPTION
Migration of the new stream specification has completed. We can now exclusively use the `oldImage` property when processing dynamoDB streams.