### PR TITLE
Android promotion info is pulled through

### DIFF
--- a/typescript/src/services/google-play.ts
+++ b/typescript/src/services/google-play.ts
@@ -47,7 +47,9 @@ export interface GoogleResponseBody {
     expiryTimeMillis: string,
     userCancellationTimeMillis: string,
     autoRenewing: boolean,
-    paymentState: 0 | 1 | 2 | 3
+    paymentState: 0 | 1 | 2 | 3,
+    promotionType: number,
+    promotionCode: string
 }
 
 export async function fetchGoogleSubscription(subscriptionId: string, purchaseToken: string, packageName: string): Promise<GoogleResponseBody | null> {

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -23,7 +23,7 @@ describe("The google pubsub", () => {
 
         const mockSqsFunction: Mock<Promise<any>, [string, {purchaseToken: string}]> = jest.fn((queurl, event) => Promise.resolve({}));
 
-        const mockFetchMetadataFunction: Mock<Promise<any>> = jest.fn(event => Promise.resolve({freeTrial: true}));
+        const mockFetchMetadataFunction: Mock<Promise<any>> = jest.fn(event => Promise.resolve({freeTrial: true, promotionType: 1, promotionCode: "100"}));
 
         const receivedEvent = {
             "version":"1.0",
@@ -89,8 +89,8 @@ describe("The google pubsub", () => {
             },
             null,
             1582319167,
-            null,
-            null,
+            "100",
+            "VANITY_CODE",
             undefined,
             undefined,
             undefined


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR pulls through the `promotionType` and `promotionCode` fields from Android subscriptions into `SubscriptionEvent`s.

`promotionType`, if present, will be `0` or `1`, mapping respectively to _one time codes_ or _vanity codes_. In the case of a _vanity code_, then `promotionCode` will be present and identify the specific code used.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
