### PR TITLE
Use guardian/setup-scala to configure Scala in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
           java-version: 11
           cache: sbt
 
+      - name: Setup Scala
+        uses: sbt/setup-sbt@v1
+
       - name: Test and Build TypeScript
         run: ./build-tc.sh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           cache: sbt
 
       - name: Setup Scala
-        uses: sbt/setup-sbt@v1
+        uses: guardian/setup-scala@v1
 
       - name: Test and Build TypeScript
         run: ./build-tc.sh

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This change adds a reference to [guardian/setup-scala@v1](https://github.com/guardian/setup-scala) to handle setting up and configuring sbt for the ci action.

Currently attempts to run builds on PR's are failing with error: 'sbt: command not found'
(example [here](https://github.com/guardian/mobile-purchases/actions/runs/11348625712/job/31562832898?pr=1677))

This is because github [changed their Ubuntu image](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) to no longer provide sbt by default.

Full discussion on this issue in [chat](https://chat.google.com/room/AAAAag0I08g/sWFbnsgComI/sWFbnsgComI?cls=10)

## How to test

If branch builds then the problem is solved.

## How can we measure success?

Branches build successfully

