### PR TITLE
handle missing userid

### DIFF
--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -65,7 +65,7 @@ const processRecord = async (
                 const identityId = await exchangeExternalIdForIdentityId(s.appAccountToken)
                 const now = new Date().toISOString()
                 const linked = new UserSubscription(identityId, s.subscriptionId, now)
-                storeUserSubscriptionInDynamo(linked)
+                await storeUserSubscriptionInDynamo(linked)
             }
             else {
                 console.log(`Subscription with receipt '${s.receipt}' did not have an 'appAccountToken'`);

--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -62,19 +62,23 @@ const processRecord = async (
 
     await Promise.all(subscriptions.map(storeSubscriptionInDynamo))
 
-    const userSubscriptions =
-        await Promise.all(subscriptions.map(async s => {
-            if (!s.appAccountToken) {
-                throw new ProcessingError(`Subscription with receipt '${s.receipt}' did not have an 'appAccountToken'`, false)
-            }
 
-            const identityId = await exchangeExternalIdForIdentityId(s.appAccountToken)
-            const now = new Date().toISOString()
 
-            return new UserSubscription(identityId, s.subscriptionId, now)
-        }))
-
-    return Promise.all(userSubscriptions.map(storeUserSubscriptionInDynamo))
+            await Promise.all(subscriptions.map(async s => {
+                if (!s.appAccountToken) {
+                    console.log(`Subscription with receipt '${s.receipt}' did not have an 'appAccountToken'`);
+                    return {}
+                    }
+                else {
+                    const identityId = await exchangeExternalIdForIdentityId(s.appAccountToken)
+                    const now = new Date().toISOString()
+                    const link =  new UserSubscription(identityId, s.subscriptionId, now) 
+                return storeUserSubscriptionInDynamo(link)
+            
+                }
+                }
+            ) 
+)
 }
 
 const processRecordWithErrorHandling = async (

--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -61,14 +61,14 @@ const processRecord = async (
         await Promise.all(subscriptions.map(storeSubscriptionInDynamo))
 
         await Promise.all(subscriptions.map(async s => {
-            if (!s.appAccountToken) {
-                console.log(`Subscription with receipt '${s.receipt}' did not have an 'appAccountToken'`);
-            }
-            else {
+            if (s.appAccountToken) {
                 const identityId = await exchangeExternalIdForIdentityId(s.appAccountToken)
                 const now = new Date().toISOString()
                 const linked = new UserSubscription(identityId, s.subscriptionId, now)
                 storeUserSubscriptionInDynamo(linked)
+            }
+            else {
+                console.log(`Subscription with receipt '${s.receipt}' did not have an 'appAccountToken'`);
             }
         }
     ))

--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -39,7 +39,7 @@ export const defaultFetchSubscriptionsFromApple =
 
 const defaultStoreSubscriptionInDynamo =
     (subscription: Subscription): Promise<void> => {
-        return dynamoMapper.put({item: subscription}).then(_ => {})
+        return dynamoMapper.put({ item: subscription }).then(_ => { })
     }
 
 type FetchSubsFromApple = (reference: AppleSubscriptionReference) => Promise<SubscriptionMaybeWithAppAccountToken[]>;
@@ -54,31 +54,24 @@ const processRecord = async (
     storeUserSubscriptionInDynamo: StoreUserSubInDynamo,
     record: SQSRecord
 ) => {
-    const reference =
-        decodeSubscriptionReference(record)
+        const reference = decodeSubscriptionReference(record)
 
-    const subscriptions =
-        await fetchSubscriptionsFromApple(reference)
+        const subscriptions = await fetchSubscriptionsFromApple(reference)
 
-    await Promise.all(subscriptions.map(storeSubscriptionInDynamo))
+        await Promise.all(subscriptions.map(storeSubscriptionInDynamo))
 
-
-
-            await Promise.all(subscriptions.map(async s => {
-                if (!s.appAccountToken) {
-                    console.log(`Subscription with receipt '${s.receipt}' did not have an 'appAccountToken'`);
-                    return {}
-                    }
-                else {
-                    const identityId = await exchangeExternalIdForIdentityId(s.appAccountToken)
-                    const now = new Date().toISOString()
-                    const link =  new UserSubscription(identityId, s.subscriptionId, now) 
-                return storeUserSubscriptionInDynamo(link)
-            
-                }
-                }
-            ) 
-)
+        await Promise.all(subscriptions.map(async s => {
+            if (!s.appAccountToken) {
+                console.log(`Subscription with receipt '${s.receipt}' did not have an 'appAccountToken'`);
+            }
+            else {
+                const identityId = await exchangeExternalIdForIdentityId(s.appAccountToken)
+                const now = new Date().toISOString()
+                const linked = new UserSubscription(identityId, s.subscriptionId, now)
+                storeUserSubscriptionInDynamo(linked)
+            }
+        }
+    ))
 }
 
 const processRecordWithErrorHandling = async (
@@ -101,8 +94,8 @@ const processRecordWithErrorHandling = async (
             console.warn("Error processing the subscription update is being handled gracefully", error);
             return;
         } else {
-           console.error("Unexpected error, will throw to retry: ", error);
-           throw error;
+            console.error("Unexpected error, will throw to retry: ", error);
+            throw error;
         }
     }
 }

--- a/typescript/tests/feast/update-subs/apple.test.ts
+++ b/typescript/tests/feast/update-subs/apple.test.ts
@@ -85,7 +85,7 @@ describe("The Feast (Apple) subscription updater", () => {
         await expect(handler(event)).resolves.toBe("OK");
     })
 
-    it("Throws an error if the receipt has no app account token, but still writes the subscription", async () => {
+    it("Still writes the subscription when the receipt has no app account token,", async () => {
         expect.assertions(2);
         const event = buildSqsEvent([{ receipt: "TEST_RECEIPT_MISSING_AAT" }])
         const handler =
@@ -96,14 +96,10 @@ describe("The Feast (Apple) subscription updater", () => {
                 mockStoreUserSubscriptionInDynamo
             )
 
-        try {
-            await handler(event);
-        } catch (error) {
-            expect((error as ProcessingError).message)
-                .toMatch("Subscription with receipt 'TEST_RECEIPT_MISSING_AAT' did not have an 'appAccountToken'");
-            expect(mockStoreSubscriptionInDynamo.mock.calls.length).toEqual(1)
+            expect.assertions(1);
+            await expect(mockStoreSubscriptionInDynamo.mock.calls.length).toEqual(1)
         }
-    })
+    )
 });
 
 beforeEach(() => {

--- a/typescript/tests/feast/update-subs/apple.test.ts
+++ b/typescript/tests/feast/update-subs/apple.test.ts
@@ -95,16 +95,16 @@ describe("The Feast (Apple) subscription updater", () => {
                 mockStoreUserSubscriptionInDynamo
             )
 
+        const result = await handler(event);
 
-        await expect(handler(event)).resolves.toBe("OK");
-
+        expect(result).toEqual("OK");
 
         const storedSubscriptionIds =
             mockStoreSubscriptionInDynamo.mock.calls.map(call => call[0].subscriptionId)
 
-        await expect(mockStoreUserSubscriptionInDynamo.mock.calls.length).toEqual(0)
-        await expect(mockStoreSubscriptionInDynamo.mock.calls.length).toEqual(1)
         expect(storedSubscriptionIds).toEqual(["sub-5"])
+        expect(mockStoreUserSubscriptionInDynamo.mock.calls.length).toEqual(0)
+        expect(mockStoreSubscriptionInDynamo.mock.calls.length).toEqual(1)
     }
     )
 });

--- a/typescript/tests/feast/update-subs/google.test.ts
+++ b/typescript/tests/feast/update-subs/google.test.ts
@@ -72,7 +72,7 @@ describe("The Feast Android subscription updater", () => {
         }));
     });
 
