### PR TITLE
Add new lambda bundle to riffraff deploy

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -99,6 +99,12 @@ deployments:
       functionNames: [mobile-purchases-delete-user-subscription-]
       fileName: delete-user-subscription.zip
 
+  mobile-purchases-soft-opt-in-acquisitions:
+    template: lambda
+    parameters:
+      functionNames: [ mobile-purchases-soft-opt-in-acquisitions- ]
+      fileName: soft-opt-in-acquisitions.zip
+
   mobile-purchases-exports-cloudformation:
     type: cloud-formation
     parameters:


### PR DESCRIPTION
We need to add the new acquisition lambda bundle to riffraff.yaml so it updates the S3 bucket with the newly compiled bundle.