### PR TITLE
Address Android pubsub errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@aws/dynamodb-data-mapper": "^0.7.3",
     "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
     "@aws/dynamodb-expressions": "^0.7.3",
+    "@googleapis/androidpublisher": "13.0.0",
     "@guardian/types": "^9.0.1",
     "@okta/jwt-verifier": "^3.1.0",
     "@types/aws-lambda": "8.10.137",
@@ -41,6 +42,6 @@
     "node-fetch": "2.6.7",
     "source-map-support": "^0.5.21",
     "typed-rest-client": "^1.8.9",
-    "@googleapis/androidpublisher": "13.0.0"
+    "zod": "^3.23.3"
   }
 }

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -8,6 +8,7 @@ import {Option} from "../utils/option";
 import {fromGooglePackageName} from "../services/appToPlatform";
 import {fetchGoogleSubscription, GOOGLE_PAYMENT_STATE} from "../services/google-play";
 import { z } from "zod";
+import { Ignorable } from './ignorable';
 
 const DeveloperNotificationBaseSchema = z.object({
     version: z.string(),
@@ -54,7 +55,7 @@ function isSubscriptionNotification(notification: DeveloperNotification): notifi
   return (notification as SubscriptionNotification).subscriptionNotification !== undefined;
 }
 
-export function parsePayload(body: Option<string>): Error | SubscriptionNotification | undefined {
+export function parsePayload(body: Option<string>): Error | SubscriptionNotification | Ignorable {
     try {
         const rawNotification = Buffer.from(JSON.parse(body ?? "").message.data, 'base64');
         const parseResult = DeveloperNotificationSchema.safeParse(JSON.parse(rawNotification.toString()));
@@ -67,7 +68,7 @@ export function parsePayload(body: Option<string>): Error | SubscriptionNotifica
             return data;
         }
 
-        return undefined;
+        return new Ignorable(`Notification is not a subscription notification. Notification was: ${JSON.stringify(data)}`)
     } catch (e) {
         console.log("Error during the parsing of the HTTP Payload body: " + e);
         return e as Error;

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -60,6 +60,7 @@ export function parsePayload(body: Option<string>): Error | SubscriptionNotifica
         const rawNotification = Buffer.from(JSON.parse(body ?? "").message.data, 'base64');
         const parseResult = DeveloperNotificationSchema.safeParse(JSON.parse(rawNotification.toString()));
         if (!parseResult.success) {
+            console.log("HTTP Payload body parse error: ", parseResult.error)
             return new Error(`HTTP Payload body parse error: ${parseResult.error}`);
         }
 

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -7,20 +7,28 @@ import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Option} from "../utils/option";
 import {fromGooglePackageName} from "../services/appToPlatform";
 import {fetchGoogleSubscription, GOOGLE_PAYMENT_STATE} from "../services/google-play";
+import { z } from "zod";
 
-interface DeveloperNotification {
-    version: string,
-    packageName: string,
-    eventTimeMillis: string,
-    subscriptionNotification: SubscriptionNotification
-}
+const SubscriptionNotificationSchema = z.object({
+    version: z.string(),
+    notificationType: z.number(),
+    purchaseToken: z.string(),
+    subscriptionId: z.string()
+});
+type SubscriptionNotification = z.infer<typeof SubscriptionNotificationSchema>;
 
-interface SubscriptionNotification {
-    version: string,
-    notificationType: number,
-    purchaseToken: string,
-    subscriptionId: string
-}
+const DeveloperNotificationSchema = z.object({
+    version: z.string(),
+    packageName: z.string(),
+    eventTimeMillis: z.string(),
+    subscriptionNotification: z.object({
+        version: z.string(),
+        notificationType: z.number(),
+        purchaseToken: z.string(),
+        subscriptionId: z.string()
+    })
+});
+type DeveloperNotification = z.infer<typeof DeveloperNotificationSchema>;
 
 interface MetaData {
     freeTrial: boolean

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -60,7 +60,6 @@ export function parsePayload(body: Option<string>): Error | SubscriptionNotifica
         const rawNotification = Buffer.from(JSON.parse(body ?? "").message.data, 'base64');
         const parseResult = DeveloperNotificationSchema.safeParse(JSON.parse(rawNotification.toString()));
         if (!parseResult.success) {
-            console.log("HTTP Payload body parse error: ", parseResult.error)
             return new Error(`HTTP Payload body parse error: ${parseResult.error}`);
         }
 

--- a/typescript/src/pubsub/ignorable.ts
+++ b/typescript/src/pubsub/ignorable.ts
@@ -1,0 +1,7 @@
+export class Ignorable {
+    message: string;
+
+    constructor(message: string) {
+        this.message = message;
+    }
+}

--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -25,7 +25,7 @@ function storeInDynamoImpl(event: SubscriptionEvent): Promise<SubscriptionEvent>
 
 export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
     request: APIGatewayProxyEvent,
-    parsePayload: (body: Option<string>) => Payload | Error,
+    parsePayload: (body: Option<string>) => Payload | undefined | Error,
     toDynamoEvent: (payload: Payload, metaData?: MetaData) => SubscriptionEvent,
     toSqsEvent: (payload: Payload) => SqsEvent,
     fetchMetadata: (payload: Payload) => Promise<MetaData | undefined>,
@@ -40,7 +40,9 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
         }
         if (request.queryStringParameters?.secret === secret) {
             const notification = parsePayload(request.body);
-            if (notification instanceof Error) {
+            if(!notification) {
+                return HTTPResponses.OK;
+            } else if (notification instanceof Error) {
                 return HTTPResponses.INVALID_REQUEST
             }
             
@@ -65,6 +67,3 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
         }
     });
 }
