### PR TITLE
Revert patch to return a stubbed 200

### DIFF
--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -33,17 +33,40 @@ function googlePackageName(headers: HttpRequestHeaders): string {
 
 export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
 
-    const today = new Date()
-    const subscriptionExpiryDate = new Date(today.setMonth(today.getMonth() + 1))
+    const purchaseToken = getPurchaseToken(request.headers);
+    const subscriptionId = getSubscriptionId(request.pathParameters);
+    if (purchaseToken && subscriptionId) {
+        const packageName = googlePackageName(request.headers);
+        console.log(`Searching for valid ${subscriptionId} subscription for Android app with package name: ${packageName}`);
 
-    const responseBody: SubscriptionStatusResponse = {
-        "subscriptionHasLapsed": false,
-        "subscriptionExpiryDate": subscriptionExpiryDate
+        try {
+            const subscription = await fetchGoogleSubscription(subscriptionId, purchaseToken, packageName);
+
+            const subscriptionExpiryDate: Option<Date> = optionalMsToDate(subscription?.expiryTimeMillis);
+            if (subscriptionExpiryDate !== null) {
+                const now: Date = new Date(Date.now());
+                const subscriptionHasLapsed: boolean = now > subscriptionExpiryDate;
+                const responseBody: SubscriptionStatusResponse = {
+                    "subscriptionHasLapsed": subscriptionHasLapsed,
+                    "subscriptionExpiryDate": subscriptionExpiryDate
+                };
+                console.log(`Successfully retrieved subscription details from Play Developer API. Response body will be: ${JSON.stringify(responseBody)}`);
+                return {statusCode: 200, body: JSON.stringify(responseBody)};
+            } else {
+                console.log(`Failed to establish expiry time of subscription`);
+                return HTTPResponses.NOT_FOUND;
+            }
+        } catch (error: any) {
+            if (error.statusCode === 410) {
+                console.log(`Purchase expired a very long time ago`);
+                return HTTPResponses.NOT_FOUND;
+            } else {
+                console.log(`Serving an Internal Server Error due to: ${error.toString().split('/tokens/')[0]}`);
+                return HTTPResponses.INTERNAL_ERROR;
+            }
+        }
+    } else {
+        return HTTPResponses.INVALID_REQUEST;
     }
 
-    console.log("Returning a stub 200 response")
-
-    // We are returning a stubbed response as a temporary workaround to a rate limit issue that
-    // is currently causing a production incident for our Android subscribers.
-    return { statusCode: 200, body: JSON.stringify(responseBody) }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR reverts the changes made in https://github.com/guardian/mobile-purchases/pull/1311, such that normal service can be resumed and the stubbed 200 response is no longer returned.

Changes to both the client of this service and our rate limit with Google mean we are insulated from the issue that necessitated the temporary fix in the linked PR.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
