### PR TITLE
feat: turn off point in time recovery for subscription events

### DIFF
--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -68,7 +68,7 @@ Resources:
           Projection:
             ProjectionType: ALL
       PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
+        PointInTimeRecoveryEnabled: false
       BillingMode: PAY_PER_REQUEST
       SSESpecification:
         SSEEnabled: true


### PR DESCRIPTION
## What does this change?

Turns off point in time recovery for a table where we believe it is not required. 

## How can we measure success?

Cost saving on a very large Dynamo table. 

## Have we considered potential risks?

This table is also backed up in 14 nightly snapshots. 
