### PR TITLE
build: fix CI build by using guardian/actions-riff-raff@v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,34 +5,86 @@ on: [push]
 jobs:
   CI:
     runs-on: ubuntu-latest
+
     permissions:
       id-token: write
       contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
           cache: yarn
+
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
           distribution: corretto
           java-version: 11
           cache: sbt
-      - name: Build and Test TypeScript
+
+      - name: Test and Build TypeScript
         run: ./build-tc.sh
-      - name: Build and Test Scala
-        run: sbt -v +test
-      - name: Assume AWS Role
+
+      - name: Test and Build Scala
+        run: sbt test assembly
+
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
-      - name: Clean, Compile and Upload to Riff-Raff
-        run: |
-          LAST_TEAMCITY_BUILD=2740
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt clean compile riffRaffUpload
+
+      - name: Upload to Riff-Raff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: Mobile::mobile-purchases
+          buildNumberOffset: 2740
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            mobile-purchases-cloudformation:
+              - cloudformation.yaml
+            mobile-purchases-exports-cloudformation:
+              - exports-cloudformation.yaml
+            mobile-purchases-google-oauth:
+              - scala/google-oauth/target/scala-2.12/mobile-purchases-google-oauth.jar
+            mobile-purchases-apple-fetch-offer-details:
+              - tsc-target/apple-fetch-offer-details.zip
+            mobile-purchases-apple-link-user-subscription:
+              - tsc-target/apple-link-user-subscription.zip
+            mobile-purchases-apple-pubsub:
+              - tsc-target/apple-pubsub.zip
+            mobile-purchases-apple-revalidate-receipts:
+              - tsc-target/apple-revalidate-receipts.zip
+            mobile-purchases-apple-subscription-status:
+              - tsc-target/apple-subscription-status.zip
+            mobile-purchases-apple-update-subscriptions:
+              - tsc-target/apple-update-subscriptions.zip
+            mobile-purchases-delete-user-subscription:
+              - tsc-target/delete-user-subscription.zip
+            mobile-purchases-export-historical-data:
+              - tsc-target/export-historical-data.zip
+            mobile-purchases-export-subscription-events-table:
+              - tsc-target/export-subscription-events-table.zip
+            mobile-purchases-export-subscription-table-v2:
+              - tsc-target/export-subscription-table-v2.zip
+            mobile-purchases-export-subscription-tables:
+              - tsc-target/export-subscription-tables.zip
+            mobile-purchases-google-link-user-subscription:
+              - tsc-target/google-link-user-subscription.zip
+            mobile-purchases-google-pubsub:
+              - tsc-target/google-pubsub.zip
+            mobile-purchases-google-subscription-status:
+              - tsc-target/google-subscription-status.zip
+            mobile-purchases-google-update-subscriptions:
+              - tsc-target/google-update-subscriptions.zip
+            mobile-purchases-soft-opt-in-acquisitions-dlq-processor:
+              - tsc-target/soft-opt-in-acquisitions-dlq-processor.zip
+            mobile-purchases-soft-opt-in-acquisitions:
+              - tsc-target/soft-opt-in-acquisitions.zip
+            mobile-purchases-user-subscriptions:
+              - tsc-target/user-subscriptions.zip

