### PR TITLE
Add Feast SQS Queue for Android

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -770,12 +770,12 @@ Resources:
         - Key: App
           Value: !Ref App
 
-  FeastAndriodSubscriptionsQueue:
+  FeastAndroidSubscriptionsQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub ${App}-${Stage}-feast-andriod-subscriptions-to-fetch
+      QueueName: !Sub ${App}-${Stage}-feast-android-subscriptions-to-fetch
       RedrivePolicy:
-        deadLetterTargetArn: !GetAtt FeastAndriodSubscriptionsQueueDlq.Arn
+        deadLetterTargetArn: !GetAtt FeastAndroidSubscriptionsQueueDlq.Arn
         maxReceiveCount: 8
       KmsMasterKeyId: alias/aws/sqs
       Tags:
@@ -786,10 +786,10 @@ Resources:
         - Key: App
           Value: !Ref App
 
-  FeastAndriodSubscriptionsQueueDlq:
+  FeastAndroidSubscriptionsQueueDlq:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub ${App}-${Stage}-feast-andriod-subscriptions-to-fetch-dlq
+      QueueName: !Sub ${App}-${Stage}-feast-android-subscriptions-to-fetch-dlq
       KmsMasterKeyId: alias/aws/sqs
       Tags:
         - Key: Stage
@@ -1236,7 +1236,7 @@ Resources:
         - Ref: AlarmTopic
       TreatMissingData: notBreaching
 
-  FeastAndriodSubscriptionDlqDepthAlarm:
+  FeastAndroidSubscriptionDlqDepthAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled:
@@ -1246,7 +1246,7 @@ Resources:
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:
         - Name: QueueName
-          Value: !GetAtt "FeastAndriodSubscriptionsQueueDlq.QueueName"
+          Value: !GetAtt "FeastAndroidSubscriptionsQueueDlq.QueueName"
       Period: 60
       Statistic: Sum
       EvaluationPeriods: 1

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1241,7 +1241,7 @@ Resources:
     Properties:
       ActionsEnabled:
         !FindInMap [ StageVariables, !Ref Stage, AlarmActionsEnabled ]
-      AlarmDescription: "Ensure that the Feast Apple subscription dead letter queue is empty"
+      AlarmDescription: "Ensure that the Feast Android subscription dead letter queue is empty"
       Namespace: "AWS/SQS"
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -770,6 +770,35 @@ Resources:
         - Key: App
           Value: !Ref App
 
+  FeastAndriodSubscriptionsQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-feast-andriod-subscriptions-to-fetch
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt FeastAndriodSubscriptionsQueueDlq.Arn
+        maxReceiveCount: 8
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
+  FeastAndriodSubscriptionsQueueDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-feast-andriod-subscriptions-to-fetch-dlq
+      KmsMasterKeyId: alias/aws/sqs
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+
   GoogleTokenRefreshFailureAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -1196,6 +1225,28 @@ Resources:
       Dimensions:
         - Name: QueueName
           Value: !GetAtt "FeastAppleSubscriptionsQueueDlq.QueueName"
+      Period: 60
+      Statistic: Sum
+      EvaluationPeriods: 1
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions:
+        - Ref: AlarmTopic
+      OKActions:
+        - Ref: AlarmTopic
+      TreatMissingData: notBreaching
+
+  FeastAndriodSubscriptionDlqDepthAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled:
+        !FindInMap [ StageVariables, !Ref Stage, AlarmActionsEnabled ]
+      AlarmDescription: "Ensure that the Feast Apple subscription dead letter queue is empty"
+      Namespace: "AWS/SQS"
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt "FeastAndriodSubscriptionsQueueDlq.QueueName"
       Period: 60
       Statistic: Sum
       EvaluationPeriods: 1


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
To create an SQS and deadletter queue for the Android.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
