### PR TITLE
Write to user-subscription link table for Feast Android

### DIFF
--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -9,6 +9,7 @@ import { ProcessingError } from "../../models/processingError";
 import { UserSubscription } from "../../models/userSubscription";
 import { getIdentityIdFromBraze } from "../../services/braze";
 import { GracefulProcessingError } from "../../models/GracefulProcessingError";
+import { storeUserSubscriptionInDynamo as defaultStoreUserSubscriptionInDynamo } from "./common";
 
 export type SubscriptionMaybeWithAppAccountToken = Subscription & {
     appAccountToken?: string
@@ -39,11 +40,6 @@ export const defaultFetchSubscriptionsFromApple =
 const defaultStoreSubscriptionInDynamo =
     (subscription: Subscription): Promise<void> => {
         return dynamoMapper.put({item: subscription}).then(_ => {})
-    }
-
-const defaultStoreUserSubscriptionInDynamo =
-    (userSubscription: UserSubscription): Promise<void> => {
-        return dynamoMapper.put({ item: userSubscription }).then(_ => {})
     }
 
 type FetchSubsFromApple = (reference: AppleSubscriptionReference) => Promise<SubscriptionMaybeWithAppAccountToken[]>;

--- a/typescript/src/feast/update-subs/common.ts
+++ b/typescript/src/feast/update-subs/common.ts
@@ -1,0 +1,6 @@
+import { UserSubscription } from "../../models/userSubscription"
+import { dynamoMapper } from "../../utils/aws"
+
+export const storeUserSubscriptionInDynamo = (userSubscription: UserSubscription): Promise<void> => {
+    return dynamoMapper.put({ item: userSubscription }).then(_ => {})
+}


### PR DESCRIPTION
## What does this change?

Following on from #1547, use the identity ID to store a user subscription record.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

The Jest tests have been extended and I've tested in CODE. As in #1547 I had to briefly switch to talking to Braze prod for the exchange as the payload I was testing with was a test sub from prod - an internal purchase by a developer.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
