### PR TITLE
add revalidation flag for apple receipts revalidation lambda

### DIFF
--- a/typescript/tests/revalidate-receipts/appleRevalidateReceipts.test.ts
+++ b/typescript/tests/revalidate-receipts/appleRevalidateReceipts.test.ts
@@ -17,7 +17,7 @@ describe('appleRevalidateReceipts', () => {
         });
 
         expect(sendToQueue).toHaveBeenCalledTimes(2);
-        expect(sendToQueue).toHaveBeenCalledWith('FeastAppSqsUrl', { receipt: feastSub.receipt }, 0);
-        expect(sendToQueue).toHaveBeenCalledWith('LiveAppSqsUrl', { receipt: liveAppSub.receipt }, 0);
+        expect(sendToQueue).toHaveBeenCalledWith('FeastAppSqsUrl', { receipt: feastSub.receipt, isRevalidation: true }, 0);
+        expect(sendToQueue).toHaveBeenCalledWith('LiveAppSqsUrl', { receipt: liveAppSub.receipt, isRevalidation: true }, 0);
     });
 });


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is the first in a string of PRs, this currently adds a revalidation flag to the apple receipts revalidation lambda. this revalidation flag needs to be added to downstream lambdas.

Once this is implemented it will allow the `mobile-purchases-apple-update-subscriptions` lambda to make less calls out to braze and dynamo as it already had the revalidation data.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This was tested locally with tests and also using tests in the CODE environment.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
