### PR TITLE
enable automatic backups of mobile purchases dynamo tables

### DIFF
--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -82,6 +82,8 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
+        - Key: devx-backup-enabled
+          Value: true
 
   SubscriptionTable:
     Type: AWS::DynamoDB::Table
@@ -124,6 +126,8 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
+        - Key: devx-backup-enabled
+          Value: true
 
   UserSubscriptionTable:
     Type: AWS::DynamoDB::Table
@@ -162,6 +166,8 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
+        - Key: devx-backup-enabled
+          Value: true
 
 Outputs:
   SubscriptionTableStream:


### PR DESCRIPTION
This adds the `(devx-backup-enabled, true)` key/value pair to 

```
mobile-purchases-CODE-subscriptions
mobile-purchases-PROD-subscriptions
mobile-purchases-CODE-user-subscriptions
mobile-purchases-PROD-user-subscriptions
mobile-purchases-CODE-subscription-events-v2
mobile-purchases-PROD-subscription-events-v2
```

as per request from DevEx. Note that I have also manually applied the tag to the existing tables, this is just to record the tag in the cloud formation