### PR TITLE
Remove unused global secondary index on subscriptions table

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1105,7 +1105,6 @@ Resources:
               Action:
                 - "dynamodb:Scan"
               Resource:
-                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions/index/ios-endTimestamp-revalidation-index
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions/index/ios-endTimestamp-revalidation-index-with-platform
                 - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${App}-${Stage}-subscriptions
         - PolicyName: sqs

--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -84,17 +84,6 @@ Resources:
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
       GlobalSecondaryIndexes:
-        - IndexName: ios-endTimestamp-revalidation-index
-          KeySchema:
-            - AttributeName: subscriptionId
-              KeyType: HASH
-            - AttributeName: endTimestamp
-              KeyType: RANGE
-          Projection:
-            NonKeyAttributes:
-              - autoRenewing
-              - receipt
-            ProjectionType: INCLUDE
         - IndexName: ios-endTimestamp-revalidation-index-with-platform
           KeySchema:
             - AttributeName: subscriptionId


### PR DESCRIPTION
## What does this change?

In #1410 a new index was added to replace the one removed here (it's the same, but also includes the platform). Since #1409 we've been using the new index, so now the old index can be removed.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
