### PR TITLE
Set the maximum number of retry events for the SOI acquisitions lambda

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1477,6 +1477,7 @@ Resources:
             Stream:
               Fn::ImportValue: !Sub ${App}-${Stage}-user-subscriptions-stream-arn
             StartingPosition: LATEST
+            MaximumRetryAttempts: 10
       Tags:
         Stage: !Ref Stage
         Stack: !Ref Stack


### PR DESCRIPTION
## What does this change?

This lambda is triggered by a stream of Dynamo events. We've encountered a scenario where the user deleted their account before this lambda ran, which means we're continually failing to get the user's email address from identity.

If the lambda errors during invocation, we get retries for free: https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-dynamodb-errors

The default retry behaviour is to retry indefinitely: https://docs.aws.amazon.com/lambda/latest/api/API_CreateEventSourceMapping.html (See MaximumRetryAttempts).

There's no point in retrying forever, so set the retry limit to 10 as a starter.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] I'll verify the cfn by deploying to CODE.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
