### PR TITLE
Exchange the UUID for an Identity ID with Braze

### DIFF
--- a/typescript/tests/feast/update-subs/google.test.ts
+++ b/typescript/tests/feast/update-subs/google.test.ts
@@ -48,9 +48,11 @@ describe("The Feast Android subscription updater", () => {
         );
         const mockFetchSubscriptionsFromGoogle = jest.fn(() => Promise.resolve(googleSubscription));
         const mockStoreSubscriptionInDynamo = jest.fn((subscription: Subscription) => Promise.resolve(subscription))
+        const mockExchangeUuid = jest.fn((uuid: string) => Promise.resolve('123456'))
         const handler = buildHandler(
             mockFetchSubscriptionsFromGoogle,
             mockStoreSubscriptionInDynamo,
+            mockExchangeUuid,
         );
 
         const result = await handler(event);
@@ -59,5 +61,6 @@ describe("The Feast Android subscription updater", () => {
         expect(mockFetchSubscriptionsFromGoogle).toHaveBeenCalledWith(purchaseToken, packageName);
         expect(mockStoreSubscriptionInDynamo.mock.calls.length).toEqual(1);
         expect(mockStoreSubscriptionInDynamo).toHaveBeenCalledWith(subscription);
+        expect(mockExchangeUuid).toHaveBeenCalledWith(googleSubscription.obfuscatedExternalAccountId);
     });
 });


### PR DESCRIPTION
## What does this change?

In the Feast Google update subscriptions lambda, exchange the UUID we have for an Identity ID using Braze (just like for the Apple equivalent).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

The Jest tests have been extended to cover this and we successfully tested in CODE (note that we had to temporarily use Braze prod from CODE so that the user in the receipt could be found).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
