### PR TITLE
Temporarily stop sending traffic to the v2 API

### DIFF
--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -45,10 +45,11 @@ export async function handler(request: APIGatewayProxyEvent): Promise<APIGateway
     if (purchaseToken && subscriptionId) {
 
         // We're testing the new implementation in production, but want to limit traffic through this codepath
-        const roll = Math.floor(Math.random() * 100 + 1)
-        if (roll <= 5) {
-            await updateParallelTestTable(purchaseToken, packageName)
-        }
+        // This was turned off 2024-11-06 in an attempt to reduce our API quota usage
+        // const roll = Math.floor(Math.random() * 100 + 1)
+        // if (roll <= 0) {
+        //     await updateParallelTestTable(purchaseToken, packageName)
+        // }
 
         const purchaseTokenHash = createHash('sha256').update(purchaseToken).digest('hex')
         console.log(`Searching for valid ${subscriptionId} subscription for Android app with package name: ${packageName}, for purchaseToken hash: ${purchaseTokenHash}`)


### PR DESCRIPTION
## What does this change?

Our Play Store API quota was hit during the morning of November 6th. We're turning the v2 API test off temporarily in an attempt to reduce our usage (in combination with investigating other options). This is downstream of the `/google/subscription/{subscriptionId}/status` endpoint.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
