### PR TITLE
Fix writing to the soft-opt-in-consent-setter queue in CODE

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -63,7 +63,7 @@ Mappings:
     CODE:
       Schedule: 'rate(365 days)'
       AlarmActionsEnabled: FALSE
-      SoftOptInConsentSetterStage: DEV
+      SoftOptInConsentSetterStage: CODE
     PROD:
       Schedule: 'rate(30 minutes)'
       AlarmActionsEnabled: TRUE

--- a/typescript/src/link/deleteLink.ts
+++ b/typescript/src/link/deleteLink.ts
@@ -39,7 +39,7 @@ async function disableSoftOptIns(userLinks: ReadUserSubscription[], subscription
 
     const user = userLinks[0];
 
-    await sendToSqsSoftOptIns(Stage === "PROD" ? `${queueNamePrefix}/soft-opt-in-consent-setter-queue-PROD` : `${queueNamePrefix}/soft-opt-in-consent-setter-queue-DEV`, {
+    await sendToSqsSoftOptIns(Stage === "PROD" ? `${queueNamePrefix}/soft-opt-in-consent-setter-queue-PROD` : `${queueNamePrefix}/soft-opt-in-consent-setter-queue-CODE`, {
         identityId: user.userId,
         eventType: "Cancellation",
         productName: mapPlatformToSoftOptInProductName(platform),

--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -67,7 +67,7 @@ async function sendSoftOptIns(identityId: string, subscriptionId: string, platfo
     await sendToSqsSoftOptIns(
         Stage === "PROD"
             ? `${queueNamePrefix}/soft-opt-in-consent-setter-queue-PROD`
-            : `${queueNamePrefix}/soft-opt-in-consent-setter-queue-DEV`,
+            : `${queueNamePrefix}/soft-opt-in-consent-setter-queue-CODE`,
         message
     );
     console.log(`Sent message to soft-opt-in-consent-setter-queue for user: ${identityId}: ${JSON.stringify(message)}`)

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -40,7 +40,7 @@ async function getSqsClientForSoftOptIns(): Promise<Sqs> {
         const membershipAccountId = await getMembershipAccountId();
         const sts = new STS();
 
-        const softOptInConsentSetterStage = Stage === "PROD" ? "PROD" : "DEV";
+        const softOptInConsentSetterStage = Stage === "PROD" ? "PROD" : "CODE";
 
         const assumeRoleResult = await sts.assumeRole({
             RoleArn: `arn:aws:iam::${membershipAccountId}:role/membership-${softOptInConsentSetterStage}-soft-opt-in-consent-setter-QueueCrossAccountRole`,

--- a/typescript/tests/link/deleteLink.test.ts
+++ b/typescript/tests/link/deleteLink.test.ts
@@ -125,7 +125,7 @@ describe("handler", () => {
         };
 
         const expectedQueueMessageParams1 = {
-            QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV',
+            QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-CODE',
             MessageBody: JSON.stringify(expectedSoftOptInMessage1),
         };
 
@@ -164,7 +164,7 @@ describe("handler", () => {
         };
 
         const expectedQueueMessageParams1 = {
-            QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV',
+            QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-CODE',
             MessageBody: JSON.stringify(expectedSoftOptInMessage1),
         };
 

--- a/typescript/tests/soft-opt-ins/acquisition.test.ts
+++ b/typescript/tests/soft-opt-ins/acquisition.test.ts
@@ -159,7 +159,7 @@ describe('handler', () => {
         expect(mockSQS.sendMessage).toHaveBeenCalledTimes(1);
 
         const expectedSendMessageParams = {
-            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV`,
+            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-CODE`,
             MessageBody: JSON.stringify({identityId: '67890', eventType: 'Acquisition', productName: "InAppPurchase", subscriptionId: "12345"}),
         };
 
@@ -221,7 +221,7 @@ describe('handler', () => {
         // We expect mockSQS to have been called twice - once for the soft opt in setter and once for the email queue
         expect(mockSQS.sendMessage).toHaveBeenCalledTimes(2);
         const expectedSOIParams = {
-            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV`,
+            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-CODE`,
             MessageBody: JSON.stringify({ identityId, eventType: 'Acquisition', productName: "FeastInAppPurchase", subscriptionId }),
         };
         expect(mockSQS.sendMessage).toHaveBeenCalledWith(expectedSOIParams);
@@ -294,7 +294,7 @@ describe('handler', () => {
         // We expect mockSQS to have been called twice - once for the soft opt in setter and once for the email queue
         expect(mockSQS.sendMessage).toHaveBeenCalledTimes(2);
         const expectedSOIParams = {
-            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV`,
+            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-CODE`,
             MessageBody: JSON.stringify({ identityId, eventType: 'Acquisition', productName: "FeastInAppPurchase", subscriptionId }),
         };
         expect(mockSQS.sendMessage).toHaveBeenCalledWith(expectedSOIParams);
@@ -370,7 +370,7 @@ describe('handler', () => {
         expect(fetch).toHaveBeenCalledTimes(1);
 
         const expectedSendMessageParams1 = {
-            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-DEV`,
+            QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-CODE`,
             MessageBody: JSON.stringify({identityId: '67890', eventType: 'Acquisition', productName: "InAppPurchase", subscriptionId: "12345"}),
         };
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Previously running the SOI acquisition lambda in CODE would always fail with an error about writing to the SQS queue for the soft-opt-in-consent-setter lambda. This is because the mobile-purchases codebase expected the soi-consent-setter stage to be `DEV`, but it's actually `CODE`. It was renamed/consolidated to CODE in guardian/support-service-lambdas#1955. Since then, this part of the codebase hasn't worked in mobile-purchases CODE since it was referencing constructs which didn't exist.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've invoked the lambda in CODE and can see that it now successfully writes to the CODE queue for the soft-opt-in-consent-setter.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
