### PR TITLE
Feast product name should be `FeastInAppPurchase` in soft-opt-in queue

### DIFF
--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -72,6 +72,8 @@ async function sendSoftOptIns(identityId: string, subscriptionId: string, platfo
         subscriptionId: subscriptionId
     };
 
+    console.log("Attempting to send soft opt-in message to queue", message);
+
     await sendToSqsSoftOptIns(
         Stage === "PROD"
             ? `${queueNamePrefix}/soft-opt-in-consent-setter-queue-PROD`

--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -72,8 +72,6 @@ async function sendSoftOptIns(identityId: string, subscriptionId: string, platfo
         subscriptionId: subscriptionId
     };
 
-    console.log("Attempting to send soft opt-in message to queue", message);
-
     await sendToSqsSoftOptIns(
         Stage === "PROD"
             ? `${queueNamePrefix}/soft-opt-in-consent-setter-queue-PROD`

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -136,10 +136,11 @@ export function sendToSqs(queueUrl: string, event: any, delaySeconds?: number): 
     }).promise()
 }
 
+export type SoftOptInEventProductName = "InAppPurchase" | "FeastInAppPurchase";
 export interface SoftOptInEvent {
     identityId: string;
     eventType: "Acquisition" | "Cancellation" | "Switch";
-    productName: "InAppPurchase";
+    productName: SoftOptInEventProductName
     subscriptionId: string;
 }
 


### PR DESCRIPTION
## What does this change?

The soft-opt-in consents for Feast IAPs are different from other IAPs. In the soft-opt-in-consent-setter lambda the config has been updated to specify the new consents, but that lambda needs to be able to distinguish Feast IAPs from others. So in this PR we start providing a different productName (`FeastInAppPurchase`) for Feast events.

## How to test

I've extended and run the Jest tests. I'll also deploy to CODE and test there.

Update: I've tested in CODE. There's something going on with the cross account role and permissions to add to the queue so the lambda invocation errors, but I logged the message which would be added to the queue and it looks correct for both non-Feast and Feast:

![Screenshot 2024-03-20 at 17 11 23](https://github.com/guardian/mobile-purchases/assets/379839/0ea1cae1-6fca-4b5a-9bba-7de616cb226c)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
