### PR TITLE
Add new global secondary index with platform, to be used by revalidate lambda

### DIFF
--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -93,6 +93,7 @@ Resources:
           Projection:
             NonKeyAttributes:
               - autoRenewing
+              - platform
               - receipt
             ProjectionType: INCLUDE
       Tags:

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -93,6 +93,17 @@ Resources:
           Projection:
             NonKeyAttributes:
               - autoRenewing
+              - receipt
+            ProjectionType: INCLUDE
+        - IndexName: ios-endTimestamp-revalidation-index-with-platform
+          KeySchema:
+            - AttributeName: subscriptionId
+              KeyType: HASH
+            - AttributeName: endTimestamp
+              KeyType: RANGE
+          Projection:
+            NonKeyAttributes:
+              - autoRenewing
               - platform
               - receipt
             ProjectionType: INCLUDE

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -59,7 +59,7 @@ export async function handler(event: ScheduleEvent) {
     const queryScan = dynamoMapper.scan(
         EndTimeStampFilterSubscription,
         {
-            indexName: 'ios-endTimestamp-revalidation-index-with-platform',
+            indexName: 'ios-endTimestamp-revalidation-index',
             filter: filter
         });
 

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -59,7 +59,7 @@ export async function handler(event: ScheduleEvent) {
     const queryScan = dynamoMapper.scan(
         EndTimeStampFilterSubscription,
         {
-            indexName: 'ios-endTimestamp-revalidation-index',
+            indexName: 'ios-endTimestamp-revalidation-index-with-platform',
             filter: filter
         });
 


### PR DESCRIPTION
## What does this change?

When querying for records to revalidate with Apple, we want to exclude Feast records (see #1409). This requires a new index (really I want to change to the existing index, but that isn't possible, so I'll add the new index then remove the old one when it's no longer used).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Deploy to CODE, see the new index in the Dynamo console.

I've also verified it's usable by #1409.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
