### PR TITLE
Use purchases.subscriptionsv2 for Android Feast subscriptions

### DIFF
--- a/typescript/src/feast/update-subs/google.ts
+++ b/typescript/src/feast/update-subs/google.ts
@@ -42,6 +42,8 @@ export const buildHandler = (
             const subscription = googleSubscriptionToSubscription(subRef.purchaseToken, subRef.packageName, subscriptionFromGoogle);
             await putSubscription(subscription);
 
+            console.log("Obfuscated external account ID:", subscriptionFromGoogle.obfuscatedExternalAccountId)
+
             console.log(`Processed subscription: ${subscription.subscriptionId}`);
 
             return "OK"

--- a/typescript/src/feast/update-subs/google.ts
+++ b/typescript/src/feast/update-subs/google.ts
@@ -42,8 +42,6 @@ export const buildHandler = (
             const subscription = googleSubscriptionToSubscription(subRef.purchaseToken, subRef.packageName, subscriptionFromGoogle);
             await putSubscription(subscription);
 
-            console.log("Obfuscated external account ID:", subscriptionFromGoogle.obfuscatedExternalAccountId)
-
             console.log(`Processed subscription: ${subscription.subscriptionId}`);
 
             return "OK"

--- a/typescript/src/services/google-play-v2.ts
+++ b/typescript/src/services/google-play-v2.ts
@@ -21,6 +21,8 @@ export type GoogleSubscription = {
     freeTrial: boolean
     // Whether the subscription was taken out as a test purchase
     testPurchase: boolean,
+    // Obfuscated external account ID
+    obfuscatedExternalAccountId?: string,
     // The raw response from Google
     rawResponse: unknown,
 }
@@ -113,6 +115,8 @@ export async function fetchGoogleSubscriptionV2(
             throw Error("An order ID is expected to be associated with the purchase, but was not present")
         }
 
+        const obfuscatedExternalAccountId = purchase.data.externalAccountIdentifiers?.obfuscatedExternalAccountId ?? undefined;
+
         return {
             startTime: parseNullableDate(startTime),
             expiryTime: new Date(expiryTime),
@@ -122,6 +126,7 @@ export async function fetchGoogleSubscriptionV2(
             billingPeriodDuration,
             freeTrial: isFreeTrial(offerId, latestOrderId),
             testPurchase,
+            obfuscatedExternalAccountId,
             rawResponse: purchase.data,
         }
     } catch (error: any) {

--- a/typescript/src/services/google-play-v2.ts
+++ b/typescript/src/services/google-play-v2.ts
@@ -20,7 +20,9 @@ export type GoogleSubscription = {
     // Whether the subscription is currently benefitting from a free trial
     freeTrial: boolean
     // Whether the subscription was taken out as a test purchase
-    testPurchase: boolean
+    testPurchase: boolean,
+    // The raw response from Google
+    rawResponse: unknown,
 }
 
 // Given a `purchaseToken` and `packageName`, attempts to build a `GoogleSubscription` by:
@@ -119,7 +121,8 @@ export async function fetchGoogleSubscriptionV2(
             productId,
             billingPeriodDuration,
             freeTrial: isFreeTrial(offerId, latestOrderId),
-            testPurchase
+            testPurchase,
+            rawResponse: purchase.data,
         }
     } catch (error: any) {
         if (error?.status == 400 || error?.status == 404 || error?.status == 410) {

--- a/typescript/tests/feast/update-subs/google.test.ts
+++ b/typescript/tests/feast/update-subs/google.test.ts
@@ -27,7 +27,8 @@ describe("The Feast Android subscription updater", () => {
             productId: subscriptionId,
             billingPeriodDuration: "P1M",
             freeTrial: false,
-            testPurchase: false
+            testPurchase: false,
+            rawResponse: "test-raw-response",
         };
         const subscription = new Subscription(
             purchaseToken,

--- a/typescript/tests/feast/update-subs/google.test.ts
+++ b/typescript/tests/feast/update-subs/google.test.ts
@@ -28,6 +28,7 @@ describe("The Feast Android subscription updater", () => {
             billingPeriodDuration: "P1M",
             freeTrial: false,
             testPurchase: false,
+            obfuscatedExternalAccountId: "aaaa-bbbb-cccc-dddd",
             rawResponse: "test-raw-response",
         };
         const subscription = new Subscription(


### PR DESCRIPTION
## What does this change?

Use the [`purchases.subscriptionsv2`](https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2) endpoint to retrieve data about Android Feast subs, instead of [`purchases.subscriptions` v1](https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptions) (which we use for the live app).

The reason for the migration is that when using the v1 endpoint, we rely on being able to map a product ID to a billing duration. This mapping is defined here:https://github.com/guardian/mobile-purchases/blob/bb1632ea1e53d0fb2ca0e870b67677558a4ea2b9/typescript/src/services/productBillingPeriod.ts#L4. This isn't very robust (in the past, new products have been added in the Play store, but not reflected here, meaning we get rows without a billing period). Furthermore, the was the Feast app has been configured in the Play store, it's not actually possible to map things this way. Instead, if we use the v2 endpoint, we can retrieve the billing period using Play store APIs.

Some back story on the v2 endpont: Tom Wadeson did some work to implement the v2 endpoint. In product there's a test which uses the v2 endpoint in parallel with the v1 endpoint for x% of requests to the subscriptions endpoint. There's a draft PR #1338 to use the new libs everywhere, but not merged yet. Using this for Feast feels like a nice step in the migration path as we're using it for real but in a focused context.

## How to test

I've updated the Jest tests and tested in CODE (and can now see the billing duration being correctly set).

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
