### PR TITLE
Trigger different SOI email for Feast purchases

### DIFF
--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -81,6 +81,19 @@ async function sendSoftOptIns(identityId: string, subscriptionId: string, platfo
     console.log(`Sent message to soft-opt-in-consent-setter-queue for user: ${identityId}: ${JSON.stringify(message)}`)
 }
 
+const buildBrazeEmailMessage = (emailAddress: string, identityId: string) => {
+    const brazeMessage = {
+        To: {
+            Address: emailAddress,
+            ContactAttributes: {SubscriberAttributes: {}}
+        },
+        DataExtensionName: "SV_PA_SOINotification",
+        IdentityUserId: identityId
+    };
+
+    return brazeMessage;
+};
+
 // returns true if message successfully processed
 export async function processAcquisition(subscriptionRecord: ReadSubscription, identityId: string): Promise<boolean> {
     const subscriptionId = subscriptionRecord.subscriptionId;
@@ -111,14 +124,7 @@ export async function processAcquisition(subscriptionRecord: ReadSubscription, i
         const identityApiKey = await getIdentityApiKey();
 
         const emailAddress = await getUserEmailAddress(identityId, identityApiKey);
-        const brazeMessage = {
-            To: {
-                Address: emailAddress,
-                ContactAttributes: {SubscriberAttributes: {}}
-            },
-            DataExtensionName: "SV_PA_SOINotification",
-            IdentityUserId: identityId
-        };
+        const brazeMessage = buildBrazeEmailMessage(emailAddress, identityId);
 
         try {
             await sendToSqsComms(`${queueNamePrefix}/braze-emails-${Stage}`, brazeMessage);


### PR DESCRIPTION
## What does this change?

For Feast IAPs, the email which should be triggered is distinct from other IAPs.

This pushes a slightly different message onto the queue for Feast, which will result in membership-workflow triggering a different email campaign. See also guardian/membership-workflow#507.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I triggered the lambda with a dummy Dynamo insert event and see the correct data added to the braze-emails queue for Feast and non-Feast events.

Feast:

<img width="908" alt="Screenshot 2024-03-25 at 10 33 48" src="https://github.com/guardian/mobile-purchases/assets/379839/ca29881a-69af-42b7-846e-f9ac0c220cbe">

Non-Feast:

<img width="903" alt="Screenshot 2024-03-25 at 10 41 28" src="https://github.com/guardian/mobile-purchases/assets/379839/65130ca8-80fc-4ae8-9152-a89356347b0d">

Note that the emails didn't actually send, I think because the campaigns aren't currently activated in the Braze B2C - Dev environment. I think seeing the correct data get added to the queue is good enough.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
