### PR TITLE
Handle deleted feast subs

### DIFF
--- a/typescript/src/link/deleteLink.ts
+++ b/typescript/src/link/deleteLink.ts
@@ -57,7 +57,7 @@ export async function handler(event: DynamoDBStreamEvent): Promise<any> {
         return dynamoEvent.eventName === "REMOVE" &&
             dynamoEvent.userIdentity?.type === "Service" &&
             dynamoEvent.userIdentity?.principalId === "dynamodb.amazonaws.com" &&
-            dynamoEvent.dynamodb?.OldImage?.subscriptionId
+            dynamoEvent.dynamodb?.OldImage?.subscriptionId?.S
     });
 
     const subscriptions = ttlEvents

--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -1,4 +1,4 @@
-import {dynamoMapper, sendToSqs, sendToSqsComms, sendToSqsSoftOptIns, SoftOptInEvent, SoftOptInEventProductName} from "../utils/aws";
+import {sendToSqsComms, sendToSqsSoftOptIns, SoftOptInEvent} from "../utils/aws";
 import {ReadSubscription} from "../models/subscription";
 import {Region, Stage} from "../utils/appIdentity";
 import fetch from 'node-fetch';
@@ -6,6 +6,7 @@ import { Response } from 'node-fetch';
 import {getIdentityApiKey, getIdentityUrl, getMembershipAccountId} from "../utils/guIdentityApi";
 import {plusDays} from "../utils/dates";
 import { Platform } from "../models/platform";
+import { mapPlatformToSoftOptInProductName } from "../utils/softOptIns";
 
 export function isPostAcquisition(startTimestamp: string): boolean {
     const twoDaysInMilliseconds = 48 * 60 * 60 * 1000;
@@ -52,15 +53,6 @@ async function getUserEmailAddress(identityId: string, identityApiKey: string): 
         return await handleError(`error while retrieving user data for identityId: ${identityId}: ${error}`);
     }
 }
