### PR TITLE
user lowercase for username in promotional message

### DIFF
--- a/typescript/src/promotional-offers/appleFetchOfferDetails.ts
+++ b/typescript/src/promotional-offers/appleFetchOfferDetails.ts
@@ -46,7 +46,7 @@ async function payloadToResponse(payload: HttpRequestPayload): Promise<Response>
     const keyIdentifier = await getConfigValue<string>("promotional-offers-keyIdentifier");
     const productIdentifier = payload.productIdentifier;
     const offerIdentifier = payload.offerIdentifier;
-    const applicationUsername = payload.username;
+    const applicationUsername = payload.username.toLowerCase();
     const nonce = crypto.randomUUID().toLowerCase();
     const timestamp = Date.now();
 


### PR DESCRIPTION

This updates the change that we made here: https://github.com/guardian/mobile-purchases/pull/1160, for the signature of promotional offers, to enforce a lowercase username. As specified by the documentation: https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/subscriptions_and_offers/generating_a_signature_for_promotional_offers


