### PR TITLE
replace feast android sqs queue to follow convention in repo

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -781,7 +781,7 @@ Resources:
         maxReceiveCount: 8
       KmsMasterKeyId: alias/aws/sqs
       Tags:
-        - Key: Stag
+        - Key: Stage
           Value: !Ref Stage
         - Key: Stack
           Value: !Ref Stack

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -160,7 +160,7 @@ Resources:
                 - !GetAtt GoogleSubscriptionsQueue.Arn
                 - !GetAtt AppleSubscriptionsQueue.Arn
                 - !GetAtt FeastAppleSubscriptionsQueue.Arn
-                - !GetAtt FeastAndroidSubscriptionsQueue.Arn
+                - !GetAtt FeastGoogleSubscriptionsQueue.Arn
                 - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-apple-historical-subscriptions
                 - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${App}-${Stage}-google-historical-subscriptions
         - PolicyName: Kms
@@ -637,7 +637,7 @@ Resources:
           Stack: !Ref Stack
           App: !Ref App
           Secret: !Ref FeastGooglePubSubSecret
-          QueueUrl: !Ref FeastAndroidSubscriptionsQueue
+          QueueUrl: !Ref FeastGoogleSubscriptionsQueue
       Description: Records Google play store events for Feast app
       MemorySize: 128
       Timeout: 29
@@ -772,26 +772,26 @@ Resources:
         - Key: App
           Value: !Ref App
 
-  FeastAndroidSubscriptionsQueue:
+  FeastGoogleSubscriptionsQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub ${App}-${Stage}-feast-android-subscriptions-to-fetch
+      QueueName: !Sub ${App}-${Stage}-feast-google-subscriptions-to-fetch
       RedrivePolicy:
-        deadLetterTargetArn: !GetAtt FeastAndroidSubscriptionsQueueDlq.Arn
+        deadLetterTargetArn: !GetAtt FeastGoogleSubscriptionsQueueDlq.Arn
         maxReceiveCount: 8
       KmsMasterKeyId: alias/aws/sqs
       Tags:
-        - Key: Stage
+        - Key: Stag
           Value: !Ref Stage
         - Key: Stack
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
 
-  FeastAndroidSubscriptionsQueueDlq:
+  FeastGoogleSubscriptionsQueueDlq:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub ${App}-${Stage}-feast-android-subscriptions-to-fetch-dlq
+      QueueName: !Sub ${App}-${Stage}-feast-google-subscriptions-to-fetch-dlq
       KmsMasterKeyId: alias/aws/sqs
       Tags:
         - Key: Stage
@@ -1267,7 +1267,7 @@ Resources:
     Properties:
       FunctionName: !Ref UpdateFeastGoogleSubscriptionsLambda
       Enabled: true
-      EventSourceArn: !GetAtt FeastAndroidSubscriptionsQueue.Arn
+      EventSourceArn: !GetAtt FeastGoogleSubscriptionsQueue.Arn
       BatchSize: 1
 
   FeastAppleSubscriptionDlqDepthAlarm:
@@ -1295,7 +1295,7 @@ Resources:
         - Key: App
           Value: mobile-purchases-feast-apple-update-subscriptions
 
-  FeastAndroidSubscriptionDlqDepthAlarm:
+  FeastGoogleSubscriptionDlqDepthAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled:
@@ -1305,7 +1305,7 @@ Resources:
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:
         - Name: QueueName
-          Value: !GetAtt "FeastAndroidSubscriptionsQueueDlq.QueueName"
+          Value: !GetAtt "FeastGoogleSubscriptionsQueueDlq.QueueName"
       Period: 60
       Statistic: Sum
       EvaluationPeriods: 1


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR renames the `feast android` with `feast google` to align with the project's naming conventions. This change improves code consistency

- `FeastAndroidSubscriptionsQueue` to `FeastGoogleSubscriptionsQueue`
- `feast-android-subscriptions-to-fetch` to  `feast-google-subscriptions-to-fetch`

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This has been tested in CODE, making sure that the upstream and downstream lambdas work

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
