### PR TITLE
Refactor Android Feast update-subs handler + add test

### DIFF
--- a/typescript/src/feast/update-subs/google.ts
+++ b/typescript/src/feast/update-subs/google.ts
@@ -1,11 +1,50 @@
-import {SQSEvent} from "aws-lambda";
-import {parseAndStoreSubscriptionUpdate} from "../../update-subs/updatesub";
-import {getGoogleSubResponse} from "../../update-subs/google";
+import { SQSEvent, SQSRecord } from "aws-lambda";
+import { getGoogleSubResponse } from "../../update-subs/google";
+import { Subscription } from '../../models/subscription';
+import { ProcessingError } from "../../models/processingError";
+import { GracefulProcessingError } from "../../models/GracefulProcessingError";
+import { putSubscription } from "../../update-subs/updatesub";
 
-export async function handler(event: SQSEvent) {
-    const promises = event.Records.map(record => parseAndStoreSubscriptionUpdate(record, getGoogleSubResponse));
+export const buildHandler = (
+    fetchSubscriptionDetails: (record: SQSRecord) => Promise<Subscription[]>,
+    putSubscription: (subscription: Subscription) => Promise<Subscription>,
+): (event: SQSEvent) => Promise<string> => (async (event: SQSEvent) => { 
+    const promises = event.Records.map(async (sqsRecord: SQSRecord) => {
+        try {
+            const subscriptions = await fetchSubscriptionDetails(sqsRecord); // Subscription[]
+            await Promise.all(subscriptions.map(sub => putSubscription(sub)));
+
+            console.log(`Processed ${subscriptions.length} subscriptions: ${subscriptions.map(s => s.subscriptionId)}`);
+
+            return "OK"
+        } catch (error) {
+            if (error instanceof ProcessingError) {
+                console.error("Error processing the subscription update", error);
+
+                if (error.shouldRetry) {
+                    console.error("Will throw an exception to retry this message");
+                    throw error;
+                }  else {
+                    console.error("The error wasn't retryable, giving up.");
+                    return "Error, giving up"
+                }
+            } else if(error instanceof GracefulProcessingError){
+                console.warn("Error processing the subscription update is being handled gracefully", error);
+
+                return "OK";
+            } else {
+                console.error("Unexpected error, will throw to retry: ", error);
+
+                throw error;
+            }
+        }
+    });
 
     return Promise.all(promises)
         .then(_  => "OK")
+})
 
-}
+export const handler = buildHandler(
+    getGoogleSubResponse,
+    putSubscription,
+);

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -4,11 +4,11 @@ import {dynamoMapper, sendToSqs} from "../utils/aws";
 import {ProcessingError} from "../models/processingError";
 import {GracefulProcessingError} from "../models/GracefulProcessingError";
 
-function putSubscription(subscription: Subscription): Promise<Subscription> {
+export function putSubscription(subscription: Subscription): Promise<Subscription> {
     return dynamoMapper.put({item: subscription}).then(result => result.item)
 }
 
-async function queueHistoricalSubscription(subscription: Subscription): Promise<void> {
+export async function queueHistoricalSubscription(subscription: Subscription): Promise<void> {
     const queueUrl = process.env.HistoricalQueueUrl;
     if (queueUrl === undefined) throw new Error("No HistoricalQueueUrl env parameter provided");
 

--- a/typescript/tests/feast/update-subs/google.test.ts
+++ b/typescript/tests/feast/update-subs/google.test.ts
@@ -34,7 +34,7 @@ describe("The Feast Android subscription updater", () => {
             subscriptionFromGoogle,
             undefined, // receipt
             null, // apple payload
-            undefined,
+            undefined, // ttl
         );
         const stubFetchSubscriptionsFromGoogle = () => Promise.resolve([subscription]);
         const mockStoreSubscriptionInDynamo = jest.fn((subscription: Subscription) => Promise.resolve(subscription))

--- a/typescript/tests/feast/update-subs/google.test.ts
+++ b/typescript/tests/feast/update-subs/google.test.ts
@@ -1,0 +1,52 @@
+import { buildHandler } from "../../../src/feast/update-subs/google";
+import { Subscription } from "../../../src/models/subscription";
+import { GoogleResponseBody } from "../../../src/services/google-play";
+import { plusDays } from "../../../src/utils/dates";
+import { buildSqsEvent } from "./test-helpers";
+
+describe("The Feast Android subscription updater", () => {
+    it("Should fetch the subscription associated with the reference from Google and persist to Dynamo", async () => {
+        const packageName = "uk.co.guardian.feast";
+        const purchaseToken = "test-purchase-token";
+        const subscriptionId = "test-subscription-id";
+        const event = buildSqsEvent([{
+            packageName,
+            purchaseToken,
+            subscriptionId,
+        }]);
+        const subscriptionFromGoogle: GoogleResponseBody = {
+            autoRenewing: true,
+            expiryTimeMillis: plusDays(new Date(), 30).getTime().toString(),
+            paymentState: 1,
+            startTimeMillis: plusDays(new Date(), -1).getTime().toString(),
+            userCancellationTimeMillis: "",
+        };
+        const subscription = new Subscription(
+            purchaseToken,
+            plusDays(new Date(), -1).toISOString(), // start date
+            plusDays(new Date(), 30).toISOString(), // expiry date
+            undefined, // cancellation date
+            true, // auto renewing
+            subscriptionId,
+            "android-feast",
+            false, // free trial
+            "monthly",
+            subscriptionFromGoogle,
+            undefined, // receipt
+            null, // apple payload
+            undefined,
+        );
+        const stubFetchSubscriptionsFromGoogle = () => Promise.resolve([subscription]);
+        const mockStoreSubscriptionInDynamo = jest.fn((subscription: Subscription) => Promise.resolve(subscription))
+        const handler = buildHandler(
+            stubFetchSubscriptionsFromGoogle,
+            mockStoreSubscriptionInDynamo,
+        );
+
+        const result = await handler(event);
+
+        expect(result).toEqual("OK");
+        expect(mockStoreSubscriptionInDynamo.mock.calls.length).toEqual(1);
+        expect(mockStoreSubscriptionInDynamo).toHaveBeenCalledWith(subscription);
+    });
+});

--- a/typescript/tests/feast/update-subs/test-helpers.ts
+++ b/typescript/tests/feast/update-subs/test-helpers.ts
@@ -1,0 +1,26 @@
+import type { SQSEvent } from "aws-lambda";
+import type { SubscriptionReference } from "../../../src/models/subscriptionReference";
+
+export const buildSqsEvent = (subscriptions: SubscriptionReference[]): SQSEvent => {
+    const records = subscriptions.map(subscription =>
+    ({
+        messageId: "",
+        receiptHandle: "",
+        body: JSON.stringify(subscription),
+        attributes: {
+            ApproximateReceiveCount: "",
+            SentTimestamp: "",
+            SenderId: "",
+            ApproximateFirstReceiveTimestamp: "",
+        },
+        messageAttributes: {},
+        md5OfBody: "",
+        eventSource: "",
+        eventSourceARN: "",
+        awsRegion: "",
+    }))
+
+    return {
+        Records: records
+    }
+}


### PR DESCRIPTION
## What does this change?

This PR refactors the Android Feast update-subs handler to make it easier to test and to extend for Feast specific things.

Note that I've removed the queueing of historical subs. We don't do this for iOS Feast, I'm pretty sure this was de-scoped.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Tested in CODE (and added a Jest integration test).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
