### PR TITLE
Set up feast-acquisition-events-router-lambda to pass relevant events to the Apple and Google Processing Lambdas

### DIFF
--- a/feast-acquisition-events.cloudformation.yaml
+++ b/feast-acquisition-events.cloudformation.yaml
@@ -21,6 +21,7 @@ Parameters:
   AlarmTopic:
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to
     Type: String
+  EventBusName: String
 
 Mappings:
   StageVariables:
@@ -433,3 +434,14 @@ Resources:
       PolicyName: Secretmanageraccesspolicy79659139
       Roles:
         - !Ref FeastAcquisitionEventsLambdaServiceRole
+
+  FeastAcquisitionEventsLambdaEventBridgePutEventsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: PutEvents
+            Effect: Allow
+            Resource: !Ref EventBusName
+        Version: '2012-10-17'
+      PolicyName: WriteToEventBus

--- a/feast-acquisition-events.cloudformation.yaml
+++ b/feast-acquisition-events.cloudformation.yaml
@@ -3,6 +3,9 @@ Description: FeastAcquisitionEventsLambdas
 Transform: AWS::Serverless-2016-10-31
 
 Parameters:
+  MobileAccountId:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: 'mobileAccountId'
   Stack:
     Description: Stack name
     Type: String
@@ -153,6 +156,45 @@ Resources:
         - Key: App
           Value: mobile-purchases-feast-google-acquisition-events
 
+  FeastAcquisitionEventsRouterDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${App}-${Stage}-feast-acquisition-events-router-dlq
+      Tags:
+        - Key: gu:repo
+          Value: guardian/mobile-purchases
+        - Key: App
+          Value: !Ref App
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+
+  FeastAcquisitionEventsRouterDlqDepthAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled:
+        !FindInMap [ StageVariables, !Ref Stage, AlarmActionsEnabled ]
+      AlarmDescription: "Ensure that the feast acquisition events router dead letter queue is empty"
+      Namespace: "AWS/SQS"
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt "FeastAcquisitionEventsRouterDlq.QueueName"
+      Period: 60
+      Statistic: Sum
+      EvaluationPeriods: 1
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions:
+        - Ref: AlarmTopic
+      OKActions:
+        - Ref: AlarmTopic
+      TreatMissingData: notBreaching
+      Tags:
+        - Key: App
+          Value: mobile-purchases-feast-acquisition-events-router
+
   FeastAcquisitionEventsLambdaServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -270,6 +312,7 @@ Resources:
           App: !Sub ${App}
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
+          DLQUrl: !Ref FeastAcquisitionEventsRouterDlq
       Description: A lambda triggered by DynamoDB input actions to identify Feast subscriptions and write to the corresponding queue.
       MemorySize: 512
       Timeout: 60

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -1,7 +1,94 @@
-import type { DynamoDBStreamEvent } from 'aws-lambda';
+import type { DynamoDBRecord, DynamoDBStreamEvent } from 'aws-lambda';
+import { Platform } from "../../models/platform";
+import {ReadSubscription} from "../../models/subscription";
+import {dynamoMapper/*, sendToSqs*/} from "../../utils/aws";
+import {plusDays} from "../../utils/dates";
+
+
+export const isActiveSubscription = (currentTime: Date, subscriptionRecord: ReadSubscription): boolean => {
+    // Check if the subscription is active
+    const end = new Date(Date.parse(subscriptionRecord.endTimestamp));
+    const endWithGracePeriod = plusDays(end, 30);
+    return (currentTime.getTime() <= endWithGracePeriod.getTime());
+}
+
+export const processAcquisition = (subscriptionRecord: ReadSubscription, identityId: string): boolean => {
+    const subscriptionId = subscriptionRecord.subscriptionId;
+    const now = new Date();
+
+    if (!isActiveSubscription(now, subscriptionRecord)) {
+        console.log(`Subscription ${subscriptionRecord.subscriptionId} is not active. Stopping processing.`);
+        return true;
+    }
+
+    const platform = subscriptionRecord.platform;
+    const tokens = subscriptionRecord.applePayload ?? subscriptionRecord.googlePayload;
+
+    //check if iOS or Android
+    //Assemble data anything needed for acquisitions records that we can get from the subscription, plus apple/google tokens to use in querying them
+    //Send to SQS
+
+    return true;
+}
 
 export const handler = async (event: DynamoDBStreamEvent): Promise<String> => {
     const message: String = 'Feast Acquisition Events Router Lambda has been called';
     console.log(message)
+
+    const records = event.Records;
+
+    let processedCount = 0;
+
+    const processRecordPromises = records.map(async (record: DynamoDBRecord) => {
+        const eventName = record.eventName;
+
+        const identityId = record?.dynamodb?.NewImage?.userId?.S || "";
+        const subscriptionId = record?.dynamodb?.NewImage?.subscriptionId?.S || "";
+
+        if (eventName === "INSERT") {
+            processedCount++;
+
+            console.log(`identityId: ${identityId}, subscriptionId: ${subscriptionId}`);
+// need to know if productId of the subscription contains "uk.co.guardian.Feast" or even just "Feast"
+            let itemToQuery = new ReadSubscription();
+            itemToQuery.setSubscriptionId(subscriptionId);
+
+            let subscriptionRecord: ReadSubscription;
+
+            try {
+                subscriptionRecord = await dynamoMapper.get(itemToQuery);
+            } catch (error) {
+                console.log(`Subscription ${subscriptionId} record not found in the subscriptions table. Error: `, error);
+
+            /*
+                Need to add config for a router Dead Letter Queue and send to this in case of error.
+                try {
+                    const timestamp = Date.now();
+                    await sendToSqs(dlqUrl, {subscriptionId, identityId, timestamp});
+                } catch(e) {
+                    console.log(`could not send message to dead letter queue for identityId: ${identityId}, subscriptionId: ${subscriptionId}. Error: `, e)
+                }*/
+
+                return false;
+            }
+            const isFeast = subscriptionRecord.platform === Platform.IosFeast || subscriptionRecord.platform === Platform.AndroidFeast;
+            if (isFeast) {
+                return processAcquisition(subscriptionRecord, identityId);
+            }
+            return true;
+        }
+    });
+
+    await Promise.all(processRecordPromises);
+
+    console.log(`Processed ${processedCount} newly inserted records from the link (mobile-purchases-${Stage}-user-subscriptions) DynamoDB table`);
+    //for each record
+    //check if eventName == "INSERT"
+    //extract 'dynamobb':StreamRecord
+    //extract key
+    //lookup key in DynamoDB
+    //If Subscription type is Feast, determine if Google or apple
+    //Extract relevant Fields
+    //Send message to queue
     return message;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This work is to configure a lambda that will listen to the event stream for the UserSubscriptions DynamoDB table and whenever a new Feast Event is added to this table, check whether it is android or iOS and pass the UserSubscription record to the corresponding SQS queue.

See the Routing Lambda Function in the following diagram for details:

![image](https://github.com/user-attachments/assets/147bba40-549e-4660-8ebb-e58c6143b6ce)


## How to test

Unit Tests to be added
To test manually: 
1 - Deploy to CODE
2 - Add a record to the user-subscriptions Dynamo table with the Platform set to Feast-iOS or Feast-Android
3 - Ensure that the Router lambda is triggered
4 - Ensure that the Subscription Event is sent to the correct Queue
5 - Ensure that the correct processing Lambda is called

## How can we measure success?

This lambda will trigger when a record is added to the User Subscription Dynamo table and pass the corresponding subscription on to the correct Processing Lambda.
