### PR TITLE
Revert cached subscription status & reinstate stub

### DIFF
--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -7,11 +7,9 @@ import {
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {fetchGoogleSubscription} from "../services/google-play";
 import {optionalMsToDate} from "../utils/dates";
-import {ReadSubscription} from "../models/subscription";
-import {dynamoMapper} from "../utils/aws";
-import {createHash} from 'crypto'
+import {Option} from "../utils/option";
 
-type SubscriptionStatus = {
+interface SubscriptionStatusResponse {
     "subscriptionHasLapsed": boolean
     "subscriptionExpiryDate": Date
 }
@@ -35,68 +33,17 @@ function googlePackageName(headers: HttpRequestHeaders): string {
 
 export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
 
-    const purchaseToken = getPurchaseToken(request.headers);
-    const subscriptionId = getSubscriptionId(request.pathParameters);
-    const packageName = googlePackageName(request.headers);
+    const today = new Date()
+    const subscriptionExpiryDate = new Date(today.setMonth(today.getMonth() + 1))
 
-    if (purchaseToken && subscriptionId) {
-        const purchaseTokenHash = createHash('sha256').update(purchaseToken).digest('hex')
-        console.log(`Searching for valid ${subscriptionId} subscription for Android app with package name: ${packageName}, for purchaseToken hash: ${purchaseTokenHash}`)
-        try {
-            const subscriptionStatus = 
-                await getSubscriptionStatusFromDynamo(purchaseToken, purchaseTokenHash) ?? 
-                await getSubscriptionStatusFromGoogle(subscriptionId, purchaseToken, packageName, purchaseTokenHash)
-            
-            if (subscriptionStatus !== null) {
-                return { statusCode: 200, body: JSON.stringify(subscriptionStatus) }
-            } else {
-                console.log(`No subscription found found for purchaseToken hash: ${purchaseTokenHash}`)
-                return HTTPResponses.NOT_FOUND;
-            }
-        } catch (error: any) {
-            console.log(`Serving an Internal Server Error due to: ${error.toString().split('/tokens/')[0]}`)
-            return HTTPResponses.INTERNAL_ERROR
-        }
-    } else {
-        return HTTPResponses.INVALID_REQUEST
+    const responseBody: SubscriptionStatusResponse = {
+        "subscriptionHasLapsed": false,
+        "subscriptionExpiryDate": subscriptionExpiryDate
     }
-}
 
+    console.log("Returning a stub 200 response")
 
-async function getSubscriptionStatusFromGoogle(subscriptionId: string, purchaseToken: string, packageName: string, purchaseTokenHash: string): Promise<SubscriptionStatus | null> {
-    console.log(`Fetching subscription from Google for purchaseToken hash: ${purchaseTokenHash}`)
-    const subscription = await fetchGoogleSubscription(subscriptionId, purchaseToken, packageName)
-    const subscriptionExpiryDate = optionalMsToDate(subscription?.expiryTimeMillis)
-    const googleSubscriptionStatus = subscriptionExpiryDate ? subscriptionStatus(subscriptionExpiryDate) : null
-    console.log(`Google SubscriptionStatus for purchaseToken hash: ${purchaseTokenHash}: ${JSON.stringify(googleSubscriptionStatus)}`)
-    return googleSubscriptionStatus
-}
-
-async function getSubscriptionStatusFromDynamo(purchaseToken: string, purchaseTokenHash: string): Promise<SubscriptionStatus | null> {
-    try {
-        console.log(`Fetching subscription from Dynamo for purchaseToken hash: ${purchaseTokenHash}`)
-        let itemToQuery = new ReadSubscription()
-        itemToQuery.setSubscriptionId(purchaseToken)
-        const subscription = await dynamoMapper.get(itemToQuery)
-        const subscriptionExpiryDate = new Date(subscription.endTimestamp)
-        const dynamoSubscriptionStatus = subscriptionStatus(subscriptionExpiryDate)
-        console.log(`Dynamo SubscriptionStatus for purchaseToken hash: ${purchaseTokenHash}: ${JSON.stringify(dynamoSubscriptionStatus)}`)
-        return dynamoSubscriptionStatus
-    } catch (error: any) {
-        if (error.name === 'ItemNotFoundException') {
-            console.log(`No subscription found in Dynamo with purchaseToken hash: ${purchaseTokenHash}`)
-        } else {
-            console.log(`The following Dynamo error occurred when attempting to retrieve a subscription with purchaseToken hash: ${purchaseTokenHash}: ${error}`)
-        }
-        // All exceptions are swallowed here as we fall-back on the Google API for all failure modes (including cache misses)
-        return null
-    }
-}
-
-function subscriptionStatus(expiryDate: Date): SubscriptionStatus {
-    const now = new Date(Date.now())
-    return {
-        "subscriptionHasLapsed": now > expiryDate,
-        "subscriptionExpiryDate": expiryDate
-    }
+    // We are returning a stubbed response as a temporary workaround to a rate limit issue that
+    // is currently causing a production incident for our Android subscribers.
+    return { statusCode: 200, body: JSON.stringify(responseBody) }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

**THIS PR HAS BEEN PREPARED IN CASE WE NEED TO ROLLBACK A PRODUCTION FIX. DO NOT MERGE.**

This PR will revert the work to return cached subscription statuses, and reinstate the stubbed response.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
