### PR TITLE
Cloudformation description improvements

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -253,7 +253,7 @@ Resources:
               produces: [application/json]
               responses:
                 "200":
-                  "description": "200 response"
+                  "description": "Successfully handled link request from iOS Live App"
           "/google/linkToSubscriptions":
             post:
               x-amazon-apigateway-integration:
@@ -264,7 +264,7 @@ Resources:
               produces: [application/json]
               responses:
                 "200":
-                  "description": "200 response"
+                  "description": "Successfully handled link request from Android Live App"
           "/user/subscriptions/me":
             get:
               x-amazon-apigateway-integration:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -944,7 +944,7 @@ Resources:
       OKActions:
         - Ref: AlarmTopic
       AlarmName: !Sub mobile-purchases-${Stage}-apple-pubsub-check-errors
-      AlarmDescription: A HTTP request to the iOS pubsub endpoint resulted in a 5XX error.
+      AlarmDescription: Two HTTP requests to the iOS pubsub endpoint resulted in 5XX errors.
       Dimensions:
         - Name: ApiName
           Value: !Sub ${App}-${Stage}
@@ -973,7 +973,7 @@ Resources:
       OKActions:
         - Ref: AlarmTopic
       AlarmName: !Sub mobile-purchases-${Stage}-feast-apple-pubsub-check-errors
-      AlarmDescription: A HTTP request to the iOS Feast pubsub endpoint resulted in a 5XX error.
+      AlarmDescription: Two HTTP requests to the iOS Feast pubsub endpoint resulted in 5XX errors.
       Dimensions:
         - Name: ApiName
           Value: !Sub ${App}-${Stage}
@@ -1002,7 +1002,7 @@ Resources:
       OKActions:
         - Ref: AlarmTopic
       AlarmName: !Sub mobile-purchases-${Stage}-google-pubsub-check-errors
-      AlarmDescription: A HTTP request to the Google pubsub endpoint resulted in a 5XX error.
+      AlarmDescription: Two HTTP requests to the Google pubsub endpoint resulted in 5XX errors.
       Dimensions:
         - Name: ApiName
           Value: !Sub ${App}-${Stage}
@@ -1031,7 +1031,7 @@ Resources:
       OKActions:
         - Ref: AlarmTopic
       AlarmName: !Sub mobile-purchases-${Stage}-feast-google-pubsub-check-errors
-      AlarmDescription: A HTTP request to the Feast Google pubsub endpoint resulted in a 5XX error.
+      AlarmDescription: Two HTTP requests to the Feast Google pubsub endpoint resulted in 5XX errors.
       Dimensions:
         - Name: ApiName
           Value: !Sub ${App}-${Stage}

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -209,7 +209,7 @@ Resources:
               produces: [application/json]
               responses:
                 "200":
-                  "description": "200 response"
+                  "description": "Successfully processed a Live App purchase receipt from Google Play Store"
           "/google/subscription/{subscriptionId}/status":
             get:
               x-amazon-apigateway-integration:
@@ -242,7 +242,7 @@ Resources:
               produces: [application/json]
               responses:
                 "200":
-                  "description": "200 response"
+                  "description": "Successfully processed a Live App purchase receipt from the Apple App Store"
           "/apple/linkToSubscriptions":
             post:
               x-amazon-apigateway-integration:
@@ -308,7 +308,7 @@ Resources:
               produces: [application/json]
               responses:
                 "200":
-                  "description": "200 response"
+                  "description": "Successfully processed a Feast App purchase receipt from the Apple App Store"
           "/feast/google/pubsub":
             post:
               x-amazon-apigateway-integration:
@@ -319,7 +319,7 @@ Resources:
               produces: [application/json]
               responses:
                 "200":
-                  "description": "200 response"
+                  "description": "Successfully processed a Feast App purchase receipt from the Google Play Store"
           "/healthcheck":
             get:
               responses:


### PR DESCRIPTION
## What does this change?
This updates descriptions for the pubsub and link endpoint responses as well as for the pubsub 5XX alarms.

I preferred to update the alarms' description rather than changing the threshold as the threshold has previously purposefully been changed to be less sensitive.
We should review all alarms at a later stage.