### PR TITLE
Feast subscription update lambda: write the subscription record, even if app account token is missing

### DIFF
--- a/typescript/tests/feast/update-subs/updatesubs.test.ts
+++ b/typescript/tests/feast/update-subs/updatesubs.test.ts
@@ -1,6 +1,6 @@
 
 import { SQSEvent } from "aws-lambda";
-import { MaybeHasAppAccountToken, buildHandler, withAppAccountToken } from "../../../src/feast/update-subs/updatesubs";
+import { SubscriptionMaybeWithAppAccountToken, buildHandler, withAppAccountToken } from "../../../src/feast/update-subs/updatesubs";
 import { Subscription } from "../../../src/models/subscription";
 import { AppleSubscriptionReference } from "../../../src/models/subscriptionReference";
 import { UserSubscription } from "../../../src/models/userSubscription";
@@ -143,7 +143,7 @@ const subscription =
         receipt: string,
         appAccountToken?: string,
         identityId?: string
-    ): { subscription: MaybeHasAppAccountToken<Subscription>, identityId?: string } => {
+    ): { subscription: SubscriptionMaybeWithAppAccountToken, identityId?: string } => {
         const subscription = new Subscription(id, "", "", "", false, "", "ios-feast", false, "6M", null, receipt, null);
         return {
             subscription: appAccountToken ? withAppAccountToken(subscription, appAccountToken): subscription,

--- a/typescript/tests/feast/update-subs/updatesubs.test.ts
+++ b/typescript/tests/feast/update-subs/updatesubs.test.ts
@@ -1,11 +1,11 @@
 
 import { SQSEvent } from "aws-lambda";
-import { buildHandler, withAppAccountToken } from "../../../src/feast/update-subs/updatesubs";
+import { MaybeHasAppAccountToken, buildHandler, withAppAccountToken } from "../../../src/feast/update-subs/updatesubs";
 import { Subscription } from "../../../src/models/subscription";
 import { AppleSubscriptionReference } from "../../../src/models/subscriptionReference";
 import { UserSubscription } from "../../../src/models/userSubscription";
-import { getIdentityIdFromBraze } from "../../../src/services/braze";
 import { GracefulProcessingError } from "../../../src/models/GracefulProcessingError";
+import { ProcessingError } from "../../../src/models/processingError";
 
 describe("The Feast (Apple) subscription updater", () => {
     it("Should fetch the subscription(s) associated with the reference from Apple and persist them to Dynamo", async () => {
@@ -45,10 +45,10 @@ describe("The Feast (Apple) subscription updater", () => {
                 stubExchangeExternalIdForIdentityId,
                 mockStoreUserSubscriptionInDynamo
             )
-        
+
         const result =
             await handler(event)
-        
+
         expect(mockStoreUserSubscriptionInDynamo.mock.calls.length).toEqual(3)
 
         const storedUserSubscriptions =
@@ -58,14 +58,14 @@ describe("The Feast (Apple) subscription updater", () => {
                     subscriptionId: call[0].subscriptionId
                 }
             })
-        
+
         const expectedUserSubscriptions =
             [
                 { subscriptionId: "sub-1", userId: "identity-id-1" },
                 { subscriptionId: "sub-2", userId: "identity-id-2" },
                 { subscriptionId: "sub-3", userId: "identity-id-2" },
             ]
-        
+
         expect(storedUserSubscriptions).toEqual(expectedUserSubscriptions)
     });
 
@@ -84,6 +84,27 @@ describe("The Feast (Apple) subscription updater", () => {
         expect.assertions(1);
 
         await expect(handler(event)).resolves.toBe("OK");
+    })
+
+    it("Throws an error if the receipt has no app account token, but still writes the subscription", async () => {
+        expect.assertions(2);
+        const event =
+            buildSqsEvent(["TEST_RECEIPT_MISSING_AAT"])
+        const handler =
+            buildHandler(
+                stubFetchSubscriptionsFromApple,
+                mockStoreSubscriptionInDynamo,
+                stubExchangeExternalIdForIdentityId,
+                mockStoreUserSubscriptionInDynamo
+            )
+
+        try {
+            await handler(event);
+        } catch (error) {
+            expect((error as ProcessingError).message)
+                .toMatch("Subscription with receipt 'TEST_RECEIPT_MISSING_AAT' did not have an 'appAccountToken'");
+            expect(mockStoreSubscriptionInDynamo.mock.calls.length).toEqual(1)
+        }
     })
 });
 
@@ -117,9 +138,15 @@ const buildSqsEvent = (receipts: string[]): SQSEvent => {
 }
 
 const subscription =
-    (id: string, receipt: string, appAccountToken: string, identityId: string) => {
+    (
+        id: string,
+        receipt: string,
+        appAccountToken?: string,
+        identityId?: string
+    ): { subscription: MaybeHasAppAccountToken<Subscription>, identityId?: string } => {
+        const subscription = new Subscription(id, "", "", "", false, "", "ios-feast", false, "6M", null, receipt, null);
         return {
-            subscription: withAppAccountToken(new Subscription(id, "", "", "", false, "", "ios-feast", false, "6M", null, receipt, null), appAccountToken),
+            subscription: appAccountToken ? withAppAccountToken(subscription, appAccountToken): subscription,
             identityId: identityId
         }
     }
@@ -129,15 +156,23 @@ const subscriptions = [
     subscription("sub-2", "TEST_RECEIPT_2", "app-account-token-2", "identity-id-2"),
     subscription("sub-3", "TEST_RECEIPT_2", "app-account-token-2", "identity-id-2"),
     subscription("sub-4", "TEST_RECEIPT_3", "app-account-token-3", "identity-id-3"),
+    subscription("sub-5", "TEST_RECEIPT_MISSING_AAT", undefined, undefined),
 ]
 
 const stubFetchSubscriptionsFromApple =
-    (reference: AppleSubscriptionReference) => 
+    (reference: AppleSubscriptionReference) =>
         Promise.resolve(subscriptions.filter(s => s.subscription.receipt == reference.receipt).map(s => s.subscription))
 
-const stubExchangeExternalIdForIdentityId = 
-    (externalId: string) =>
-        Promise.resolve(subscriptions.find(s => s.subscription.appAccountToken == externalId)?.identityId!)
+const stubExchangeExternalIdForIdentityId =
+    (externalId: string) => {
+        const maybeMatchingSub = subscriptions.find(s => s.subscription.appAccountToken == externalId)
+
+        if (maybeMatchingSub) {
+            return Promise.resolve(subscriptions.find(s => s.subscription.appAccountToken == externalId)?.identityId!)
+        }
+
+        return Promise.reject(`Failed to exchange app account token ${externalId} for identity ID`)
+    }
 
 const mockStoreSubscriptionInDynamo =
     jest.fn((subscription: Subscription) => Promise.resolve())


### PR DESCRIPTION
## What does this change?

We've identified some cases where a receipt for Feast may not contain an `appAccountToken`, which is how we link to an identity ID. Handling these correctly and ensuring they are linked with an identity ID is something we're looking at separately.  In the meantime, the lack of `appAccountToken` currently causes is to fail to write the subscription record AND the link record. But we shouldn't let it prevent us from writing the subscription. It's useful data, and makes it easier for us to identity the records which don't have a link to an identity ID.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've added an integration style test to verify the new behaviour. I've deployed to CODE, and verified that behaviour is good when there _is_ an app account token, but cannot figure out how to trigger the new code path (since this depends on the response from Apple). I suggest getting this into production and keeping a close eye on it.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
