### PR TITLE
Handle 21007 response for Apple receipt lookup gracefully

### DIFF
--- a/typescript/src/feast/update-subs/updatesubs.ts
+++ b/typescript/src/feast/update-subs/updatesubs.ts
@@ -86,9 +86,7 @@ const processRecordWithErrorHandling = async (
     storeUserSubscriptionInDynamo: StoreUserSubInDynamo,
     record: SQSRecord
 ) => {
-    console.log("In processRecordWithErrorHandling")
     try {
-        console.log("In processRecordWithErrorHandling")
         return await processRecord(
             fetchSubscriptionsFromApple,
             storeSubscriptionInDynamo,
@@ -97,7 +95,6 @@ const processRecordWithErrorHandling = async (
             record
         );
     } catch (error) {
-        console.log("ATTEMPTING TO HANDLE ERROR")
         if (error instanceof GracefulProcessingError) {
             console.warn("Error processing the subscription update is being handled gracefully", error);
             return;

--- a/typescript/src/feast/update-subs/updatesubs.ts
+++ b/typescript/src/feast/update-subs/updatesubs.ts
@@ -69,10 +69,8 @@ const processRecord = async (
 
     const userSubscriptions =
         await Promise.all(subscriptions.map(async s => {
-            const identityId =
-                await exchangeExternalIdForIdentityId(s.appAccountToken)
-            const now =
-                new Date().toISOString()
+            const identityId = await exchangeExternalIdForIdentityId(s.appAccountToken)
+            const now = new Date().toISOString()
 
             return new UserSubscription(identityId, s.subscriptionId, now)
         }))

--- a/typescript/src/feast/update-subs/updatesubs.ts
+++ b/typescript/src/feast/update-subs/updatesubs.ts
@@ -47,11 +47,16 @@ const defaultStoreUserSubscriptionInDynamo =
         return dynamoMapper.put({ item: userSubscription }).then(_ => {})
     }
 
+type FetchSubsFromApple = (reference: AppleSubscriptionReference) => Promise<HasAppAccountToken<Subscription>[]>;
+type StoreSubInDynamo = (subscription: Subscription) => Promise<void>;
+type ExchangeExternalIdForIdentityId = (externalId: string) => Promise<string>;
+type StoreUserSubInDynamo = (userSubscription: UserSubscription) => Promise<void>;
+
 const processRecord = async (
-    fetchSubscriptionsFromApple: (reference: AppleSubscriptionReference) => Promise<HasAppAccountToken<Subscription>[]>,
-    storeSubscriptionInDynamo: (subscription: Subscription) => Promise<void>,
-    exchangeExternalIdForIdentityId: (externalId: string) => Promise<string>,
-    storeUserSubscriptionInDynamo: (userSubscription: UserSubscription) => Promise<void>,
+    fetchSubscriptionsFromApple: FetchSubsFromApple,
+    storeSubscriptionInDynamo: StoreSubInDynamo,
+    exchangeExternalIdForIdentityId: ExchangeExternalIdForIdentityId,
+    storeUserSubscriptionInDynamo: StoreUserSubInDynamo,
     record: SQSRecord
 ) => {
     const reference =
@@ -76,10 +81,10 @@ const processRecord = async (
 }
 
 export function buildHandler(
-    fetchSubscriptionsFromApple: (reference: AppleSubscriptionReference) => Promise<HasAppAccountToken<Subscription>[]> = defaultFetchSubscriptionsFromApple,
-    storeSubscriptionInDynamo: (subscription: Subscription) => Promise<void> = defaultStoreSubscriptionInDynamo,
-    exchangeExternalIdForIdentityId: (externalId: string) => Promise<string> = getIdentityIdFromBraze,
-    storeUserSubscriptionInDynamo: (userSubscription: UserSubscription) => Promise<void> = defaultStoreUserSubscriptionInDynamo,
+    fetchSubscriptionsFromApple: FetchSubsFromApple = defaultFetchSubscriptionsFromApple,
+    storeSubscriptionInDynamo: StoreSubInDynamo = defaultStoreSubscriptionInDynamo,
+    exchangeExternalIdForIdentityId: ExchangeExternalIdForIdentityId = getIdentityIdFromBraze,
+    storeUserSubscriptionInDynamo: StoreUserSubInDynamo = defaultStoreUserSubscriptionInDynamo,
 ): (event: SQSEvent) => Promise<string> {
     return (event: SQSEvent) => {
         const promises = event.Records.map((record) => {


### PR DESCRIPTION
## What does this change?

If the receipt lookup fails with 21007, fail gracefully.

This happens if the sub comes from a sandbox purchase, it's okay that it fails - this is expected. We don't want the lambda run to error triggering a retry. So catch these types of errors and let the lambda return successfully. This mirrors the behaviour for the live app.

## How to test

`yarn test`

~~I'll also attempt to run this in CODE.~~ I've run this in CODE and can see a sandbox receipt is still handled correctly. It's hard to verify the 21007 code since this is only returned when a sandbox receipt is sent to the prod Apple API. I feel confident in the change and will keep an eye on things in prod.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
