### PR TITLE
Return SOI product name with subscription data

### DIFF
--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -7,6 +7,7 @@ import {getUserId, getAuthToken, UserIdResolution} from "../utils/guIdentityApi"
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {plusDays} from "../utils/dates";
 import {getConfigValue} from "../utils/ssmConfig";
+import { mapPlatformToSoftOptInProductName } from '../utils/softOptIns';
 
 interface SubscriptionStatus {
     subscriptionId: string
@@ -17,6 +18,7 @@ interface SubscriptionStatus {
     gracePeriod: boolean
     autoRenewing: boolean
     productId: string
+    softOptInProductName: string
 }
 
 interface SubscriptionStatusResponse {
@@ -64,7 +66,8 @@ async function getSubscriptions(subscriptionIds: string[]) : Promise<Subscriptio
             valid: valid,
             gracePeriod: gracePeriod,
             autoRenewing: sub.autoRenewing,
-            productId: sub.productId
+            productId: sub.productId,
+            softOptInProductName: mapPlatformToSoftOptInProductName(sub.platform),
         }
     });
 

--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -29,6 +29,7 @@ async function getUserSubscriptionIds(userId: string): Promise<string[]> {
     const subs: string[] = [];
 
     const subscriptionResults = dynamoMapper.query(ReadUserSubscription, {userId: userId});
+    console.log({ subscriptionResults })
 
     for await (const sub of subscriptionResults) {
         subs.push(sub.subscriptionId)
@@ -87,6 +88,7 @@ export async function handler(httpRequest: APIGatewayProxyEvent): Promise<APIGat
     try {
         const apiKeys = await apiKeysConfig();
         const authToken = getAuthToken(httpRequest.headers);
+        console.log({ authToken, apiKeys })
 
         let userId: string;
 

--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -29,7 +29,6 @@ async function getUserSubscriptionIds(userId: string): Promise<string[]> {
     const subs: string[] = [];
 
     const subscriptionResults = dynamoMapper.query(ReadUserSubscription, {userId: userId});
-    console.log({ subscriptionResults })
 
     for await (const sub of subscriptionResults) {
         subs.push(sub.subscriptionId)
@@ -88,7 +87,6 @@ export async function handler(httpRequest: APIGatewayProxyEvent): Promise<APIGat
     try {
         const apiKeys = await apiKeysConfig();
         const authToken = getAuthToken(httpRequest.headers);
-        console.log({ authToken, apiKeys })
 
         let userId: string;
 

--- a/typescript/tests/user/user.test.ts
+++ b/typescript/tests/user/user.test.ts
@@ -1,0 +1,69 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { handler } from "../../src/user/user";
+
+const TEST_SECRET = 'test_secret';
+jest.mock("../../src/utils/ssmConfig", () => {
+  return {
+    getConfigValue: () => Promise.resolve(TEST_SECRET),
+  };
+});
+
+jest.mock('@aws/dynamodb-data-mapper', () => {
+    const actualDataMapper = jest.requireActual('@aws/dynamodb-data-mapper');
+
+    const queryFn = jest.fn();
+
+    return {
+        ...actualDataMapper,
+        DataMapper: jest.fn().mockImplementation(() => ({
+            query: queryFn,
+        })),
+        setMockQuery: (mockImplementation: (arg0: any) => any) => {
+            queryFn.mockImplementation(async function* (params) {
+                const iterator = mockImplementation(params);
+                for await (const item of iterator) {
+                    yield item;
+                }
+            });
+        },
+    };
+});
+const setMockQuery = require('@aws/dynamodb-data-mapper').setMockQuery;
+
+describe("The user subscriptions lambda", () => {
+    it("returns the correct subscriptions for a user", async () => {
+        const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
+        const userId = "123";
+        setMockQuery(async function* () {
+            yield {
+                userId,
+                subscriptionId: "1",
+            };
+        });
+        const event = buildApiGatewayEvent(userId);
+
+        const response = await handler(event);
+
+        expect(response.statusCode).toBe(200);
+        expect(mockDataMapper.query).toHaveBeenCalledTimes(1);
+    });
+});
+
+
+const buildApiGatewayEvent = (userId: string): APIGatewayProxyEvent => {
+    return {
+        headers: {
+            'Authorization': `Bearer ${TEST_SECRET}`
+        },
+        multiValueHeaders: {},
+        httpMethod: "POST",
+        isBase64Encoded: false,
+        path: '',
+        pathParameters: { userId },
+        queryStringParameters: {secret: "test_secret"},
+        multiValueQueryStringParameters: {},
+        // @ts-ignore
+        requestContext: null,
+        resource: '',
+    };
+};


### PR DESCRIPTION
## What does this change?

This PR adds the SOI product name to data returned by the /user/subscriptions endpoint(s). This will be used by the soft-opt-in-consents-setter lambda.

## How to test

I've added some test coverage to the existing lambda, and will attempt to test on CODE too.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
