### PR TITLE
Fix regression in Google subscription status endpoint

### DIFF
--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -50,12 +50,17 @@ export async function handler(request: APIGatewayProxyEvent): Promise<APIGateway
             if (subscriptionStatus !== null) {
                 return { statusCode: 200, body: JSON.stringify(subscriptionStatus) }
             } else {
-                console.log(`No subscription found found for purchaseToken hash: ${purchaseTokenHash}`)
+                console.log(`No subscription found for purchaseToken hash: ${purchaseTokenHash}`)
                 return HTTPResponses.NOT_FOUND;
             }
         } catch (error: any) {
-            console.log(`Serving an Internal Server Error due to: ${error.toString().split('/tokens/')[0]}`)
-            return HTTPResponses.INTERNAL_ERROR
+            if (error.statusCode == 410) {
+                console.log(`No subscription found for purchaseToken hash: ${purchaseTokenHash} (410-Gone from upstream API)`)
+                return HTTPResponses.NOT_FOUND
+            } else {
+                console.log(`Serving an Internal Server Error due to: ${error.toString().split('/tokens/')[0]}`)
+                return HTTPResponses.INTERNAL_ERROR
+            }
         }
     } else {
         return HTTPResponses.INVALID_REQUEST


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The Google (`android-publisher`) API may return a 410 in the case of especially old purchase tokens being used to lookup subscriptions. If this happens, the app expects to receive a 404 from `mobile-purchases`.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Observe in CODE that a 404 is returned in the case of an especially old purchase token being provided.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
