### PR TITLE
Prep link endpoint for Feast

### DIFF
--- a/typescript/src/link/apple-utils.ts
+++ b/typescript/src/link/apple-utils.ts
@@ -7,7 +7,7 @@ type AppleSubscription = {
 }
 
 export type AppleLinkPayload = {
-    platform: Platform.DailyEdition | Platform.Ios | Platform.IosPuzzles | Platform.IosEdition,
+    platform: Platform.DailyEdition | Platform.Ios | Platform.IosPuzzles | Platform.IosEdition | Platform.IosFeast,
     subscriptions: AppleSubscription[]
 }
 

--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -5,6 +5,7 @@ import {UserSubscription} from "../models/userSubscription";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {parseAppleLinkPayload} from "./apple-utils"
 import {AppleLinkPayload} from "./apple-utils"
+import { Platform } from '../models/platform';
 
 function toUserSubscription(userId: string, payload: AppleLinkPayload): UserSubscription[] {
     const now = new Date().toISOString()
@@ -16,6 +17,25 @@ function toUserSubscription(userId: string, payload: AppleLinkPayload): UserSubs
 }
 
 function toSqsPayload(payload: AppleLinkPayload): SubscriptionCheckData[] {
+    // The link endpoint is used for iOS Feast in a specific scenario - where
+    // the user takes out an IAP with a promo code. In this case we've found
+    // that the appAccountToken, which we usually use for Feast to link users
+    // with IAPs, isn't set. So instead in this specific scenario the Feast app
+    // uses the link endpoint. The link endpoint does two things - it creates
+    // the user subscription record, and also possibly queues the subscription
+    // lookup (pushes onto the SQS queue for the update subs lambda). I don't
+    // think this needs to happen for Feast. Furthermore, it's hard to support
+    // because the credentials used for lookup in the non-Feast case are
+    // different than other apps and in the update subs lambda we don't
+    // currently know which app the subscription is for (hence having separate
+    // lambdas for Feast and everything else). We _could_ push onto the Feast
+    // update subs queue but we know that's going to fail in the user lookup
+    // part, due to the aforementioned lack of appAccountToken. So I think the
+    // easiest solution for now is just not to enqueue Feast subs for lookup.
+    if (payload.platform === Platform.IosFeast) {
+        return [];
+    }
+
     return payload.subscriptions.map(sub => ({
         subscriptionId: sub.originalTransactionId,
         subscriptionReference: {

--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -33,6 +33,7 @@ function toSqsPayload(payload: AppleLinkPayload): SubscriptionCheckData[] {
     // part, due to the aforementioned lack of appAccountToken. So I think the
     // easiest solution for now is just not to enqueue Feast subs for lookup.
     if (payload.platform === Platform.IosFeast) {
+        console.log("Not enqueuing Feast subs for lookup");
         return [];
     }
 

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -15,6 +15,11 @@ export interface SubscriptionCheckData {
 }
 
 async function enqueueUnstoredPurchaseToken(subChecks: SubscriptionCheckData[]): Promise<number> {
+    // There's nothing to do if there are no subs to check - this will always be
+    // the case for Feast.
+    if (subChecks.length === 0) {
+        return 0;
+    }
 
     const dynamoResult = dynamoMapper.batchGet(subChecks.map(sub => new ReadSubscription().setSubscriptionId(sub.subscriptionId)));
 


### PR DESCRIPTION
## What does this change?

The link endpoint will now handle Feast IAPs (in some cases). When a user takes out an IAP using an offer code, the appAccountToken is not set in the receipt. So we need a different way to link identity IDs with IAPs. We've decided to use the link endpoint used by the live apps to facilitate this. It will only be called for promo code purchases. Other Feast purchases will use the appAccountToken as usual.

**Note about subscription lookups:**

The link endpoint does two things - it creates the user subscription record, and also possibly queues the subscription lookup (pushes onto the SQS queue for the update subs lambda). I don't think this needs to happen for Feast. Furthermore, it's hard to support because the credentials used for lookup in the non-Feast case are different than other apps and in the update subs lambda we don't currently know which app the subscription is for (hence having separate lambdas for Feast and everything else). We _could_ push onto the Feast update subs queue but we know that's going to fail in the user lookup part, due to the aforementioned lack of appAccountToken. So I think the easiest solution for now is just not to enqueue Feast subs for lookup.

## How to test

Tested on CODE. When the platform == `ios-feast` I've seen the user sub record get created, and no lookups queued (as expected). For non `ios-feast` I've seen the sub record created and the lookups queued (existing behaviour for everything other than Feast).

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
