### PR TITLE
Ensure that soft opt-ins are set for Android Feast in-app purchases

### DIFF
--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -122,7 +122,7 @@ export async function processAcquisition(subscriptionRecord: ReadSubscription, i
         handleError(`Soft opt-in message send failed for subscriptionId: ${subscriptionId}. ${e}`)
     }
 
-    const isFeast = (): boolean =>
+    const isFeast =
         subscriptionRecord.platform === Platform.IosFeast ||
         subscriptionRecord.platform === Platform.AndroidFeast;
 

--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -122,7 +122,9 @@ export async function processAcquisition(subscriptionRecord: ReadSubscription, i
         handleError(`Soft opt-in message send failed for subscriptionId: ${subscriptionId}. ${e}`)
     }
 
-    const isFeast = subscriptionRecord.platform === Platform.IosFeast;
+    const isFeast = (): boolean =>
+        subscriptionRecord.platform === Platform.IosFeast ||
+        subscriptionRecord.platform === Platform.AndroidFeast;
 
     if (subscriptionRecord && (isPostAcquisition(subscriptionRecord.startTimestamp) || isFeast)) {
         const identityApiKey = await getIdentityApiKey();

--- a/typescript/src/utils/softOptIns.ts
+++ b/typescript/src/utils/softOptIns.ts
@@ -5,6 +5,7 @@ export type SoftOptInEventProductName = "InAppPurchase" | "FeastInAppPurchase";
 export const mapPlatformToSoftOptInProductName = (platform: string | undefined): SoftOptInEventProductName => {
     switch (platform) {
         case Platform.IosFeast:
+        case Platform.AndroidFeast:
             return "FeastInAppPurchase";
         default:
             return "InAppPurchase";

--- a/typescript/tests/soft-opt-ins/acquisition.test.ts
+++ b/typescript/tests/soft-opt-ins/acquisition.test.ts
@@ -293,12 +293,11 @@ describe('handler', () => {
 
         // We expect mockSQS to have been called twice - once for the soft opt in setter and once for the email queue
         expect(mockSQS.sendMessage).toHaveBeenCalledTimes(2);
-        // TODO: fix this when correct SOIs are sent
-        // const expectedSOIParams = {
-        //     QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV`,
-        //     MessageBody: JSON.stringify({ identityId, eventType: 'Acquisition', productName: "FeastInAppPurchase", subscriptionId }),
-        // };
-        // expect(mockSQS.sendMessage).toHaveBeenCalledWith(expectedSOIParams);
+        const expectedSOIParams = {
+            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV`,
+            MessageBody: JSON.stringify({ identityId, eventType: 'Acquisition', productName: "FeastInAppPurchase", subscriptionId }),
+        };
+        expect(mockSQS.sendMessage).toHaveBeenCalledWith(expectedSOIParams);
         const expectedEmailParams = {
             QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/braze-emails-CODE`,
             MessageBody: JSON.stringify({


### PR DESCRIPTION
This updates the existing switch statement to ensure that Android Feast IAPs trigger the correct soft opt-ins.