### PR TITLE
Fix caching of cross account credentials

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1259,26 +1259,3 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
-
-  failedSettingAcquisitionSoftOptIns:
-    Condition: IsProd
-    Type: AWS::CloudWatch::Alarm
-    DependsOn:
-      - SoftOptInAcquisitionsLambda
-    Properties:
-      AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
-      AlarmName: !Sub ${App}-soft-opt-in-acquisitions-${Stage} failed to set soft opt-ins for a user
-      AlarmDescription: >
-        An error occurred in the SoftOptInAcquisitionsLambda and failed to set soft opt-ins for a user
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: Stage
-          Value: !Sub ${Stage}
-      EvaluationPeriods: 1
-      MetricName: failed_to_send_acquisition_message
-      Namespace: AWS/Lambda
-      Period: 3600
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching


### PR DESCRIPTION
We were getting errors of expired tokens when sending messages to the SQS queues in the `membership` AWS account. The PR adds logic to refresh the client and tokens every 30 minutes.

 I've also added error handling to the SQS calls. The alarm that triggers on the `failed_to_send_acquisition_message` has been removed as we throw an exception for all errors that occur within the lambda, therefore it is redundant.