--- a/build.sbt
+++ b/build.sbt
@@ -34,36 +34,11 @@ lazy val googleOauth = project.in(scalaRoot / "google-oauth").enablePlugins(Asse
   .dependsOn(common % testAndCompileDependencies)
 
 lazy val root = project
-  .enablePlugins(RiffRaffArtifact).in(file("."))
+  .in(file("."))
   .aggregate(common, googleOauth)
   .settings(
     fork := true, // was hitting deadlock, found similar complaints online, disabling concurrency helps: https://github.com/sbt/sbt/issues/3022, https://github.com/mockito/mockito/issues/1067
     name := "mobile-purchases",
-    riffRaffPackageType := file(".nothing"),
-    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    riffRaffManifestProjectName := s"Mobile::${name.value}",
-    riffRaffArtifactResources += (googleOauth / assembly).value -> s"${(googleOauth / name).value}/${(googleOauth / assembly).value.getName}",
-    riffRaffArtifactResources += file("tsc-target/google-pubsub.zip") -> s"mobile-purchases-google-pubsub/google-pubsub.zip",
-    riffRaffArtifactResources += file("tsc-target/apple-pubsub.zip") -> s"mobile-purchases-apple-pubsub/apple-pubsub.zip",
-    riffRaffArtifactResources += file("tsc-target/google-subscription-status.zip") -> s"mobile-purchases-google-subscription-status/google-subscription-status.zip",
-    riffRaffArtifactResources += file("tsc-target/apple-subscription-status.zip") -> s"mobile-purchases-apple-subscription-status/apple-subscription-status.zip",
-    riffRaffArtifactResources += file("tsc-target/apple-fetch-offer-details.zip") -> s"mobile-purchases-apple-fetch-offer-details/apple-fetch-offer-details.zip",
-    riffRaffArtifactResources += file("tsc-target/apple-link-user-subscription.zip") -> s"mobile-purchases-apple-link-user-subscription/apple-link-user-subscription.zip",
-    riffRaffArtifactResources += file("tsc-target/google-link-user-subscription.zip") -> s"mobile-purchases-google-link-user-subscription/google-link-user-subscription.zip",
-    riffRaffArtifactResources += file("tsc-target/delete-user-subscription.zip") -> s"mobile-purchases-delete-user-subscription/delete-user-subscription.zip",
-    riffRaffArtifactResources += file("tsc-target/google-update-subscriptions.zip") -> s"mobile-purchases-google-update-subscriptions/google-update-subscriptions.zip",
-    riffRaffArtifactResources += file("tsc-target/apple-update-subscriptions.zip") -> s"mobile-purchases-apple-update-subscriptions/apple-update-subscriptions.zip",
-    riffRaffArtifactResources += file("tsc-target/user-subscriptions.zip") -> s"mobile-purchases-user-subscriptions/user-subscriptions.zip",
-    riffRaffArtifactResources += file("tsc-target/soft-opt-in-acquisitions.zip") -> s"mobile-purchases-soft-opt-in-acquisitions/soft-opt-in-acquisitions.zip",
-    riffRaffArtifactResources += file("tsc-target/soft-opt-in-acquisitions-dlq-processor.zip") -> s"mobile-purchases-soft-opt-in-acquisitions-dlq-processor/soft-opt-in-acquisitions-dlq-processor.zip",
-    riffRaffArtifactResources += file("tsc-target/export-subscription-tables.zip") -> s"mobile-purchases-export-subscription-tables/export-subscription-tables.zip",
-    riffRaffArtifactResources += file("tsc-target/export-subscription-table-v2.zip") -> s"mobile-purchases-export-subscription-table-v2/export-subscription-table-v2.zip",
-    riffRaffArtifactResources += file("tsc-target/export-subscription-events-table.zip") -> s"mobile-purchases-export-subscription-events-table/export-subscription-events-table.zip",
-    riffRaffArtifactResources += file("tsc-target/export-historical-data.zip") -> s"mobile-purchases-export-historical-data/export-historical-data.zip",
-    riffRaffArtifactResources += file("tsc-target/apple-revalidate-receipts.zip") -> s"mobile-purchases-apple-revalidate-receipts/apple-revalidate-receipts.zip",
-    riffRaffArtifactResources += file("cloudformation.yaml") -> s"mobile-purchases-cloudformation/cloudformation.yaml",
-    riffRaffArtifactResources += file("exports-cloudformation.yaml") -> s"mobile-purchases-exports-cloudformation/exports-cloudformation.yaml",
   )
 
 def commonAssemblySettings(module: String): immutable.Seq[Def.Setting[_]] = commonSettings(module) ++ List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
 addDependencyTreePlugin


### PR DESCRIPTION
## What does this change?

This fixes the CI build, which is currently broken.

The changes include:
- remove [sbt-riffraff-artifact](https://github.com/guardian/sbt-riffraff-artifact) plugin
- remove references to Riff-Raff in the `build.sbt` file
- use [guardian/actions-riff-raff@v2](https://github.com/guardian/actions-riff-raff)

## How to test

- Create a new branch
- Make a change to this file "cloudformation.yaml"
- Push your branch to GitHub
- Deploy your branch to CODE
- Check the CloudFormation stack has been updated

## How can we measure success?

Developers can deploy without problems.

