### PR TITLE
Update Apple pub sub lambda to Node 20

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -425,7 +425,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: apple-pubsub.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-apple-pubsub/apple-pubsub.zip


### PR DESCRIPTION
## What does this change?

In #1376 the nvmrc was updated to specify Node 20, but the Node version in the cloudformation is still 14. This updates the Apple pubsub lambda to 20.

As confidence grows I'll probably update multiple lambdas in one go, but starting small. I don't envisage any issues as the tests have been happily running against Node 20 for a while.

## How to test

I've deployed to code and invoked the lambda, which seems happy.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
