### PR TITLE
Remove sfcontactid from SQS SOI message

### DIFF
--- a/typescript/src/soft-opt-ins/acquisitions.ts
+++ b/typescript/src/soft-opt-ins/acquisitions.ts
@@ -103,7 +103,6 @@ async function processAcquisition(record: DynamoDBRecord): Promise<void> {
                 ContactAttributes: {SubscriberAttributes: {}}
             },
             DataExtensionName: "SV_PA_SOINotification",
-            SfContactId: "",
             IdentityUserId: identityId
         };
 


### PR DESCRIPTION
membership-workflow is breaking because we are including sfcontactid and then it attempts to retrieve the salesforce contact.

I have just tested removing the property and it works