### PR TITLE
Add description for soft-opt-in acquisitions lambda

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1267,7 +1267,7 @@ Resources:
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
           DLQUrl: !Ref AcquisitionsDeadLetterQueue
-      Description: asdf
+      Description: Trigger setting soft-opt-in consents and sending emails based on Dynamo events
       MemorySize: 512
       Timeout: 60
       Events:


### PR DESCRIPTION
## What does this change?

Previously the description for this lambda wasn't informative:

<img width="725" alt="Screenshot 2024-03-27 at 14 27 40" src="https://github.com/guardian/mobile-purchases/assets/379839/a9e8dc93-cb0a-4450-92b5-dac18f4d0a8e">

After:

<img width="837" alt="Screenshot 2024-03-27 at 14 34 54" src="https://github.com/guardian/mobile-purchases/assets/379839/b3841946-f01c-4ec8-ae68-429b6d1778bd">

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
