### PR TITLE
Add a lambda to handle feast google purchases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,3 +100,5 @@ jobs:
               - tsc-target/feast-apple-pubsub.zip
             mobile-purchases-feast-apple-update-subscriptions:
               - tsc-target/feast-apple-update-subscriptions.zip
+            mobile-purchases-feast-google-pubsub:
+              - tsc-target/feast-google-pubsub.zip

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -305,6 +305,17 @@ Resources:
               responses:
                 "200":
                   "description": "200 response"
+          "/feast/google/pubsub":
+            post:
+              x-amazon-apigateway-integration:
+                httpMethod: POST
+                type: aws_proxy
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FeastGooglePubSubLambda.Arn}/invocations
+              consumes: [application/json]
+              produces: [application/json]
+              responses:
+                "200":
+                  "description": "200 response"
           "/healthcheck":
             get:
               responses:
@@ -598,6 +609,36 @@ Resources:
           Type: Api
           Properties:
             Path: "/apple/fetchOfferDetails"
+            Method: POST
+            RestApiId: !Ref MobilePuchasesApi
+      Tags:
+        Stage: !Ref Stage
+        Stack: !Ref Stack
+        App: !Ref App
+
+  FeastGooglePubSubLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: feast-google-pubsub.handler
+      Runtime: nodejs20.x
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}-feast-google-pubsub/feast-google-pubsub.zip
+      FunctionName: !Sub ${App}-feastgooglepubsub-${Stage}
+      Role: !GetAtt MobilePurchasesLambdasRole.Arn
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+      Description: Records Google play store events for Feast app
+      MemorySize: 128
+      Timeout: 29
+      Events:
+        PostApi:
+          Type: Api
+          Properties:
+            Path: "/feast/google/pubsub"
             Method: POST
             RestApiId: !Ref MobilePuchasesApi
       Tags:
@@ -964,6 +1005,35 @@ Resources:
           Value: POST
         - Name: Resource
           Value: /google/pubsub
+        - Name: Stage
+          Value: !Ref Stage
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: 5XXError
+      Namespace: AWS/ApiGateway
+      Period: 300
+      Statistic: Sum
+      Threshold: 2
+      TreatMissingData: notBreaching
+
+  FeastGooglePubsub5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled:
+        !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
+      AlarmActions:
+        - Ref: AlarmTopic
+      OKActions:
+        - Ref: AlarmTopic
+      AlarmName: !Sub mobile-purchases-${Stage}-feast-google-pubsub-check-errors
+      AlarmDescription: A HTTP request to the Feast Google pubsub endpoint resulted in a 5XX error.
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub ${App}-${Stage}
+        - Name: Method
+          Value: POST
+        - Name: Resource
+          Value: /feast/google/pubsub
         - Name: Stage
           Value: !Ref Stage
       ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -50,6 +50,10 @@ Parameters:
     Type: String
     Description: The secret used by apple's pubsub for the feast app
     NoEcho: true
+  FeastGooglePubSubSecret:
+    Type: String
+    Description: The secret used by google's pubsub for the feast app
+    NoEcho: true
   AlarmTopic:
     Type: String
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to
@@ -631,6 +635,7 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
+          Secret: !Ref FeastGooglePubSubSecret
       Description: Records Google play store events for Feast app
       MemorySize: 128
       Timeout: 29

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -44,6 +44,12 @@ deployments:
       functionNames: [mobile-purchases-feast-apple-update-subscriptions-]
       fileName: feast-apple-update-subscriptions.zip
 
+  mobile-purchases-feast-google-pubsub:
+    template: lambda
+    parameters:
+      functionNames: [mobile-purchases-feastgooglepubsub-]
+      fileName: feast-google-pubsub.zip
+
   mobile-purchases-google-pubsub:
     template: lambda
     parameters:

--- a/typescript/src/feast/pubsub/google.ts
+++ b/typescript/src/feast/pubsub/google.ts
@@ -1,4 +1,4 @@
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import type {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 
 export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult>  {
     // placeholder for new lambda

--- a/typescript/src/feast/pubsub/google.ts
+++ b/typescript/src/feast/pubsub/google.ts
@@ -1,6 +1,7 @@
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 
 export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult>  {
+    // placeholder for new lambda
     console.log(`${JSON.stringify(request)}`)
     return { statusCode: 200, body: JSON.stringify(request) }
 }

--- a/typescript/src/feast/pubsub/google.ts
+++ b/typescript/src/feast/pubsub/google.ts
@@ -1,0 +1,6 @@
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+
+export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult>  {
+    console.log(`${JSON.stringify(request)}`)
+    return { statusCode: 200, body: JSON.stringify(request) }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ const getEntries = (env) => {
     "apple-revalidate-receipts": "./typescript/src/revalidate-receipts/appleRevalidateReceipts.ts",
     "feast-apple-pubsub": "./typescript/src/feast/pubsub/apple.ts",
     "feast-apple-update-subscriptions": "./typescript/src/feast/update-subs/apple.ts",
+    "feast-google-pubsub": "./typescript/src/feast/pubsub/google.ts",
   };
   return env.production ? entries : {
     ...entries,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This provides the webhook for the store to send purchase informations to. The lambda doesn't do anything yet.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Call the endpoint in CODE and it should return a 200 echoing the request body.
I tested with postman and it worked as intended.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
