### PR TITLE
Revalidating receipts works for Feast IAPs

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1142,6 +1142,7 @@ Resources:
                 - "sqs:SendMessage"
               Resource:
                 - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-apple-subscriptions-to-fetch
+                - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-feast-apple-subscriptions-to-fetch
 
   DeleteUserSubscriptionLambda:
     Type: AWS::Serverless::Function
@@ -1233,7 +1234,8 @@ Resources:
           App: !Sub ${App}
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
-          SqsUrl: !Ref AppleSubscriptionsQueue
+          LiveAppSqsUrl: !Ref AppleSubscriptionsQueue
+          FeastAppSqsUrl: !Ref FeastAppleSubscriptionsQueue
       Description: Finds recently expired subscriptions
       MemorySize: 2048
       Timeout: 180

--- a/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
+++ b/typescript/src/revalidate-receipts/appleRevalidateReceipts.ts
@@ -103,7 +103,7 @@ export function buildHandler(
                 const sqsUrl = queueUrlForPlatform(subscription.platform);
                 await sendSubscriptionReferenceToQueue(sqsUrl, subscriptionReference, delayInSeconds);
                 sendCounts[countKey]++;
-                console.log(`Sent subscription with id: ${subscription.subscriptionId} and expiry timestamp: ${subscription.endTimestamp}`)
+                console.log(`Sent ${subscription.platform} subscription with id: ${subscription.subscriptionId} and expiry timestamp: ${subscription.endTimestamp}`)
             } else {
                 console.warn(`No receipt found for ${subscription.subscriptionId}`);
             }

--- a/typescript/tests/helpers/withEnv.ts
+++ b/typescript/tests/helpers/withEnv.ts
@@ -1,0 +1,8 @@
+export const withEnv = async (env: Record<string, string>, callback: () => any) => {
+    const oldEnv = process.env;
+    process.env = env;
+
+    await callback();
+
+    process.env = oldEnv;
+}

--- a/typescript/tests/revalidate-receipts/appleRevalidateReceipts.test.ts
+++ b/typescript/tests/revalidate-receipts/appleRevalidateReceipts.test.ts
@@ -1,11 +1,7 @@
 import { Subscription } from '../../src/models/endTimestampFilter';
 import { buildHandler } from '../../src/revalidate-receipts/appleRevalidateReceipts';
 import { Platform } from '../../src/models/platform';
-
-beforeAll(() => {
-    process.env.LiveAppSqsUrl = 'LiveAppSqsUrl';
-    process.env.FeastAppSqsUrl = 'FeastAppSqsUrl';
-})
+import { withEnv } from '../helpers/withEnv';
 
 describe('appleRevalidateReceipts', () => {
     it('pushes events to the correct SQS queue', async () => {
@@ -16,7 +12,9 @@ describe('appleRevalidateReceipts', () => {
         // @ts-ignore: I just need something which we can iterate over
         const handler = buildHandler(getSubscriptions, sendToQueue);
 
-        await handler({});
+        await withEnv({ LiveAppSqsUrl: 'LiveAppSqsUrl', FeastAppSqsUrl: 'FeastAppSqsUrl' }, async () => {
+            await handler({});
+        });
 
         expect(sendToQueue).toHaveBeenCalledTimes(2);
         expect(sendToQueue).toHaveBeenCalledWith('FeastAppSqsUrl', { receipt: feastSub.receipt }, 0);

--- a/typescript/tests/revalidate-receipts/appleRevalidateReceipts.test.ts
+++ b/typescript/tests/revalidate-receipts/appleRevalidateReceipts.test.ts
@@ -1,0 +1,25 @@
+import { Subscription } from '../../src/models/endTimestampFilter';
+import { buildHandler } from '../../src/revalidate-receipts/appleRevalidateReceipts';
+import { Platform } from '../../src/models/platform';
+
+beforeAll(() => {
+    process.env.LiveAppSqsUrl = 'LiveAppSqsUrl';
+    process.env.FeastAppSqsUrl = 'FeastAppSqsUrl';
+})
+
+describe('appleRevalidateReceipts', () => {
+    it('pushes events to the correct SQS queue', async () => {
+        const feastSub = new Subscription('12345', new Date().toISOString(), true, Platform.IosFeast, "FEAST-RECEIPT");
+        const liveAppSub = new Subscription('67890', new Date().toISOString(), true, Platform.Ios, "LIVE-RECEIPT");
+        const getSubscriptions = () => [feastSub, liveAppSub];
+        const sendToQueue = jest.fn();
+        // @ts-ignore: I just need something which we can iterate over
+        const handler = buildHandler(getSubscriptions, sendToQueue);
+
+        await handler({});
+
+        expect(sendToQueue).toHaveBeenCalledTimes(2);
+        expect(sendToQueue).toHaveBeenCalledWith('FeastAppSqsUrl', { receipt: feastSub.receipt }, 0);
+        expect(sendToQueue).toHaveBeenCalledWith('LiveAppSqsUrl', { receipt: liveAppSub.receipt }, 0);
+    });
+});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We periodically revalidate IAP subscription receipts with Apple but fetching those which have an end timestamp within a particular date range. So far we've been filtering Feast IAPs out. This PR switches to picking them up but adds them to a different SQS queue (because the receipt lookup lambda is different).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I'll attempt to test this on CODE.

A new integration test for the lambda has been added.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
