### PR TITLE
Create `feast-google-update-subscriptions` lambda

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,3 +102,5 @@ jobs:
               - tsc-target/feast-apple-update-subscriptions.zip
             mobile-purchases-feast-google-pubsub:
               - tsc-target/feast-google-pubsub.zip
+            mobile-purchases-feast-google-update-subscriptions:
+              - tsc-target/feast-google-update-subscriptions.zip

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -160,6 +160,7 @@ Resources:
                 - !GetAtt GoogleSubscriptionsQueue.Arn
                 - !GetAtt AppleSubscriptionsQueue.Arn
                 - !GetAtt FeastAppleSubscriptionsQueue.Arn
+                - !GetAtt FeastAndroidSubscriptionsQueue.Arn
                 - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-apple-historical-subscriptions
                 - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-google-historical-subscriptions
         - PolicyName: Kms
@@ -1258,6 +1259,14 @@ Resources:
       FunctionName: !Ref UpdateFeastAppleSubscriptionsLambda
       Enabled: true
       EventSourceArn: !GetAtt FeastAppleSubscriptionsQueue.Arn
+      BatchSize: 1
+
+  FeastGoogleSubscriptionsEventSource:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      FunctionName: !Ref UpdateGoogleAppleSubscriptionsLambda
+      Enabled: true
+      EventSourceArn: !GetAtt FeastAndroidSubscriptionsQueue.Arn
       BatchSize: 1
 
   FeastAppleSubscriptionDlqDepthAlarm:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1264,7 +1264,7 @@ Resources:
   FeastGoogleSubscriptionsEventSource:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
-      FunctionName: !Ref UpdateGoogleAppleSubscriptionsLambda
+      FunctionName: !Ref UpdateFeastGoogleSubscriptionsLambda
       Enabled: true
       EventSourceArn: !GetAtt FeastAndroidSubscriptionsQueue.Arn
       BatchSize: 1

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1233,6 +1233,25 @@ Resources:
       Timeout: 25
       Runtime: nodejs20.x
 
+  UpdateFeastGoogleSubscriptionsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${App}-feast-google-update-subscriptions-${Stage}
+      Code:
+        S3Bucket: !Ref DeployBucket
+        S3Key: !Sub ${Stack}/${Stage}/${App}-feast-google-update-subscriptions/feast-google-update-subscriptions.zip
+      Environment:
+        Variables:
+          App: !Sub ${App}
+          Stack: !Sub ${Stack}
+          Stage: !Sub ${Stage}
+      Description: Consumes Feast subscription data updates from Google Play store from sqs and stores them in dynamo
+      Handler: feast-google-update-subscriptions.handler
+      MemorySize: 512
+      Role: !GetAtt MobilePurchasesLambdasRole.Arn
+      Timeout: 25
+      Runtime: nodejs20.x
+
   FeastAppleSubscriptionsEventSource:
     Type: AWS::Lambda::EventSourceMapping
     Properties:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -44,6 +44,12 @@ deployments:
       functionNames: [mobile-purchases-feast-apple-update-subscriptions-]
       fileName: feast-apple-update-subscriptions.zip
 
+  mobile-purchases-feast-google-update-subscriptions:
+    template: lambda
+    parameters:
+      functionNames: [ mobile-purchases-feast-google-update-subscriptions- ]
+      fileName: feast-google-update-subscriptions.zip
+
   mobile-purchases-feast-google-pubsub:
     template: lambda
     parameters:

--- a/typescript/src/feast/update-subs/google.ts
+++ b/typescript/src/feast/update-subs/google.ts
@@ -1,0 +1,9 @@
+import { SQSEvent } from "aws-lambda";
+
+export function buildHandler(): (event: SQSEvent) => void {
+    return (event: SQSEvent) => {
+        console.log(`Received SQS event: ${event}`)
+    }
+}
+
+export const handler = buildHandler();

--- a/typescript/src/feast/update-subs/google.ts
+++ b/typescript/src/feast/update-subs/google.ts
@@ -2,7 +2,7 @@ import { SQSEvent } from "aws-lambda";
 
 export function buildHandler(): (event: SQSEvent) => void {
     return (event: SQSEvent) => {
-        console.log(`Received SQS event: ${event}`)
+        console.log("Received SQS event:", event)
     }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ const getEntries = (env) => {
     "feast-apple-pubsub": "./typescript/src/feast/pubsub/apple.ts",
     "feast-apple-update-subscriptions": "./typescript/src/feast/update-subs/apple.ts",
     "feast-google-pubsub": "./typescript/src/feast/pubsub/google.ts",
+    "feast-google-update-subscriptions": "./typescript/src/feast/update-subs/google.ts",
   };
   return env.production ? entries : {
     ...entries,


### PR DESCRIPTION
Defines a new lambda for updating Feast subs with the Google Play Store. The lambda's handler function is just a skeleton currently, but it's ready to be built up. 