### PR TITLE
Upgrade SubscriptionEvent for Promotional Offers

### DIFF
--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -25,6 +25,16 @@ export class SubscriptionEvent {
     applePayload?: any;
     @attribute()
     ttl: number;
+    @attribute()
+    promotional_offer_id: string | null;
+    @attribute()
+    promotional_offer_name: string | null;
+    @attribute()
+    product_id: string;
+    @attribute()
+    purchase_date_ms: number;
+    @attribute()
+    expires_date_ms: number;
 
     constructor(
         subscriptionId: string,
@@ -37,7 +47,12 @@ export class SubscriptionEvent {
         freeTrial: boolean | undefined,
         googlePayload: any,
         applePayload: any,
-        ttl: number
+        ttl: number,
+        promotional_offer_id: string | null,
+        promotional_offer_name: string | null,
+        product_id: any,
+        purchase_date_ms: any,
+        expires_date_ms: any
     ) {
         this.subscriptionId = subscriptionId;
         this.timestampAndType = timestampAndType;
@@ -50,6 +65,11 @@ export class SubscriptionEvent {
         this.googlePayload = googlePayload;
         this.applePayload = applePayload;
         this.ttl = ttl;
+        this.promotional_offer_id = promotional_offer_id;
+        this.promotional_offer_name = promotional_offer_name;
+        this.product_id = product_id;
+        this.purchase_date_ms = purchase_date_ms;
+        this.expires_date_ms = expires_date_ms
     }
 
     get [DynamoDbTable]() {
@@ -59,6 +79,6 @@ export class SubscriptionEvent {
 
 export class ReadSubscriptionEvent extends SubscriptionEvent {
     constructor() {
-        super("", "", "", "", "", "", "", undefined,{}, {}, 0);
+        super("", "", "", "", "", "", "", undefined,{}, {}, 0, "", "", "", 0, 0);
     }
 }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -356,7 +356,12 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         freeTrial,
         null,
         notification,
-        dateToSecondTimestamp(thirtyMonths(now))
+        dateToSecondTimestamp(thirtyMonths(now)),
+        "[*] promotional_offer_id",
+        "[*] promotional_offer_name",
+        "[*] product_id",
+        1009,
+        1010
     );
 }
 

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -345,6 +345,26 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
     // The Guardian's "free trial" period definition is slightly different from Apple, hence why we test for is_in_intro_offer_period
     const freeTrial = sortByExpiryDate[0].is_trial_period === "true" || sortByExpiryDate[0].is_in_intro_offer_period === "true";
 
+    const extractPromotionalOfferId = (notification: StatusUpdateNotification): string => {
+        return "[2] extractPromotionalOfferId";
+    }
+
+    const extractPromotionalOfferName = (notification: StatusUpdateNotification): string => {
+        return "[2] promotional_offer_name";
+    }
+
+    const extractProductId = (notification: StatusUpdateNotification): string => {
+        return "[2] product_id";
+    }
+
+    const purchaseDateMs = (notification: StatusUpdateNotification): number => {
+        return 0;
+    }
+
+    const expiresDateMs = (notification: StatusUpdateNotification): number => {
+        return 0;
+    }
+
     return new SubscriptionEvent(
         sortByExpiryDate[0].original_transaction_id,
         now.toISOString() + "|" + eventType,
@@ -355,13 +375,13 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
         notification.bid,
         freeTrial,
         null,
-        notification,
+        notification, // applePayload
         dateToSecondTimestamp(thirtyMonths(now)),
-        "[*] promotional_offer_id",
-        "[*] promotional_offer_name",
-        "[*] product_id",
-        1009,
-        1010
+        extractPromotionalOfferId(notification),   // SubscriptionEvent.promotional_offer_id
+        extractPromotionalOfferName(notification), // SubscriptionEvent.promotional_offer_name
+        extractProductId(notification),            // SubscriptionEvent.product_id
+        purchaseDateMs(notification),              // SubscriptionEvent.purchase_date_ms
+        expiresDateMs(notification)                // SubscriptionEvent.expires_date_ms
     );
 }
 

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -366,6 +366,7 @@ export function toSqsSubReference(event: StatusUpdateNotification): AppleSubscri
 }
 
 export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult>  {
+    console.log(`[23ad7cb3] ${JSON.stringify(request)}`);
     return parseStoreAndSend(
         request,
         parsePayload,

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -271,6 +271,8 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
         return err("The notification from Apple didn't have any data we can parse")
     }
 
+    console.log(`[512f4ed7] ${JSON.stringify(payload)}`);
+
     const unifiedReceipt = parseUnifiedReceipt(payload.unified_receipt);
     if(unifiedReceipt.kind === ResultKind.Err) {
         return unifiedReceipt

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -283,23 +283,42 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
         return unifiedReceipt
     }
 
-    const extractPromotionalOfferId = (payload: unknown): string => {
-        return "[1650] promotional_offer_id"
+    const extractPromotionalOfferId = (unifiedReceipt: UnifiedReceiptInfo): string | null => {
+        if (unifiedReceipt.latest_receipt_info.length > 0) {
+            return unifiedReceipt.latest_receipt_info[0].promotional_offer_id || null;
+        }
+        return null;
     }
 
-    const extractPromotionalOfferName = (payload: unknown): string => {
-        return "[1650] promotional_offer_name";
+    const extractPromotionalOfferName = (unifiedReceipt: UnifiedReceiptInfo): string | null => {
+        // essentially return the first product id and empty string if it could not be found
+        // This should be corrected, but I cannot see a promotional offer name
+        if (unifiedReceipt.latest_receipt_info.length > 0) {
+            return unifiedReceipt.latest_receipt_info[0].offer_code_ref_name || null;
+        }
+        return null;
     }
 
-    const extractProductId = (payload: unknown): string => {
-        return "[1650] product_id";
+    const extractProductId = (unifiedReceipt: UnifiedReceiptInfo): string => {
+        // essentially return the first product id and empty string if it could not be found
+        // This should be corrected, but I cannot see a promotional offer name
+        if (unifiedReceipt.latest_receipt_info.length > 0) {
+            return unifiedReceipt.latest_receipt_info[0].product_id;
+        }
+        return "";
     }
-
-    const purchaseDateMs = (payload: unknown): number => {
+    
+    const purchaseDateMs = (unifiedReceipt: UnifiedReceiptInfo): number => {
+        if (unifiedReceipt.latest_receipt_info.length > 0) {
+            return Number(unifiedReceipt.latest_receipt_info[0].purchase_date_ms || "0");
+        }
         return 0;
     }
 
-    const expiresDateMs = (payload: unknown): number => {
+    const expiresDateMs = (unifiedReceipt: UnifiedReceiptInfo): number => {
+        if (unifiedReceipt.latest_receipt_info.length > 0) {
+            return Number(unifiedReceipt.latest_receipt_info[0].purchase_date_ms || "0");
+        }
         return 0;
     }
 
@@ -329,11 +348,11 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
             auto_renew_product_id: payload.auto_renew_product_id,
             expiration_intent: payload.expiration_intent,
             unified_receipt: unifiedReceipt.value,
-            promotional_offer_id: extractPromotionalOfferId(payload),
-            promotional_offer_name: extractPromotionalOfferName(payload),
-            product_id: extractProductId(payload),
-            purchase_date_ms: purchaseDateMs(payload),
-            expires_date_ms: expiresDateMs(payload)
+            promotional_offer_id: extractPromotionalOfferId(unifiedReceipt.value),
+            promotional_offer_name: extractPromotionalOfferName(unifiedReceipt.value),
+            product_id: extractProductId(unifiedReceipt.value),
+            purchase_date_ms: purchaseDateMs(unifiedReceipt.value),
+            expires_date_ms: expiresDateMs(unifiedReceipt.value)
         })
     }
     return err("Notification from Apple cannot be parsed")

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -102,11 +102,11 @@ export function toDynamoEvent(notification: DeveloperNotification, metaData?: Me
         notification,
         null,
         dateToSecondTimestamp(thirtyMonths(eventTime)),
-        null,      // string | null ; Introduced during the Apple extension of SubscriptionEvent
-        null,      // string | null ; Introduced during the Apple extension of SubscriptionEvent
-        undefined, // any ; Introduced during the Apple extension of SubscriptionEvent
-        undefined, // any ; Introduced during the Apple extension of SubscriptionEvent
-        undefined  // any ; Introduced during the Apple extension of SubscriptionEvent
+        null,      // string | null ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
+        null,      // string | null ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
+        undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
+        undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
+        undefined  // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
     );
 }
 

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -101,7 +101,12 @@ export function toDynamoEvent(notification: DeveloperNotification, metaData?: Me
         metaData?.freeTrial,
         notification,
         null,
-        dateToSecondTimestamp(thirtyMonths(eventTime))
+        dateToSecondTimestamp(thirtyMonths(eventTime)),
+        null,      // string | null ; Introduced during the Apple extension of SubscriptionEvent
+        null,      // string | null ; Introduced during the Apple extension of SubscriptionEvent
+        undefined, // any ; Introduced during the Apple extension of SubscriptionEvent
+        undefined, // any ; Introduced during the Apple extension of SubscriptionEvent
+        undefined  // any ; Introduced during the Apple extension of SubscriptionEvent
     );
 }
 

--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -20,7 +20,6 @@ async function catchingServerErrors(block: () => Promise<APIGatewayProxyResult>)
 }
 
 function storeInDynamoImpl(event: SubscriptionEvent): Promise<SubscriptionEvent> {
-    console.log(`[246ff796] storeInDynamoImpl ${JSON.stringify(event)}`);
     return dynamoMapper.put({item: event}).then(result => result.item);
 }
 
@@ -34,13 +33,11 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
     sendToSqsFunction: (queueUrl: string, event: SqsEvent) => Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> = sendToSqs,
 ): Promise<APIGatewayProxyResult> {
     const secret = process.env.Secret;
-    console.log(`[4ba45228] secret: ${secret}`);
     return catchingServerErrors(async () => {
         if (secret === undefined) {
             console.error("PubSub secret in env is 'undefined'");
             return HTTPResponses.INTERNAL_ERROR
         }
-        console.log(`[4ba45228] request.queryStringParameters?.secret: ${request.queryStringParameters?.secret}`);
         if (request.queryStringParameters?.secret === secret) {
             const notification = parsePayload(request.body);
             if (notification instanceof Error) {
@@ -50,17 +47,11 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
             const queueUrl = process.env.QueueUrl;
             if (queueUrl === undefined) throw new Error("No QueueUrl env parameter provided");
 
-            console.log("[586bc9c6] 07");
             const metaData = await fetchMetadata(notification);
-            console.log("[586bc9c6] 08");
             const dynamoEvent = toDynamoEvent(notification, metaData);
-            console.log("[586bc9c6] 09");
             const dynamoPromise = storeInDynamo(dynamoEvent);
-            console.log("[586bc9c6] 10");
             const sqsEvent = toSqsEvent(notification);
-            console.log("[586bc9c6] 11");
             const sqsPromise = sendToSqsFunction(queueUrl, sqsEvent);
-            console.log("[586bc9c6] 12");
 
             return Promise.all([sqsPromise, dynamoPromise])
                 .then(value => HTTPResponses.OK)

--- a/typescript/src/services/appleValidateReceipts.ts
+++ b/typescript/src/services/appleValidateReceipts.ts
@@ -40,7 +40,7 @@ export interface ValidationOptions {
 // https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html
 // And
 // https://developer.apple.com/documentation/appstoreservernotifications/responsebody
-// Both documentation are equally wrong when compared to the reality, so some of the definition bellow match neither.
+// Both documentation are equally wrong when compared to the reality, so some of the definition below match neither.
 export interface AppleValidationServerResponse {
     auto_renew_status: 0 | 1,
     "is-retryable"?: boolean,

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -53,8 +53,8 @@ function sqsRecordToAppleSubscription(record: SQSRecord): Promise<Subscription[]
 }
 
 export async function handler(event: SQSEvent): Promise<string> {
+    console.log(`[ea8dff7a] ${JSON.stringify(event)}`);
     const promises = event.Records.map( record => parseAndStoreSubscriptionUpdate(record, sqsRecordToAppleSubscription));
-
     return Promise.all(promises)
         .then( _ => "OK");
 }

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -49,7 +49,7 @@ function sqsRecordToAppleSubscription(record: SQSRecord): Promise<Subscription[]
     // sandboxRetry is set to false such that in production we don't store any sandbox receipt that would have snuck all the way here
     // In CODE or locally the default endpoint will be sanbox therefore no retry is necessary
     return validateReceipt(subRef.receipt, {sandboxRetry: false})
-        .then(subs => subs.map(toAppleSubscription))
+        .then(subs => subs.map(toAppleSubscription)) // `subs` here is a AppleValidationResponse[]
 }
 
 export async function handler(event: SQSEvent): Promise<string> {

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -53,7 +53,6 @@ function sqsRecordToAppleSubscription(record: SQSRecord): Promise<Subscription[]
 }
 
 export async function handler(event: SQSEvent): Promise<string> {
-    console.log(`[ea8dff7a] ${JSON.stringify(event)}`);
     const promises = event.Records.map( record => parseAndStoreSubscriptionUpdate(record, sqsRecordToAppleSubscription));
     return Promise.all(promises)
         .then( _ => "OK");

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -14,7 +14,7 @@ async function queueHistoricalSubscription(subscription: Subscription): Promise<
 
     const payload = subscription.googlePayload ?? subscription.applePayload;
     if (payload) {
-        console.log(`[0e22c3c2] ${payload}`);
+        console.log(`[0e22c3c2] ${JSON.stringify(payload)}`);
         await sendToSqs(queueUrl, {
             subscriptionId: subscription.subscriptionId,
             snapshotDate: (new Date()).toISOString(),

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -5,7 +5,6 @@ import {ProcessingError} from "../models/processingError";
 import {GracefulProcessingError} from "../models/GracefulProcessingError";
 
 function putSubscription(subscription: Subscription): Promise<Subscription> {
-    console.log(`[1f085081] ${JSON.stringify(subscription)}`);
     return dynamoMapper.put({item: subscription}).then(result => result.item)
 }
 
@@ -15,7 +14,6 @@ async function queueHistoricalSubscription(subscription: Subscription): Promise<
 
     const payload = subscription.googlePayload ?? subscription.applePayload;
     if (payload) {
-        console.log(`[0e22c3c2] ${JSON.stringify(payload)}`);
         await sendToSqs(queueUrl, {
             subscriptionId: subscription.subscriptionId,
             snapshotDate: (new Date()).toISOString(),

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -14,6 +14,7 @@ async function queueHistoricalSubscription(subscription: Subscription): Promise<
 
     const payload = subscription.googlePayload ?? subscription.applePayload;
     if (payload) {
+        console.log(`[0e22c3c2] ${payload}`);
         await sendToSqs(queueUrl, {
             subscriptionId: subscription.subscriptionId,
             snapshotDate: (new Date()).toISOString(),
@@ -27,7 +28,7 @@ export async function parseAndStoreSubscriptionUpdate(
     fetchSubscriberDetails: (record: SQSRecord) => Promise<Subscription[]>
 ) : Promise<string> {
     try {
-        const subscriptions = await fetchSubscriberDetails(sqsRecord);
+        const subscriptions = await fetchSubscriberDetails(sqsRecord); // Subscription[]
         await Promise.all(subscriptions.map(putSubscription));
         await Promise.all(subscriptions.map(queueHistoricalSubscription));
         console.log(`Processed ${subscriptions.length} subscriptions: ${subscriptions.map(s => s.subscriptionId)}`);

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -5,6 +5,7 @@ import {ProcessingError} from "../models/processingError";
 import {GracefulProcessingError} from "../models/GracefulProcessingError";
 
 function putSubscription(subscription: Subscription): Promise<Subscription> {
+    console.log(`[1f085081] ${JSON.stringify(subscription)}`);
     return dynamoMapper.put({item: subscription}).then(result => result.item)
 }
 

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -148,12 +148,9 @@ export interface SoftOptInEvent {
 
 export async function sendToSqsSoftOptIns(queueUrl: string, event: SoftOptInEvent, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     const membershipSqs = await getSqsClientForSoftOptIns();
-    console.log(`[efb32f83(1)] sendToSqs ${JSON.stringify(event)}`);
-    const messageBody = JSON.stringify(event, (k, v) => v === undefined ? null : v);
-    console.log(`[efb32f83(2)] sendToSqs ${messageBody}`);
     return membershipSqs.sendMessage({
         QueueUrl: queueUrl,
-        MessageBody: messageBody,
+        MessageBody: JSON.stringify(event),
         DelaySeconds: delaySeconds
     }).promise();
 }

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -129,6 +129,9 @@ export async function putMetric(metricName: string, value: number = 1.0): Promis
 }
 
 export function sendToSqs(queueUrl: string, event: any, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
+    console.log(`[fddc199d(1)] sendToSqs ${JSON.stringify(event)}`);
+    const messageBody = JSON.stringify(event, (k, v) => v === undefined ? null : v);
+    console.log(`[fddc199d(2)] sendToSqs ${messageBody}`);
     return sqs.sendMessage({
         QueueUrl: queueUrl,
         MessageBody: JSON.stringify(event),

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -159,12 +159,9 @@ export async function sendToSqsSoftOptIns(queueUrl: string, event: SoftOptInEven
 }
 export async function sendToSqsComms(queueUrl: string, event: any, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     const membershipSqs = await getSqsClientForComms();
-    console.log(`[ac7339f6(1)] sendToSqs ${JSON.stringify(event)}`);
-    const messageBody = JSON.stringify(event, (k, v) => v === undefined ? null : v);
-    console.log(`[ac7339f6(2)] sendToSqs ${messageBody}`);
     return membershipSqs.sendMessage({
         QueueUrl: queueUrl,
-        MessageBody: messageBody,
+        MessageBody: JSON.stringify(event),
         DelaySeconds: delaySeconds
     }).promise();
 }

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -129,7 +129,7 @@ export async function putMetric(metricName: string, value: number = 1.0): Promis
 }
 
 export function sendToSqs(queueUrl: string, event: any, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
-    console.log(`[fddc199d(1)] sendToSqs ${JSON.stringify(event)}`);
+    console.log(`[fddc199d(1)] sendToSqs ${JSON.stringify(event, (k, v) => v === undefined ? "was undefined" : v)}`);
     const messageBody = JSON.stringify(event, (k, v) => v === undefined ? null : v);
     console.log(`[fddc199d(2)] sendToSqs ${messageBody}`);
     return sqs.sendMessage({

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -134,7 +134,7 @@ export function sendToSqs(queueUrl: string, event: any, delaySeconds?: number): 
     console.log(`[fddc199d(2)] sendToSqs ${messageBody}`);
     return sqs.sendMessage({
         QueueUrl: queueUrl,
-        MessageBody: JSON.stringify(event),
+        MessageBody: messageBody,
         DelaySeconds: delaySeconds
     }).promise()
 }

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -129,12 +129,9 @@ export async function putMetric(metricName: string, value: number = 1.0): Promis
 }
 
 export function sendToSqs(queueUrl: string, event: any, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
-    console.log(`[fddc199d(1)] sendToSqs ${JSON.stringify(event, (k, v) => v === undefined ? "was undefined" : v)}`);
-    const messageBody = JSON.stringify(event, (k, v) => v === undefined ? null : v);
-    console.log(`[fddc199d(2)] sendToSqs ${messageBody}`);
     return sqs.sendMessage({
         QueueUrl: queueUrl,
-        MessageBody: messageBody,
+        MessageBody: JSON.stringify(event),
         DelaySeconds: delaySeconds
     }).promise()
 }

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -148,17 +148,23 @@ export interface SoftOptInEvent {
 
 export async function sendToSqsSoftOptIns(queueUrl: string, event: SoftOptInEvent, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     const membershipSqs = await getSqsClientForSoftOptIns();
+    console.log(`[efb32f83(1)] sendToSqs ${JSON.stringify(event)}`);
+    const messageBody = JSON.stringify(event, (k, v) => v === undefined ? null : v);
+    console.log(`[efb32f83(2)] sendToSqs ${messageBody}`);
     return membershipSqs.sendMessage({
         QueueUrl: queueUrl,
-        MessageBody: JSON.stringify(event),
+        MessageBody: messageBody,
         DelaySeconds: delaySeconds
     }).promise();
 }
 export async function sendToSqsComms(queueUrl: string, event: any, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     const membershipSqs = await getSqsClientForComms();
+    console.log(`[ac7339f6(1)] sendToSqs ${JSON.stringify(event)}`);
+    const messageBody = JSON.stringify(event, (k, v) => v === undefined ? null : v);
+    console.log(`[ac7339f6(2)] sendToSqs ${messageBody}`);
     return membershipSqs.sendMessage({
         QueueUrl: queueUrl,
-        MessageBody: JSON.stringify(event),
+        MessageBody: messageBody,
         DelaySeconds: delaySeconds
     }).promise();
 }

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -166,8 +166,13 @@ describe("The apple pubsub", () => {
                         }
                     ],
                     status: 0
-                }
-        };
+                },
+                promotional_offer_id: "promotional_offer_id",
+                promotional_offer_name: "promotional_offer_name",
+                product_id: "product_id",
+                purchase_date_ms: 0,
+                expires_date_ms: 0
+            };
 
         const input: APIGatewayProxyEvent = {
             queryStringParameters: {secret: "MYSECRET"},

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -88,7 +88,12 @@ describe("The google pubsub", () => {
                 version: "1.0"
             },
             null,
-            1582319167
+            1582319167,
+            null,
+            null,
+            undefined,
+            undefined,
+            undefined
         );
 
         const expectedSubscriptionReferenceInSqs = {packageName: "com.guardian.debug", purchaseToken: "PURCHASE_TOKEN", subscriptionId: "my.sku"};


### PR DESCRIPTION
As part of iOS promotional offers (late 2023), we are expecting new attributes to be added to the payload that hit `apple/pubsub` and we want them in the datalake and then Big Query

We know that they will appear in the elements of `[payload].applePayload.unified_receipt.latest_receipt_info`. Essentially moving from 

```
{
    "transaction_id": "[removed]",
    "product_id": "uk.co.guardian.gia.6months",
    "original_transaction_id": "[removed]",
    "web_order_line_item_id": "[removed]",
    "quantity": "1",
    "purchase_date_ms": "1363680291000",
    "original_purchase_date_ms": "1363680294000",
    "expires_date": "2013-09-19 08:04:51 Etc/GMT",
    "expires_date_ms": "1379577891000",
    "is_in_intro_offer_period": "false",
    "is_trial_period": "false"
}
```

to 
 
```
{
    "transaction_id": "[removed]",
    "product_id": "uk.co.guardian.gla.1month.2023Mar.metered",
    "original_transaction_id": "[removed]",
    "web_order_line_item_id": "[removed]",
    "quantity": "1",
    "purchase_date_ms": "1699629642000",
    "original_purchase_date_ms": "1699629644000",
    "expires_date": "2024-02-10 15:20:42 Etc/GMT",
    "expires_date_ms": "1707578442000",
    "is_in_intro_offer_period": "false",
    "is_trial_period": "true",
    "promotional_offer_id": "f9e6f9c5-1f00-4359-9eb8-36de7d98f689",
    "offer_code_ref_name": "NewPhoneSalesUK23"
}
```

While extracting the data we perform the following renaming and type annotation

```
promotional_offer_id -> [idem]                 : string | null
offer_code_ref_name  -> promotional_offer_name : string | null
product_id           -> [idem]                 : string
purchase_date_ms     -> [idem]                 : number
expires_date_ms      -> [idem]                 : number
```

The new values are extracted and put into the object we put into dynamo table: **mobile-purchases-PROD-subscription-events-v2**, and they end up in **ophan-raw-mobile-subscription-events**

Note: This change also comes with guards that prevent very large payloads from erroring in CODE (they have only ever been observed in CODE).
