### PR TITLE
Add 5XX alarm for Android pubsub endpoint

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -898,7 +898,7 @@ Resources:
       OKActions:
         - Ref: AlarmTopic
       AlarmName: !Sub mobile-purchases-${Stage}-apple-pubsub-check-errors
-      AlarmDescription: A HTTP request to the pubsub endpoint resulted in a 5XX error.
+      AlarmDescription: A HTTP request to the iOS pubsub endpoint resulted in a 5XX error.
       Dimensions:
         - Name: ApiName
           Value: !Sub ${App}-${Stage}
@@ -927,7 +927,7 @@ Resources:
       OKActions:
         - Ref: AlarmTopic
       AlarmName: !Sub mobile-purchases-${Stage}-feast-apple-pubsub-check-errors
-      AlarmDescription: A HTTP request to the pubsub endpoint resulted in a 5XX error.
+      AlarmDescription: A HTTP request to the iOS Feast pubsub endpoint resulted in a 5XX error.
       Dimensions:
         - Name: ApiName
           Value: !Sub ${App}-${Stage}

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -946,6 +946,35 @@ Resources:
       Threshold: 2
       TreatMissingData: notBreaching
 
+  GooglePubsub5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled:
+        !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
+      AlarmActions:
+        - Ref: AlarmTopic
+      OKActions:
+        - Ref: AlarmTopic
+      AlarmName: !Sub mobile-purchases-${Stage}-google-pubsub-check-errors
+      AlarmDescription: A HTTP request to the Google pubsub endpoint resulted in a 5XX error.
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub ${App}-${Stage}
+        - Name: Method
+          Value: POST
+        - Name: Resource
+          Value: /google/pubsub
+        - Name: Stage
+          Value: !Ref Stage
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: 5XXError
+      Namespace: AWS/ApiGateway
+      Period: 300
+      Statistic: Sum
+      Threshold: 2
+      TreatMissingData: notBreaching
+
   UserSubscriptionsLambda:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
## What does this change?

Adds a Cloudwatch alarm for 5XX errors from the /google/pubsub endpoint. There isn't one of these for the endpoint, though there are alarms for the iOS & Feast pubsub endpoints.

[Until recently](https://github.com/guardian/mobile-purchases/pull/1465) this endpoint returned a lot of errors, hopefully now an error is genuinely an error and something we should look into.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
