### PR TITLE
Set PendingRenewalInfo.price_increase_status as optional

### DIFF
--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -223,7 +223,7 @@ function parsePendingRenewalInfo(payload: unknown):  Result<string, PendingRenew
         typeof payload.original_transaction_id === "string" &&
         typeof payload.product_id === "string" &&
         (typeof payload.price_consent_status === "string" || typeof payload.price_consent_status === "undefined") &&
-        typeof payload.price_increase_status === "string"
+        (typeof payload.price_increase_status === "string" || typeof payload.price_increase_status === "undefined")
     ) {
         return ok({
             auto_renew_product_id: payload.auto_renew_product_id,

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -16,7 +16,7 @@ export interface PendingRenewalInfo {
     original_transaction_id: string
     product_id: string,
     price_consent_status?: string,
-    price_increase_status: string
+    price_increase_status?: string
 }
 
 export interface AppleValidatedReceiptServerInfo {


### PR DESCRIPTION
When we did this PR ( https://github.com/guardian/mobile-purchases/pull/1184 ), to update the `AppleReceiptInfo` type with two additional field, we set up `offer_code_ref_name` as mandatory. This was a mistake because they are optionals. (The Apple documentation seems to take the convention that unless specifically declared as mandatory any field is optional). 

Here we update `AppleReceiptInfo` to set `offer_code_ref_name` as optional. 
 