### PR TITLE
Send Feast SOI email for Android (as well as iOS)

### DIFF
--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -76,6 +76,7 @@ async function sendSoftOptIns(identityId: string, subscriptionId: string, platfo
 const buildBrazeEmailMessage = (emailAddress: string, identityId: string, platform: string | undefined) => {
     switch (platform) {
         case Platform.IosFeast:
+        case Platform.AndroidFeast:
             return {
                 To: {
                     Address: emailAddress,
@@ -122,7 +123,8 @@ export async function processAcquisition(subscriptionRecord: ReadSubscription, i
         handleError(`Soft opt-in message send failed for subscriptionId: ${subscriptionId}. ${e}`)
     }
 
-    const isFeast = subscriptionRecord.platform === Platform.IosFeast;
+    const isFeast = subscriptionRecord.platform === Platform.IosFeast
+        || subscriptionRecord.platform === Platform.AndroidFeast;
 
     if (subscriptionRecord && (isPostAcquisition(subscriptionRecord.startTimestamp) || isFeast)) {
         const identityApiKey = await getIdentityApiKey();


### PR DESCRIPTION
## What does this change?

When a reader takes out a Feast Android IAP we want to send the same SOI email from Braze as for iOS Feast.

## How to test

I've added to the lambda Jest tests to cover this.

I've also tested in CODE. I posted a dummy Dynamo insert event to the lambda for a subscription which has a platform of `android-feast` and can see it pushed an event to the queue with the correct campaign iD:

![Screenshot 2024-06-05 at 09 05 28](https://github.com/guardian/mobile-purchases/assets/379839/4795d04e-7cc0-4db7-a102-6aa375d9f748)

Note that there's an issue with the SOI consent setter cross account role so I had to comment this bit out to test the email send part.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
