### PR TITLE
add apple feast pubsub secret to cloudformation

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -46,7 +46,7 @@ Parameters:
     Type: String
     Description: The secret used by apple's pubsub
     NoEcho: true
-  AppleFeastPubSubSecret:
+  FeastApplePubSubSecret:
     Type: String
     Description: The secret used by apple's pubsub for the feast app
     NoEcho: true
@@ -621,7 +621,7 @@ Resources:
           Stack: !Ref Stack
           App: !Ref App
           QueueUrl: !Ref FeastAppleSubscriptionsQueue
-          Secret: !Ref AppleFeastPubSubSecret
+          Secret: !Ref FeastApplePubSubSecret
       Description: Records app store events for Feast app
       MemorySize: 128
       Timeout: 29

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -44,7 +44,11 @@ Parameters:
     NoEcho: true
   ApplePubSubSecret:
     Type: String
-    Description: The secret used by google's pubsub
+    Description: The secret used by apple's pubsub
+    NoEcho: true
+  AppleFeastPubSubSecret:
+    Type: String
+    Description: The secret used by apple's pubsub for the feast app
     NoEcho: true
   AlarmTopic:
     Type: String
@@ -617,6 +621,7 @@ Resources:
           Stack: !Ref Stack
           App: !Ref App
           QueueUrl: !Ref FeastAppleSubscriptionsQueue
+          Secret: !Ref AppleFeastPubSubSecret
       Description: Records app store events for Feast app
       MemorySize: 128
       Timeout: 29


### PR DESCRIPTION
Adds `FeastApplePubSubSecret` param and sets its value as an environment variable in the Feast pubsub lambda.