-
-const mapPlatformToSoftOptInProductName = (platform: string | undefined): SoftOptInEventProductName => {
-    switch (platform) {
-        case Platform.IosFeast:
-            return "FeastInAppPurchase";
-        default:
-            return "InAppPurchase";
-    }
-};
 
 async function sendSoftOptIns(identityId: string, subscriptionId: string, platform: string | undefined, queueNamePrefix: string) {
     const productName = mapPlatformToSoftOptInProductName(platform);

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -9,7 +9,6 @@ import {PromiseResult} from "aws-sdk/lib/request";
 import SSM = require("aws-sdk/clients/ssm");
 import STS from "aws-sdk/clients/sts";
 import {getMembershipAccountId} from "./guIdentityApi";
-import { Platform } from "../models/platform";
 import { SoftOptInEventProductName } from "./softOptIns";
 
 const credentialProvider = new CredentialProviderChain([

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -9,6 +9,8 @@ import {PromiseResult} from "aws-sdk/lib/request";
 import SSM = require("aws-sdk/clients/ssm");
 import STS from "aws-sdk/clients/sts";
 import {getMembershipAccountId} from "./guIdentityApi";
+import { Platform } from "../models/platform";
+import { SoftOptInEventProductName } from "./softOptIns";
 
 const credentialProvider = new CredentialProviderChain([
     function () { return new ECSCredentials(); },
@@ -136,14 +138,12 @@ export function sendToSqs(queueUrl: string, event: any, delaySeconds?: number): 
     }).promise()
 }
 
-export type SoftOptInEventProductName = "InAppPurchase" | "FeastInAppPurchase";
 export interface SoftOptInEvent {
     identityId: string;
     eventType: "Acquisition" | "Cancellation" | "Switch";
     productName: SoftOptInEventProductName
     subscriptionId: string;
 }
-
 export async function sendToSqsSoftOptIns(queueUrl: string, event: SoftOptInEvent, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     const membershipSqs = await getSqsClientForSoftOptIns();
     return membershipSqs.sendMessage({
@@ -152,6 +152,7 @@ export async function sendToSqsSoftOptIns(queueUrl: string, event: SoftOptInEven
         DelaySeconds: delaySeconds
     }).promise();
 }
+
 export async function sendToSqsComms(queueUrl: string, event: any, delaySeconds?: number): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
     const membershipSqs = await getSqsClientForComms();
     return membershipSqs.sendMessage({

--- a/typescript/src/utils/softOptIns.ts
+++ b/typescript/src/utils/softOptIns.ts
@@ -1,0 +1,12 @@
+import { Platform } from "../models/platform";
+
+export type SoftOptInEventProductName = "InAppPurchase" | "FeastInAppPurchase";
+
+export const mapPlatformToSoftOptInProductName = (platform: string | undefined): SoftOptInEventProductName => {
+    switch (platform) {
+        case Platform.IosFeast:
+            return "FeastInAppPurchase";
+        default:
+            return "InAppPurchase";
+    }
+};

--- a/typescript/tests/link/deleteLink.test.ts
+++ b/typescript/tests/link/deleteLink.test.ts
@@ -134,7 +134,7 @@ describe("handler", () => {
         expect(result).toEqual({ recordCount: 1, rowCount: 1 })
     })
 
-    it('puts Feast deletions on the SOI SQS queue the product name FeastInAppPurchase', async () => {
+    it('puts Feast deletions on the SOI SQS queue with the product name FeastInAppPurchase', async () => {
         // get the mock instances
         const mockSQS = new (require('aws-sdk/clients/sqs'))();
 

--- a/typescript/tests/link/deleteLink.test.ts
+++ b/typescript/tests/link/deleteLink.test.ts
@@ -92,7 +92,6 @@ describe("handler", () => {
     });
 
     it('should process removed records, put messages on queue', async () => {
-
         // get the mock instances
         const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
         const mockSQS = new (require('aws-sdk/clients/sqs'))();
@@ -105,7 +104,7 @@ describe("handler", () => {
         });
 
         const event: DynamoDBStreamEvent = {
-            Records: [removeDynamoRecord]
+            Records: [buildRemovedDynamoRecord('1', 'ios')]
         }
 
         const result = await handler(event);
@@ -123,6 +122,45 @@ describe("handler", () => {
             eventType: "Cancellation",
             productName: "InAppPurchase",
             subscriptionId: "1"
+        };
+
+        const expectedQueueMessageParams1 = {
+            QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV',
+            MessageBody: JSON.stringify(expectedSoftOptInMessage1),
+        };
+
+        expect(mockSQS.sendMessage).toHaveBeenCalledWith(expectedQueueMessageParams1);
+
+        expect(result).toEqual({ recordCount: 1, rowCount: 1 })
+    })
+
+    it('puts Feast deletions on the SOI SQS queue the product name FeastInAppPurchase', async () => {
+        // get the mock instances
+        const mockSQS = new (require('aws-sdk/clients/sqs'))();
+
+        const subscriptionId = '1';
+        const userId = '123';
+
+        setMockQuery(async function* (params: { keyCondition: any; indexName: any; }) {
+            yield {
+                subscriptionId,
+                userId,
+            };
+        });
+
+        const event: DynamoDBStreamEvent = {
+            Records: [buildRemovedDynamoRecord(subscriptionId, 'ios-feast')]
+        }
+
+        const result = await handler(event);
+
+        expect(mockSQS.sendMessage).toHaveBeenCalledTimes(1);
+
+        const expectedSoftOptInMessage1 = {
+            identityId: userId,
+            eventType: "Cancellation",
+            productName: "FeastInAppPurchase",
+            subscriptionId,
         };
 
         const expectedQueueMessageParams1 = {
@@ -156,11 +194,14 @@ describe("handler", () => {
     })
 })
 
-const removeDynamoRecord: DynamoDBRecord = {
+const buildRemovedDynamoRecord = (subscriptionId: string, platform: string): DynamoDBRecord => ({
     dynamodb: {
         OldImage: {
             subscriptionId: {
-                S: "1",
+                S: subscriptionId,
+            },
+            platform: {
+                S: platform,
             },
         }
     },
@@ -169,7 +210,7 @@ const removeDynamoRecord: DynamoDBRecord = {
         type: "Service",
         principalId: "dynamodb.amazonaws.com"
     }
-};
+});
 
 const modifyDynamoRecord: DynamoDBRecord = {
     dynamodb: {


### PR DESCRIPTION
## What does this change?

When a row from the subscriptions Dynamo table is removed, we put an item onto the SQS queue read by the soft-opt-in-consent-setter. When the subscription is a Feast IAP, we should provide a different SOI product name, as the consents are different.

## How to test

We've extended the existing Jest tests and we'll test in CODE.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
