### PR TITLE
Change apple-subscription-status-check-errors alarm

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -922,11 +922,9 @@ Resources:
         !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
       AlarmActions:
         - Ref: AlarmTopic
-      OKActions:
-        - Ref: AlarmTopic
       AlarmName: !Sub mobile-purchases-${Stage}-apple-subscription-status-check-errors
       AlarmDescription: |
-        More than 10% of attempts to check Apple subscription status resulted in a 5XX error.
+        More than 10% of attempts to check Apple subscription status resulted in a 5XX error over a 20min period.
       Metrics:
         - Id: e1
           Label: Percentage of requests which result in a 5XX error
@@ -946,7 +944,7 @@ Resources:
                   Value: /apple/subscription/status
                 - Name: Stage
                   Value: !Ref Stage
-            Period: 600
+            Period: 1200
             Stat: Sum
           ReturnData: false
         - Id: m2
@@ -964,7 +962,7 @@ Resources:
                   Value: /apple/subscription/status
                 - Name: Stage
                   Value: !Ref Stage
-            Period: 600
+            Period: 1200
             Stat: Sum
           ReturnData: false
       ComparisonOperator: GreaterThanOrEqualToThreshold


### PR DESCRIPTION
This endpoint is called by the iOS app to check if a subscription is valid.
If it fails, there is no immediate effect on the user.

This error rate alarm sometimes goes off during quiet periods overnight.
We do get the occasional error, which appears to be on Apple's side. Specifically:
1. Lambda time outs. The timeout is 30 seconds, which is reasonable given this is client facing.
2. `Server error received from Apple, got status 21107, will retry`

This PR:
1. increases the period of the alarm from 10mins to 20mins. This should make it less sensitive to errors during quiet periods.
2. Removes the `OKActions`, which triggers an unhelpful follow up event