### PR TITLE
Additional fields to support subscription IAP changes

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -221,7 +221,9 @@ function parsePendingRenewalInfo(payload: unknown):  Result<string, PendingRenew
         (typeof payload.grace_period_expires_date_ms === "string" || typeof payload.grace_period_expires_date_ms === "undefined") &&
         billingRetryPeriod.kind === ResultKind.Ok &&
         typeof payload.original_transaction_id === "string" &&
-        typeof payload.product_id === "string"
+        typeof payload.product_id === "string" &&
+        typeof payload.price_consent_status === "string" &&
+        typeof payload.price_increase_status === "string"
     ) {
         return ok({
             auto_renew_product_id: payload.auto_renew_product_id,

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -222,7 +222,7 @@ function parsePendingRenewalInfo(payload: unknown):  Result<string, PendingRenew
         billingRetryPeriod.kind === ResultKind.Ok &&
         typeof payload.original_transaction_id === "string" &&
         typeof payload.product_id === "string" &&
-        typeof payload.price_consent_status === "string" &&
+        (typeof payload.price_consent_status === "string" || typeof payload.price_consent_status === "undefined") &&
         typeof payload.price_increase_status === "string"
     ) {
         return ok({

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -230,7 +230,9 @@ function parsePendingRenewalInfo(payload: unknown):  Result<string, PendingRenew
             grace_period_expires_date_ms: payload.grace_period_expires_date_ms,
             is_in_billing_retry_period: billingRetryPeriod.value,
             original_transaction_id: payload.original_transaction_id,
-            product_id: payload.product_id
+            product_id: payload.product_id,
+            price_consent_status: payload.price_consent_status,
+            price_increase_status: payload.price_increase_status
         })
     }
     return err("Pending Renewal Info object from Apple cannot be parsed")

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -14,7 +14,9 @@ export interface PendingRenewalInfo {
     grace_period_expires_date_ms?: string,
     is_in_billing_retry_period?: "0" | "1"
     original_transaction_id: string
-    product_id: string
+    product_id: string,
+    price_consent_status: string,
+    price_increase_status: string
 }
 
 export interface AppleValidatedReceiptServerInfo {

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -15,7 +15,7 @@ export interface PendingRenewalInfo {
     is_in_billing_retry_period?: "0" | "1"
     original_transaction_id: string
     product_id: string,
-    price_consent_status: string,
+    price_consent_status?: string,
     price_increase_status: string
 }
 

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -155,7 +155,9 @@ describe("The apple pubsub", () => {
                             auto_renew_product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial",
                             auto_renew_status: "1",
                             original_transaction_id: "TEST",
-                            product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial"
+                            product_id: "uk.co.guardian.gla.12months.2018Dec.withFreeTrial",
+                            price_consent_status: '',
+                            price_increase_status: '',
                         }
                     ],
                     status: 0

--- a/typescript/tests/services/appleValidateReceipts.test.ts
+++ b/typescript/tests/services/appleValidateReceipts.test.ts
@@ -301,7 +301,9 @@ describe("The apple validation service", () => {
                     original_transaction_id: '1235',
                     is_in_billing_retry_period: '0',
                     product_id: 'uk.co.guardian.gla.6months.2018May.withFreeTrial',
-                    auto_renew_status: '0'
+                    auto_renew_status: '0',
+                    price_consent_status: '',
+                    price_increase_status: '',
                 },
                 {
                     expiration_intent: '1',
@@ -309,7 +311,9 @@ describe("The apple validation service", () => {
                     original_transaction_id: '1236',
                     is_in_billing_retry_period: '0',
                     product_id: 'uk.co.guardian.gla.6months.2018May.withFreeTrial',
-                    auto_renew_status: '1'
+                    auto_renew_status: '1',
+                    price_consent_status: '',
+                    price_increase_status: '',
                 }
             ]
         };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adding 2 new fields to the `pending_renewal_info` object, which ultimately emits to the `ophan-raw-mobile-subscription-historical-apple` S3 bucket:

- price_consent_status
- price_increase_status

See their definitions in the Apple documentation: https://developer.apple.com/documentation/appstorereceipts/responsebody/pending_renewal_info

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Deploy today. Check that the S3 bucket tomorrow contains these fields. Ideally all JSON entries should now have the new `price_increase_status` field with "0" value.


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The Data Platform `raw.mobile_subscription_historical_apple` is able to inherit this data

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
The record could become unparsable via `raw.mobile_subscription_historical_apple` with crossed-over fields, although surely no JSON parser expects the fields to be in a certain order?!


## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="790" alt="Screenshot 2023-09-28 at 16 01 50" src="https://github.com/guardian/mobile-purchases/assets/1515970/2389e3de-8f43-4260-8351-4322a7056d17">


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
