### PR TITLE
activate soft opt-in

### DIFF
--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -154,7 +154,7 @@ async function updateDynamoLoggingTable(identityId: string) {
     }
 }
 
-const soft_opt_in_v1_active: boolean = false;
+const soft_opt_in_v1_active: boolean = true;
 
 /*
     Date: March 2023, 6th


### PR DESCRIPTION
We switch the guard that was preventing soft opt in (version 1) ( https://github.com/guardian/mobile-purchases/pull/889 ).  

(We could also remove the guard  altogether. This will done in a subsequent refactoring PR.) 