### PR TITLE
set pubsub logging for payload investigation

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -114,7 +114,6 @@ function parseAppleReceiptInfo(payload: unknown):  Result<string, AppleReceiptIn
     if(!isObject(payload)) {
         return err("The apple receipt info field that Apple gave us isn't an object")
     }
-    // console.log(`The keys of the apple receipt info: ${Object.keys(payload)}`);
     if(typeof payload.transaction_id !== "string") return err("missing field: transaction_id")
     if(typeof payload.product_id !== "string") return err("missing field: product_id")
     if(typeof payload.original_transaction_id !== "string") return err("missing field: original_transaction_id")
@@ -197,7 +196,6 @@ function parsePendingRenewalInfo(payload: unknown):  Result<string, PendingRenew
     if(!isObject(payload)) {
         return err("The apple pending renewal info field that Apple gave us isn't an object")
     }
-    console.log(`The keys of the pending renewal info: ${Object.keys(payload)}`);
     const autoRenewStatus = parseBinaryStatus(payload.auto_renew_status);
     const billingRetryPeriod = parseBillingRetryPeriod(payload.is_in_billing_retry_period);
     const expirationIntent = parseExpirationIntent(payload.expiration_intent);
@@ -236,7 +234,6 @@ function parseUnifiedReceipt(payload: unknown):  Result<string, UnifiedReceiptIn
     if(!isObject(payload)) {
         return err("The unified receipt object that Apple gave us isn't an object")
     }
-    console.log(`The keys of the unified receipt: ${Object.keys(payload)}`);
     const latestReceiptInfo = parseArray(parseAppleReceiptInfo)(payload.latest_receipt_info)
     const pendingRenewalInfo = parseArray(parsePendingRenewalInfo)(payload.pending_renewal_info)
     if(latestReceiptInfo.kind === ResultKind.Err) {
@@ -263,7 +260,6 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
     if(!isObject(payload)) {
         return err("The notification from Apple didn't have any data we can parse")
     }
-    console.log(`The keys of the payload: ${Object.keys(payload)}`);
 
     const unifiedReceipt = parseUnifiedReceipt(payload.unified_receipt);
     if(unifiedReceipt.kind === ResultKind.Err) {
@@ -305,6 +301,7 @@ export function parsePayload(body: Option<string>): Error | StatusUpdateNotifica
         const notification: unknown = JSON.parse(body ?? "");
         const parsedNotification = parseNotification(notification);
         if(parsedNotification.kind === ResultKind.Ok) {
+            console.log(`(ec0a5f83) ${body}`);
             return parsedNotification.value;
         }
         console.log(`debugLogPayload (parse error: ${parsedNotification.err}): ${debugLogPayload(notification)}`)


### PR DESCRIPTION
In this PR:

1. Remove a few old loggings that we no longer need.

2. Add payload logging for the the apple pubsub. We will be investigating those payloads shortly and analyse their contents. 

