### PR TITLE
Rewrite product_id for Feast Android test purchases

### DIFF
--- a/typescript/src/services/google-play-v2.ts
+++ b/typescript/src/services/google-play-v2.ts
@@ -74,11 +74,10 @@ export async function fetchGoogleSubscriptionV2(
         const testPurchase =
             purchase.data?.testPurchase ? true : false
 
-        if (!product.productId) {
+        const productId = product.productId;
+        if (!productId) {
             throw Error("The product does not have an ID")
         }
-
-        const productId = mapAndroidProductId(product.productId, packageName, testPurchase)
 
         const basePlanId =
             product.offerDetails?.basePlanId
@@ -122,7 +121,8 @@ export async function fetchGoogleSubscriptionV2(
             expiryTime: new Date(expiryTime),
             userCancellationTime: parseNullableDate(userCancellationTime),
             autoRenewing,
-            productId,
+            // Map the product_id for test Feast purchases for easy identification downstream
+            productId: mapAndroidProductId(productId, packageName, testPurchase),
             billingPeriodDuration,
             freeTrial: isFreeTrial(offerId, latestOrderId),
             testPurchase,

--- a/typescript/src/services/google-play-v2.ts
+++ b/typescript/src/services/google-play-v2.ts
@@ -3,6 +3,7 @@ import S3 from 'aws-sdk/clients/s3'
 import {Stage} from "../utils/appIdentity";
 
 import {androidpublisher, auth} from '@googleapis/androidpublisher';
+import { mapAndroidProductId } from "../utils/mapAndroidProductId";
 
 export type GoogleSubscription = {
     // Time at which the subscription was granted. Not set for pending subscriptions (subscription was created but awaiting payment during signup)
@@ -73,12 +74,11 @@ export async function fetchGoogleSubscriptionV2(
         const testPurchase =
             purchase.data?.testPurchase ? true : false
 
-        const productId =
-            product.productId
-
-        if (!productId) {
+        if (!product.productId) {
             throw Error("The product does not have an ID")
         }
+
+        const productId = mapAndroidProductId(product.productId, packageName, testPurchase)
 
         const basePlanId =
             product.offerDetails?.basePlanId

--- a/typescript/src/utils/mapAndroidProductId.ts
+++ b/typescript/src/utils/mapAndroidProductId.ts
@@ -1,6 +1,10 @@
 import { Platform } from "../models/platform";
 import { fromGooglePackageName } from "../services/appToPlatform";
 
+// Map the product_id for test Feast purchases so that they can be easily
+// identified downstream. For other (non-Feast) Android test purchases the
+// product_id is already distinct and there are mechanisms for filtering out in
+// the lake.
 export const mapAndroidProductId = (productId: string, packageName: string, isTestPurchase: boolean): string => {
     if (isTestPurchase && fromGooglePackageName(packageName) === Platform.AndroidFeast) {
         return "dev_testing_feast";

--- a/typescript/src/utils/mapAndroidProductId.ts
+++ b/typescript/src/utils/mapAndroidProductId.ts
@@ -1,0 +1,10 @@
+import { Platform } from "../models/platform";
+import { fromGooglePackageName } from "../services/appToPlatform";
+
+export const mapAndroidProductId = (productId: string, packageName: string, isTestPurchase: boolean): string => {
+    if (isTestPurchase && fromGooglePackageName(packageName) === Platform.AndroidFeast) {
+        return "dev_testing_feast";
+    }
+
+    return productId;
+}

--- a/typescript/tests/utils/mapAndroidProductId.test.ts
+++ b/typescript/tests/utils/mapAndroidProductId.test.ts
@@ -1,0 +1,33 @@
+import { mapAndroidProductId } from "../../src/utils/mapAndroidProductId";
+
+describe("mapAndroidProductId", () => {
+    it("returns the product_id if not Feast Android", () => {
+        const productId = "test-product-id";
+        const googlePackageName = "com.guardian";
+        const testPurchase = true;
+
+        const determinedProductId = mapAndroidProductId(productId, googlePackageName, testPurchase);
+
+        expect(determinedProductId).toEqual(productId);
+    });
+
+    it("returns the product_id if Feast Android and not a test", () => {
+        const productId = "test-product-id";
+        const googlePackageName = "uk.co.guardian.feast";
+        const testPurchase = false;
+
+        const determinedProductId = mapAndroidProductId(productId, googlePackageName, testPurchase);
+
+        expect(determinedProductId).toEqual(productId);
+    });
+
+    it("returns dev_testing_feast for a Feast Android test purchase", () => {
+        const productId = "test-product-id";
+        const googlePackageName = "uk.co.guardian.feast";
+        const testPurchase = true;
+
+        const determinedProductId = mapAndroidProductId(productId, googlePackageName, testPurchase);
+
+        expect(determinedProductId).toEqual("dev_testing_feast");
+    });
+});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When a purchase is for a test Android Feast subscription, map the product ID to something which obviously identifies it as a test. This makes them easier to identify (and filter out) in the datalake. For other Android apps, test subs already have a distinct product name so there's an existing mechanism for filtering these out in this way.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've added a little test around the specific product_id mapping function. I've also tested in CODE with a test purchase and can see the product_id was correctly mapped in Dynamo:

<img width="473" alt="Screenshot 2024-06-13 at 12 52 02" src="https://github.com/guardian/mobile-purchases/assets/379839/af10a1d7-c261-4647-8970-11c57b741ad8">

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