-    it("Should still persist to Dynamo when no obfuscated id is available", async () => {
+    it("Still persists to Dynamo when no obfuscated id is available", async () => {
         const packageName = "uk.co.guardian.feast";
         const purchaseToken = "test-purchase-token";
         const subscriptionId = "test-subscription-id";

--- a/typescript/tests/feast/update-subs/google.test.ts
+++ b/typescript/tests/feast/update-subs/google.test.ts
@@ -92,6 +92,7 @@ describe("The Feast Android subscription updater", () => {
             billingPeriodDuration: "P1M",
             freeTrial: false,
             testPurchase: false,
+            obfuscatedExternalAccountId: undefined,
             rawResponse: "test-raw-response",
         };
         const subscription = new Subscription(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Occasionally we get responses from Apple and Google that don't have identifiers. Currently the lambda fails and retries. As this is an expected response we should treat it as a success and continue. 

One of the things we do is attempt to read a user identifier from the store receipt data (appAccountToken in the case of Apple, obfuscatedExternalAccountId in the case of Google). If the field doesn’t exist the lambda errors. This results in a number of retries and the event eventually ends up on the DLQ. However, we know there are scenarios where this will happen and are working on mitigations, namely to link to a user another way - using the link endpoint. The iOS fix is already in prod, Android is being worked on.

We therefore shouldn’t treat these as errors as they’re expected, and there’s nothing we can do to fix in this lambda (so retrying makes no sense).
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
https://trello.com/c/wZrwZqM9/405-mobile-purchases-dont-error-in-the-update-subs-feast-lambdas-if-the-receipt-data-is-missing-a-user-identifier
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->



