### PR TITLE
Soft opt ins additional functionality

### DIFF
--- a/typescript/src/link/deleteLink.ts
+++ b/typescript/src/link/deleteLink.ts
@@ -71,11 +71,15 @@ export async function handler(event: DynamoDBStreamEvent): Promise<any> {
 
     console.log(`Processed ${records} records from dynamo stream to delete ${rows} rows`);
 
-    for (const subscriptionId of subscriptionIds) {
-        await disableSoftOptIns(subscriptionId);
-    }
+    const featureFlag = false;
 
-    console.log(`Processed ${records} records from dynamo stream to disable soft opt-ins for ${records} users`);
+    if (featureFlag) {
+        for (const subscriptionId of subscriptionIds) {
+            await disableSoftOptIns(subscriptionId);
+        }
+
+        console.log(`Processed ${records} records from dynamo stream to disable soft opt-ins for ${records} users`);
+    }
 
     return {
         recordCount: records,

--- a/typescript/src/soft-opt-ins/cancelSubscription.ts
+++ b/typescript/src/soft-opt-ins/cancelSubscription.ts
@@ -49,8 +49,8 @@ export async function handler(
 		const cancellationEvents = getCancellationRecords(event);
 		const uncancellationEvents = getUncancellationRecords(event);
 
-		console.log(`${cancellationEvents.length} records to process`);
-		console.log(`${uncancellationEvents.length} records to process`);
+		console.log(`${cancellationEvents.length} cancellation events to process`);
+		console.log(`${uncancellationEvents.length} uncancellation events to process`);
 
 		const membershipAccountId = await getMembershipAccountId();
 		const queueNamePrefix = `https://sqs.${Region}.amazonaws.com/${membershipAccountId}`;
@@ -75,8 +75,8 @@ export async function handler(
 			})
 		}
 
-		console.log(`Processed ${cancellationEvents.length} records`);
-		console.log(`Processed ${uncancellationEvents.length} records`);
+		console.log(`Processed ${cancellationEvents.length} cancellation events`);
+		console.log(`Processed ${uncancellationEvents.length} uncancellation events`);
 	}
 	catch (error) {
 		console.log(error);


### PR DESCRIPTION
We recently merged the V1.5+ functionality for processing acquisitions, post acquisition sign-ins, and cancellations into production (behind a feature flag). This uses DynamoDB streams to forward messages to the soft-opt-in-consent-setter lambda. However, we still need to consider two more scenarios: 

 1. Subscriptions that expired due to payment failure or other reasons (no explicit cancellation) (Processed in the `deleteLink` file)
 2. Uncancellations (Processed in the `cancelSubscription` file)