### PR TITLE
upgrade simple-configuration-ssm to version 1.6.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import scala.collection.immutable
 
 val testAndCompileDependencies: String = "test->test;compile->compile"
 val awsVersion: String = "1.11.375"
-val simpleConfigurationVersion: String = "1.5.8"
+val simpleConfigurationVersion: String = "1.6.2"
 
 val jacksonData: String = "2.13.3"
 


### PR DESCRIPTION
Get rid of io.netty:netty-codec-http2 Denial of Service (DoS)
Introduced by com.gu:simple-configuration-core_2.12@1.5.8