-
-
-

--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -42,6 +42,7 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
         if (request.queryStringParameters?.secret === secret) {
             const notification = parsePayload(request.body);
             if (notification instanceof Error) {
+                console.log("Parsing the payload failed: ", notification.message);
                 return HTTPResponses.INVALID_REQUEST
             } else if (notification instanceof Ignorable) {
                 console.log("Ignoring event: ", notification.message);

--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -7,6 +7,7 @@ import {PromiseResult} from "aws-sdk/lib/request";
 import {sqs, dynamoMapper, sendToSqs} from "../utils/aws";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Option} from "../utils/option";
+import { Ignorable } from './ignorable';
 
 export const ONE_YEAR_IN_SECONDS = 31557600;
 
@@ -25,7 +26,7 @@ function storeInDynamoImpl(event: SubscriptionEvent): Promise<SubscriptionEvent>
 
 export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
     request: APIGatewayProxyEvent,
-    parsePayload: (body: Option<string>) => Payload | undefined | Error,
+    parsePayload: (body: Option<string>) => Payload | Ignorable | Error,
     toDynamoEvent: (payload: Payload, metaData?: MetaData) => SubscriptionEvent,
     toSqsEvent: (payload: Payload) => SqsEvent,
     fetchMetadata: (payload: Payload) => Promise<MetaData | undefined>,
@@ -40,10 +41,11 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
         }
         if (request.queryStringParameters?.secret === secret) {
             const notification = parsePayload(request.body);
-            if(!notification) {
-                return HTTPResponses.OK;
-            } else if (notification instanceof Error) {
+            if (notification instanceof Error) {
                 return HTTPResponses.INVALID_REQUEST
+            } else if (notification instanceof Ignorable) {
+                console.log("Ignoring event: ", notification.message);
+                return HTTPResponses.OK;
             }
             
             const queueUrl = process.env.QueueUrl;

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -117,7 +117,18 @@ describe("The google pubsub", () => {
         const mockStoreFunction: Mock<Promise<SubscriptionEvent>, [SubscriptionEvent]> = jest.fn(event => Promise.resolve(event));
         const mockSqsFunction: Mock<Promise<any>, [string, {purchaseToken: string}]> = jest.fn((queurl, event) => Promise.resolve({}));
         const mockFetchMetadataFunction: Mock<Promise<any>> = jest.fn(event => Promise.resolve({freeTrial: true}));
-        const badPayload = { foo: "bar" };
+        const receivedEvent = { "foo": "bar" };
+        const encodedEvent = Buffer.from(JSON.stringify(receivedEvent)).toString('base64');
+        const badPayload = {
+            message: {
+                data: encodedEvent,
+                messageId: '123',
+                message_id: '123',
+                publishTime: '2019-05-24T15:06:47.701Z',
+                publish_time: '2019-05-24T15:06:47.701Z'
+            },
+            subscription: 'projects/guardian.co.uk:maximal-ceiling-820/subscriptions/mobile-pubsub-code'
+        };
         const input: APIGatewayProxyEvent = {
             queryStringParameters: { secret: "MYSECRET" },
             body: JSON.stringify(badPayload),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4701,3 +4701,8 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+zod@^3.23.3:
+  version "3.23.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.3.tgz#eeb068f83acb55310174673dee631dfa0be5510d"
+  integrity sha512-tPvq1B/2Yu/dh2uAIH2/BhUlUeLIUvAjr6dpL/75I0pCYefHgjhXk1o1Kob3kTU8C7yU1j396jFHlsVWFi9ogg==


### PR DESCRIPTION
## What does this change?

In production we see a large volume of errors due to the payload sent to the pubsub endpoint by Google not being what we expect. We expect to always receive a [subscription notification](https://developer.android.com/google/play/billing/rtdn-reference#voided-purchase) and we (before this PR) cast to a type which matches this.

After adding some logging in #1461 I can see that we often receive a [voided purchase notification](https://developer.android.com/google/play/billing/rtdn-reference#voided-purchase). So far I've not been able to get clarity on what we should be doing with these, so let's change the behaviour to fail gracefully (and log) until we've figured out what to do. Now when we receive a voided purchase notification we'll do nothing and return a 200.

I've introduced [zod](https://zod.dev/) to do more explicit validation. I hope to extend this to other areas of the codebase in future PRs.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
