### PR TITLE
Add custom connectors for adjust to bigquery integration

### DIFF
--- a/adjust_report_etl/Feast/configuration.json
+++ b/adjust_report_etl/Feast/configuration.json
@@ -1,4 +1,4 @@
 {
   "API_KEY": "xxx",
-  "APP_TOKEN": "4qehi4vh20w0"
+  "APP_TOKEN": "yyy"
 }

--- a/adjust_report_etl/Feast/configuration.json
+++ b/adjust_report_etl/Feast/configuration.json
@@ -1,0 +1,4 @@
+{
+  "API_KEY": "xxx",
+  "APP_TOKEN": "4qehi4vh20w0"
+}

--- a/adjust_report_etl/Feast/connector.py
+++ b/adjust_report_etl/Feast/connector.py
@@ -1,11 +1,11 @@
 # Upload to fivetran using the following command:
 # fivetran deploy --api-key xxx --destination GNM --connection <connection name (same as bigquery dataset name)> --configuration configuration.json
 
-import requests
-import json
 import csv
-
+import json
 from io import StringIO
+
+import requests
 from fivetran_connector_sdk import Connector
 from fivetran_connector_sdk import Logging as log
 from fivetran_connector_sdk import Operations as op

--- a/adjust_report_etl/Feast/connector.py
+++ b/adjust_report_etl/Feast/connector.py
@@ -171,13 +171,13 @@ def update(configuration: dict, state: dict):
         log.info(f"Completed upserting {len(report_data)} rows to BigQuery.")
 
     except requests.exceptions.HTTPError as err:
-        log.warning(f"HTTP error occurred: {err}")
-        log.warning(f"Response content: {response.text}")
+        log.error(f"HTTP error occurred: {err}")
+        log.error(f"Response content: {response.text}")
     except json.JSONDecodeError as json_err:
-        log.warning(f"JSON decoding error: {json_err}")
-        log.warning(f"Raw response content: {response.text}")
+        log.error(f"JSON decoding error: {json_err}")
+        log.error(f"Raw response content: {response.text}")
     except Exception as err:
-        log.warning(f"Other error occurred: {err}")
+        log.error(f"Other error occurred: {err}")
 
 
 connector = Connector(update=update, schema=schema)

--- a/adjust_report_etl/Feast/connector.py
+++ b/adjust_report_etl/Feast/connector.py
@@ -13,30 +13,30 @@ from fivetran_connector_sdk import Operations as op
 log.LOG_LEVEL = log.Level.INFO
 
 TABLE_NAME = "csv_report"
-
+DIMENSIONS = [
+    "adgroup",
+    "adgroup_network",
+    "app",
+    "app_token",
+    "campaign",
+    "campaign_network",
+    "channel",
+    "country",
+    "creative",
+    "creative_network",
+    "currency",
+    "day",
+    "network",
+    "partner_name",
+    "source_network",
+    "store_type",
+]
 
 def schema(configuration: dict):
     return [
         {
             "table": TABLE_NAME,
-            "primary_key": [
-                "adgroup",
-                "adgroup_network",
-                "app",
-                "app_token",
-                "campaign",
-                "campaign_network",
-                "channel",
-                "country",
-                "creative",
-                "creative_network",
-                "currency",
-                "day",
-                "network",
-                "partner_name",
-                "source_network",
-                "store_type",
-            ],
+            "primary_key": DIMENSIONS,
             "columns": {
                 # Dimensions
                 "adgroup": "STRING",
@@ -76,39 +76,16 @@ def update(configuration: dict, state: dict):
     AD_SPEND_MODE = "network"
     DATE_PERIOD = "2023-04-01:-0d"
 
-    DIMENSIONS = ",".join(
-        [
-            "adgroup",
-            "adgroup_network",
-            "app",
-            "app_token",
-            "campaign",
-            "campaign_network",
-            "channel",
-            "country",
-            "creative",
-            "creative_network",
-            "currency",
-            "day",
-            "network",
-            "partner_name",
-            "source_network",
-            "store_type",
-        ]
-    )
-
-    METRICS = ",".join(
-        [
-            "clicks",
-            "impressions",
-            "installs",
-            "cost",
-            "ad_revenue",
-            "revenue",
-            "att_status_authorized",
-            "att_status_denied",
-        ]
-    )
+    METRICS = [
+        "clicks",
+        "impressions",
+        "installs",
+        "cost",
+        "ad_revenue",
+        "revenue",
+        "att_status_authorized",
+        "att_status_denied",
+    ]
 
     try:
         API_KEY = configuration["API_KEY"]
@@ -121,8 +98,8 @@ def update(configuration: dict, state: dict):
             "ad_spend_mode": AD_SPEND_MODE,
             "app_token__in": APP_TOKEN,
             "date_period": DATE_PERIOD,
-            "dimensions": DIMENSIONS,
-            "metrics": METRICS,
+            "dimensions": ",".join(DIMENSIONS),
+            "metrics": ",".join(METRICS),
         }
 
         log.info("Fetching data from Adjust...")

--- a/adjust_report_etl/Feast/connector.py
+++ b/adjust_report_etl/Feast/connector.py
@@ -130,7 +130,13 @@ def update(configuration: dict, state: dict):
 
         log.info(f"Received response with status code: {response.status_code}")
         response.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        log.error(f"HTTP error occurred: {err}")
+        log.error(f"Response content: {response.text}")
+    except Exception as err:
+        log.error(f"Other error occurred: {err}")
 
+    try:
         log.info("Processing Adjust data...")
         csv_reader = csv.DictReader(StringIO(response.text))
         report_data = [row for row in csv_reader]
@@ -169,10 +175,7 @@ def update(configuration: dict, state: dict):
                 },
             )
         log.info(f"Completed upserting {len(report_data)} rows to BigQuery.")
-
-    except requests.exceptions.HTTPError as err:
-        log.error(f"HTTP error occurred: {err}")
-        log.error(f"Response content: {response.text}")
+        
     except json.JSONDecodeError as json_err:
         log.error(f"JSON decoding error: {json_err}")
         log.error(f"Raw response content: {response.text}")

--- a/adjust_report_etl/Feast/connector.py
+++ b/adjust_report_etl/Feast/connector.py
@@ -12,7 +12,8 @@ from fivetran_connector_sdk import Operations as op
 
 log.LOG_LEVEL = log.Level.INFO
 
-TABLE_NAME = 'csv_report'
+TABLE_NAME = "csv_report"
+
 
 def schema(configuration: dict):
     return [
@@ -29,14 +30,13 @@ def schema(configuration: dict):
                 "country",
                 "creative",
                 "creative_network",
-                "currency", 
+                "currency",
                 "day",
                 "network",
                 "partner_name",
                 "source_network",
-                "store_type"
+                "store_type",
             ],
-
             "columns": {
                 # Dimensions
                 "adgroup": "STRING",
@@ -55,7 +55,6 @@ def schema(configuration: dict):
                 "partner_name": "STRING",
                 "source_network": "STRING",
                 "store_type": "STRING",
-
                 # Metrics
                 "clicks": "INT",
                 "impressions": "INT",
@@ -69,56 +68,61 @@ def schema(configuration: dict):
         }
     ]
 
+
 def update(configuration: dict, state: dict):
-    
-    ADJUST_API_URL = 'https://automate.adjust.com/reports-service/csv_report'
 
-    AD_SPEND_MODE = 'network'
-    DATE_PERIOD = '2023-04-01:-0d'
+    ADJUST_API_URL = "https://automate.adjust.com/reports-service/csv_report"
 
-    DIMENSIONS = ','.join([
-        "adgroup",
-        "adgroup_network",
-        "app",
-        "app_token",
-        "campaign",
-        "campaign_network",
-        "channel",
-        "country",
-        "creative",
-        "creative_network",
-        "currency",
-        "day",
-        "network",
-        "partner_name",
-        "source_network",
-        "store_type"
-    ])
-    
-    METRICS = ','.join([
-        "clicks",
-        "impressions",
-        "installs",
-        "cost",
-        "ad_revenue",
-        "revenue",
-        "att_status_authorized",
-        "att_status_denied",
-    ])
+    AD_SPEND_MODE = "network"
+    DATE_PERIOD = "2023-04-01:-0d"
+
+    DIMENSIONS = ",".join(
+        [
+            "adgroup",
+            "adgroup_network",
+            "app",
+            "app_token",
+            "campaign",
+            "campaign_network",
+            "channel",
+            "country",
+            "creative",
+            "creative_network",
+            "currency",
+            "day",
+            "network",
+            "partner_name",
+            "source_network",
+            "store_type",
+        ]
+    )
+
+    METRICS = ",".join(
+        [
+            "clicks",
+            "impressions",
+            "installs",
+            "cost",
+            "ad_revenue",
+            "revenue",
+            "att_status_authorized",
+            "att_status_denied",
+        ]
+    )
 
     try:
-        API_KEY = configuration['API_KEY']
+        API_KEY = configuration["API_KEY"]
         headers = {
-            'Authorization': f'Bearer {API_KEY}',
+            "Authorization": f"Bearer {API_KEY}",
         }
-        
-        APP_TOKEN = configuration['APP_TOKEN']
+
+        APP_TOKEN = configuration["APP_TOKEN"]
         params = {
-            'ad_spend_mode': AD_SPEND_MODE,
-            'app_token__in': APP_TOKEN,
-            'date_period': DATE_PERIOD,
-            'dimensions': DIMENSIONS,
-            'metrics': METRICS
+            "ad_spend_mode": AD_SPEND_MODE,
+            "app_token__in": APP_TOKEN,
+            "date_period": DATE_PERIOD,
+            "dimensions": DIMENSIONS,
+            "metrics": METRICS,
         }
 
         log.info("Fetching data from Adjust...")
@@ -126,51 +130,54 @@ def update(configuration: dict, state: dict):
 
         log.info(f"Received response with status code: {response.status_code}")
         response.raise_for_status()
-        
+
         log.info("Processing Adjust data...")
         csv_reader = csv.DictReader(StringIO(response.text))
         report_data = [row for row in csv_reader]
 
         log.info("Upserting rows to bigquery...")
         for row in report_data:
-            yield op.upsert(table=TABLE_NAME, data={
-                # Dimensions
-                "adgroup": row['adgroup'],
-                "adgroup_network": row['adgroup_network'],
-                "app": row['app'],
-                "app_token": row['app_token'],
-                "campaign": row['campaign'],
-                "campaign_network": row['campaign_network'],
-                "channel": row['channel'],
-                "country": row['country'],
-                "creative": row['creative'],
-                "creative_network": row['creative_network'],
-                "currency": row['currency'],
-                "day": row['day'],
-                "network": row['network'],
-                "partner_name": row['partner_name'],
-                "source_network": row['source_network'],
-                "store_type": row['store_type'],
-
-                # Metrics
-                "clicks": int(row['clicks']),
-                "impressions": int(row['impressions']),
-                "installs": int(row['installs']),
-                "cost": float(row['cost']),
-                "ad_revenue": float(row['ad_revenue']),
-                "revenue": float(row['revenue']),
-                "att_status_authorized": int(row['att_status_authorized']),
-                "att_status_denied": int(row['att_status_denied']),
-            })
+            yield op.upsert(
+                table=TABLE_NAME,
+                data={
+                    # Dimensions
+                    "adgroup": row["adgroup"],
+                    "adgroup_network": row["adgroup_network"],
+                    "app": row["app"],
+                    "app_token": row["app_token"],
+                    "campaign": row["campaign"],
+                    "campaign_network": row["campaign_network"],
+                    "channel": row["channel"],
+                    "country": row["country"],
+                    "creative": row["creative"],
+                    "creative_network": row["creative_network"],
+                    "currency": row["currency"],
+                    "day": row["day"],
+                    "network": row["network"],
+                    "partner_name": row["partner_name"],
+                    "source_network": row["source_network"],
+                    "store_type": row["store_type"],
+                    # Metrics
+                    "clicks": int(row["clicks"]),
+                    "impressions": int(row["impressions"]),
+                    "installs": int(row["installs"]),
+                    "cost": float(row["cost"]),
+                    "ad_revenue": float(row["ad_revenue"]),
+                    "revenue": float(row["revenue"]),
+                    "att_status_authorized": int(row["att_status_authorized"]),
+                    "att_status_denied": int(row["att_status_denied"]),
+                },
+            )
         log.info(f"Completed upserting {len(report_data)} rows to BigQuery.")
 
     except requests.exceptions.HTTPError as err:
-        log.warning(f'HTTP error occurred: {err}')
-        log.warning(f'Response content: {response.text}')
+        log.warning(f"HTTP error occurred: {err}")
+        log.warning(f"Response content: {response.text}")
     except json.JSONDecodeError as json_err:
-        log.warning(f'JSON decoding error: {json_err}')
-        log.warning(f'Raw response content: {response.text}')
+        log.warning(f"JSON decoding error: {json_err}")
+        log.warning(f"Raw response content: {response.text}")
     except Exception as err:
-        log.warning(f'Other error occurred: {err}')
+        log.warning(f"Other error occurred: {err}")
+
 
 connector = Connector(update=update, schema=schema)

--- a/adjust_report_etl/Feast/connector.py
+++ b/adjust_report_etl/Feast/connector.py
@@ -1,3 +1,6 @@
+# Upload to fivetran using the following command:
+# fivetran deploy --api-key xxx --destination GNM --connection <connection name (same as bigquery dataset name)> --configuration configuration.json
+
 import requests
 import json
 import csv
@@ -9,7 +12,7 @@ from fivetran_connector_sdk import Operations as op
 
 log.LOG_LEVEL = log.Level.INFO
 
-TABLE_NAME = 'data'
+TABLE_NAME = 'csv_report'
 
 def schema(configuration: dict):
     return [

--- a/adjust_report_etl/Premium/configuration.json
+++ b/adjust_report_etl/Premium/configuration.json
@@ -1,0 +1,4 @@
+{
+  "API_KEY": "xxx",
+  "APP_TOKEN": "3pg4s7fudsqo"
+}

--- a/adjust_report_etl/Premium/configuration.json
+++ b/adjust_report_etl/Premium/configuration.json
@@ -1,4 +1,4 @@
 {
   "API_KEY": "xxx",
-  "APP_TOKEN": "3pg4s7fudsqo"
+  "APP_TOKEN": "yyy"
 }

--- a/adjust_report_etl/Premium/connector.py
+++ b/adjust_report_etl/Premium/connector.py
@@ -1,11 +1,11 @@
 # Upload to fivetran using the following command:
 # fivetran deploy --api-key xxx --destination GNM --connection <connection name (same as bigquery dataset name)> --configuration configuration.json
 
-import requests
-import json
 import csv
-
+import json
 from io import StringIO
+
+import requests
 from fivetran_connector_sdk import Connector
 from fivetran_connector_sdk import Logging as log
 from fivetran_connector_sdk import Operations as op

--- a/adjust_report_etl/Premium/connector.py
+++ b/adjust_report_etl/Premium/connector.py
@@ -1,0 +1,176 @@
+# Upload to fivetran using the following command:
+# fivetran deploy --api-key xxx --destination GNM --connection <connection name (same as bigquery dataset name)> --configuration configuration.json
+
+import requests
+import json
+import csv
+
+from io import StringIO
+from fivetran_connector_sdk import Connector
+from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Operations as op
+
+log.LOG_LEVEL = log.Level.INFO
+
+TABLE_NAME = 'csv_report'
+
+def schema(configuration: dict):
+    return [
+        {
+            "table": TABLE_NAME,
+            "primary_key": [
+                "adgroup",
+                "adgroup_network",
+                "app",
+                "app_token",
+                "campaign",
+                "campaign_network",
+                "channel",
+                "country",
+                "creative",
+                "creative_network",
+                "currency", 
+                "day",
+                "network",
+                "partner_name",
+                "source_network",
+                "store_type"
+            ],
+
+            "columns": {
+                # Dimensions
+                "adgroup": "STRING",
+                "adgroup_network": "STRING",
+                "app": "STRING",
+                "app_token": "STRING",
+                "campaign": "STRING",
+                "campaign_network": "STRING",
+                "channel": "STRING",
+                "country": "STRING",
+                "creative": "STRING",
+                "creative_network": "STRING",
+                "currency": "STRING",
+                "day": "STRING",
+                "network": "STRING",
+                "partner_name": "STRING",
+                "source_network": "STRING",
+                "store_type": "STRING",
+
+                # Metrics
+                "clicks": "INT",
+                "impressions": "INT",
+                "installs": "INT",
+                "cost": "FLOAT",
+                "ad_revenue": "FLOAT",
+                "revenue": "FLOAT",
+                "att_status_authorized": "INT",
+                "att_status_denied": "INT",
+            },
+        }
+    ]
+
+def update(configuration: dict, state: dict):
+    
+    ADJUST_API_URL = 'https://automate.adjust.com/reports-service/csv_report'
+
+    AD_SPEND_MODE = 'network'
+    DATE_PERIOD = '2023-04-01:-0d'
+
+    DIMENSIONS = ','.join([
+        "adgroup",
+        "adgroup_network",
+        "app",
+        "app_token",
+        "campaign",
+        "campaign_network",
+        "channel",
+        "country",
+        "creative",
+        "creative_network",
+        "currency",
+        "day",
+        "network",
+        "partner_name",
+        "source_network",
+        "store_type"
+    ])
+    
+    METRICS = ','.join([
+        "clicks",
+        "impressions",
+        "installs",
+        "cost",
+        "ad_revenue",
+        "revenue",
+        "att_status_authorized",
+        "att_status_denied",
+    ])
+
+    try:
+        API_KEY = configuration['API_KEY']
+        headers = {
+            'Authorization': f'Bearer {API_KEY}',
+        }
+        
+        APP_TOKEN = configuration['APP_TOKEN']
+        params = {
+            'ad_spend_mode': AD_SPEND_MODE,
+            'app_token__in': APP_TOKEN,
+            'date_period': DATE_PERIOD,
+            'dimensions': DIMENSIONS,
+            'metrics': METRICS
+        }
+
+        log.info("Fetching data from Adjust...")
+        response = requests.get(ADJUST_API_URL, headers=headers, params=params)
+
+        log.info(f"Received response with status code: {response.status_code}")
+        response.raise_for_status()
+        
+        log.info("Processing Adjust data...")
+        csv_reader = csv.DictReader(StringIO(response.text))
+        report_data = [row for row in csv_reader]
+
+        log.info("Upserting rows to bigquery...")
+        for row in report_data:
+            yield op.upsert(table=TABLE_NAME, data={
+                # Dimensions
+                "adgroup": row['adgroup'],
+                "adgroup_network": row['adgroup_network'],
+                "app": row['app'],
+                "app_token": row['app_token'],
+                "campaign": row['campaign'],
+                "campaign_network": row['campaign_network'],
+                "channel": row['channel'],
+                "country": row['country'],
+                "creative": row['creative'],
+                "creative_network": row['creative_network'],
+                "currency": row['currency'],
+                "day": row['day'],
+                "network": row['network'],
+                "partner_name": row['partner_name'],
+                "source_network": row['source_network'],
+                "store_type": row['store_type'],
+
+                # Metrics
+                "clicks": int(row['clicks']),
+                "impressions": int(row['impressions']),
+                "installs": int(row['installs']),
+                "cost": float(row['cost']),
+                "ad_revenue": float(row['ad_revenue']),
+                "revenue": float(row['revenue']),
+                "att_status_authorized": int(row['att_status_authorized']),
+                "att_status_denied": int(row['att_status_denied']),
+            })
+        log.info(f"Completed upserting {len(report_data)} rows to BigQuery.")
+
+    except requests.exceptions.HTTPError as err:
+        log.warning(f'HTTP error occurred: {err}')
+        log.warning(f'Response content: {response.text}')
+    except json.JSONDecodeError as json_err:
+        log.warning(f'JSON decoding error: {json_err}')
+        log.warning(f'Raw response content: {response.text}')
+    except Exception as err:
+        log.warning(f'Other error occurred: {err}')
+
+connector = Connector(update=update, schema=schema)

--- a/adjust_report_etl/Premium/connector.py
+++ b/adjust_report_etl/Premium/connector.py
@@ -13,30 +13,30 @@ from fivetran_connector_sdk import Operations as op
 log.LOG_LEVEL = log.Level.INFO
 
 TABLE_NAME = "csv_report"
-
+DIMENSIONS = [
+    "adgroup",
+    "adgroup_network",
+    "app",
+    "app_token",
+    "campaign",
+    "campaign_network",
+    "channel",
+    "country",
+    "creative",
+    "creative_network",
+    "currency",
+    "day",
+    "network",
+    "partner_name",
+    "source_network",
+    "store_type",
+]
 
 def schema(configuration: dict):
     return [
         {
             "table": TABLE_NAME,
-            "primary_key": [
-                "adgroup",
-                "adgroup_network",
-                "app",
-                "app_token",
-                "campaign",
-                "campaign_network",
-                "channel",
-                "country",
-                "creative",
-                "creative_network",
-                "currency",
-                "day",
-                "network",
-                "partner_name",
-                "source_network",
-                "store_type",
-            ],
+            "primary_key": DIMENSIONS,
             "columns": {
                 # Dimensions
                 "adgroup": "STRING",
@@ -76,39 +76,16 @@ def update(configuration: dict, state: dict):
     AD_SPEND_MODE = "network"
     DATE_PERIOD = "2023-04-01:-0d"
 
-    DIMENSIONS = ",".join(
-        [
-            "adgroup",
-            "adgroup_network",
-            "app",
-            "app_token",
-            "campaign",
-            "campaign_network",
-            "channel",
-            "country",
-            "creative",
-            "creative_network",
-            "currency",
-            "day",
-            "network",
-            "partner_name",
-            "source_network",
-            "store_type",
-        ]
-    )
-
-    METRICS = ",".join(
-        [
-            "clicks",
-            "impressions",
-            "installs",
-            "cost",
-            "ad_revenue",
-            "revenue",
-            "att_status_authorized",
-            "att_status_denied",
-        ]
-    )
+    METRICS = [
+        "clicks",
+        "impressions",
+        "installs",
+        "cost",
+        "ad_revenue",
+        "revenue",
+        "att_status_authorized",
+        "att_status_denied",
+    ]
 
     try:
         API_KEY = configuration["API_KEY"]
@@ -121,8 +98,8 @@ def update(configuration: dict, state: dict):
             "ad_spend_mode": AD_SPEND_MODE,
             "app_token__in": APP_TOKEN,
             "date_period": DATE_PERIOD,
-            "dimensions": DIMENSIONS,
-            "metrics": METRICS,
+            "dimensions": ",".join(DIMENSIONS),
+            "metrics": ",".join(METRICS),
         }
 
         log.info("Fetching data from Adjust...")

--- a/adjust_report_etl/Premium/connector.py
+++ b/adjust_report_etl/Premium/connector.py
@@ -12,7 +12,8 @@ from fivetran_connector_sdk import Operations as op
 
 log.LOG_LEVEL = log.Level.INFO
 
-TABLE_NAME = 'csv_report'
+TABLE_NAME = "csv_report"
+
 
 def schema(configuration: dict):
     return [
@@ -29,14 +30,13 @@ def schema(configuration: dict):
                 "country",
                 "creative",
                 "creative_network",
-                "currency", 
+                "currency",
                 "day",
                 "network",
                 "partner_name",
                 "source_network",
-                "store_type"
+                "store_type",
             ],
-
             "columns": {
                 # Dimensions
                 "adgroup": "STRING",
@@ -55,7 +55,6 @@ def schema(configuration: dict):
                 "partner_name": "STRING",
                 "source_network": "STRING",
                 "store_type": "STRING",
-
                 # Metrics
                 "clicks": "INT",
                 "impressions": "INT",
@@ -69,56 +68,61 @@ def schema(configuration: dict):
         }
     ]
 
+
 def update(configuration: dict, state: dict):
-    
-    ADJUST_API_URL = 'https://automate.adjust.com/reports-service/csv_report'
 
-    AD_SPEND_MODE = 'network'
-    DATE_PERIOD = '2023-04-01:-0d'
+    ADJUST_API_URL = "https://automate.adjust.com/reports-service/csv_report"
 
-    DIMENSIONS = ','.join([
-        "adgroup",
-        "adgroup_network",
-        "app",
-        "app_token",
-        "campaign",
-        "campaign_network",
-        "channel",
-        "country",
-        "creative",
-        "creative_network",
-        "currency",
-        "day",
-        "network",
-        "partner_name",
-        "source_network",
-        "store_type"
-    ])
-    
-    METRICS = ','.join([
-        "clicks",
-        "impressions",
-        "installs",
-        "cost",
-        "ad_revenue",
-        "revenue",
-        "att_status_authorized",
-        "att_status_denied",
-    ])
+    AD_SPEND_MODE = "network"
+    DATE_PERIOD = "2023-04-01:-0d"
+
+    DIMENSIONS = ",".join(
+        [
+            "adgroup",
+            "adgroup_network",
+            "app",
+            "app_token",
+            "campaign",
+            "campaign_network",
+            "channel",
+            "country",
+            "creative",
+            "creative_network",
+            "currency",
+            "day",
+            "network",
+            "partner_name",
+            "source_network",
+            "store_type",
+        ]
+    )
+
+    METRICS = ",".join(
+        [
+            "clicks",
+            "impressions",
+            "installs",
+            "cost",
+            "ad_revenue",
+            "revenue",
+            "att_status_authorized",
+            "att_status_denied",
+        ]
+    )
 
     try:
-        API_KEY = configuration['API_KEY']
+        API_KEY = configuration["API_KEY"]
         headers = {
-            'Authorization': f'Bearer {API_KEY}',
+            "Authorization": f"Bearer {API_KEY}",
         }
-        
-        APP_TOKEN = configuration['APP_TOKEN']
+
+        APP_TOKEN = configuration["APP_TOKEN"]
         params = {
-            'ad_spend_mode': AD_SPEND_MODE,
-            'app_token__in': APP_TOKEN,
-            'date_period': DATE_PERIOD,
-            'dimensions': DIMENSIONS,
-            'metrics': METRICS
+            "ad_spend_mode": AD_SPEND_MODE,
+            "app_token__in": APP_TOKEN,
+            "date_period": DATE_PERIOD,
+            "dimensions": DIMENSIONS,
+            "metrics": METRICS,
         }
 
         log.info("Fetching data from Adjust...")
@@ -126,51 +130,54 @@ def update(configuration: dict, state: dict):
 
         log.info(f"Received response with status code: {response.status_code}")
         response.raise_for_status()
-        
+
         log.info("Processing Adjust data...")
         csv_reader = csv.DictReader(StringIO(response.text))
         report_data = [row for row in csv_reader]
 
         log.info("Upserting rows to bigquery...")
         for row in report_data:
-            yield op.upsert(table=TABLE_NAME, data={
-                # Dimensions
-                "adgroup": row['adgroup'],
-                "adgroup_network": row['adgroup_network'],
-                "app": row['app'],
-                "app_token": row['app_token'],
-                "campaign": row['campaign'],
-                "campaign_network": row['campaign_network'],
-                "channel": row['channel'],
-                "country": row['country'],
-                "creative": row['creative'],
-                "creative_network": row['creative_network'],
-                "currency": row['currency'],
-                "day": row['day'],
-                "network": row['network'],
-                "partner_name": row['partner_name'],
-                "source_network": row['source_network'],
-                "store_type": row['store_type'],
-
-                # Metrics
-                "clicks": int(row['clicks']),
-                "impressions": int(row['impressions']),
-                "installs": int(row['installs']),
-                "cost": float(row['cost']),
-                "ad_revenue": float(row['ad_revenue']),
-                "revenue": float(row['revenue']),
-                "att_status_authorized": int(row['att_status_authorized']),
-                "att_status_denied": int(row['att_status_denied']),
-            })
+            yield op.upsert(
+                table=TABLE_NAME,
+                data={
+                    # Dimensions
+                    "adgroup": row["adgroup"],
+                    "adgroup_network": row["adgroup_network"],
+                    "app": row["app"],
+                    "app_token": row["app_token"],
+                    "campaign": row["campaign"],
+                    "campaign_network": row["campaign_network"],
+                    "channel": row["channel"],
+                    "country": row["country"],
+                    "creative": row["creative"],
+                    "creative_network": row["creative_network"],
+                    "currency": row["currency"],
+                    "day": row["day"],
+                    "network": row["network"],
+                    "partner_name": row["partner_name"],
+                    "source_network": row["source_network"],
+                    "store_type": row["store_type"],
+                    # Metrics
+                    "clicks": int(row["clicks"]),
+                    "impressions": int(row["impressions"]),
+                    "installs": int(row["installs"]),
+                    "cost": float(row["cost"]),
+                    "ad_revenue": float(row["ad_revenue"]),
+                    "revenue": float(row["revenue"]),
+                    "att_status_authorized": int(row["att_status_authorized"]),
+                    "att_status_denied": int(row["att_status_denied"]),
+                },
+            )
         log.info(f"Completed upserting {len(report_data)} rows to BigQuery.")
 
     except requests.exceptions.HTTPError as err:
-        log.warning(f'HTTP error occurred: {err}')
-        log.warning(f'Response content: {response.text}')
+        log.warning(f"HTTP error occurred: {err}")
+        log.warning(f"Response content: {response.text}")
     except json.JSONDecodeError as json_err:
-        log.warning(f'JSON decoding error: {json_err}')
-        log.warning(f'Raw response content: {response.text}')
+        log.warning(f"JSON decoding error: {json_err}")
+        log.warning(f"Raw response content: {response.text}")
     except Exception as err:
-        log.warning(f'Other error occurred: {err}')
+        log.warning(f"Other error occurred: {err}")
+
 
 connector = Connector(update=update, schema=schema)

--- a/adjust_report_etl/Premium/connector.py
+++ b/adjust_report_etl/Premium/connector.py
@@ -130,7 +130,13 @@ def update(configuration: dict, state: dict):
 
         log.info(f"Received response with status code: {response.status_code}")
         response.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        log.error(f"HTTP error occurred: {err}")
+        log.error(f"Response content: {response.text}")
+    except Exception as err:
+        log.error(f"Other error occurred: {err}")
 
+    try:
         log.info("Processing Adjust data...")
         csv_reader = csv.DictReader(StringIO(response.text))
         report_data = [row for row in csv_reader]
@@ -169,15 +175,12 @@ def update(configuration: dict, state: dict):
                 },
             )
         log.info(f"Completed upserting {len(report_data)} rows to BigQuery.")
-
-    except requests.exceptions.HTTPError as err:
-        log.warning(f"HTTP error occurred: {err}")
-        log.warning(f"Response content: {response.text}")
+        
     except json.JSONDecodeError as json_err:
-        log.warning(f"JSON decoding error: {json_err}")
-        log.warning(f"Raw response content: {response.text}")
+        log.error(f"JSON decoding error: {json_err}")
+        log.error(f"Raw response content: {response.text}")
     except Exception as err:
-        log.warning(f"Other error occurred: {err}")
+        log.error(f"Other error occurred: {err}")
 
 
 connector = Connector(update=update, schema=schema)

--- a/adjust_report_etl/README.md
+++ b/adjust_report_etl/README.md
@@ -16,7 +16,7 @@ or configuring a request in an API testing tool, such as Postman, and verifying 
 
 - Update the script iteratively and upload to fivetran in production. Check-in with Data Design to ensure data schema is correct and records are displaying as expected.
 
-Considerations
+## Considerations
 - Adding a dimension (an aggregator, or a field that groups the data, such as by 'country'), can significantly increase the time needed to extract and load the data.
 
 - Each dimension should comprise part of the primary key as defined in the script, otherwise some records risk being overwritten
@@ -34,5 +34,5 @@ Considerations
 ## Troubleshooting
 _I was unable to find a log section in fivetran that would help to debug any issues with the script. When something went wrong, it was sometimes necessary to strip the metrics and dimensions all the way back to one of each, and rebuild from there to zero in on which one was causing the issue._
 
-- fivetran indicates that only the extract was performed
+- Fivetran indicates that only the extract was performed
   - check metrics and dimensions specifications. Ensure each one exists in Adjust, and ensure they are typed correctly in the python script.

--- a/adjust_report_etl/README.md
+++ b/adjust_report_etl/README.md
@@ -32,7 +32,8 @@ or configuring a request in an API testing tool, such as Postman, and verifying 
 - Connection name automatically maps to the connection name in fivetran as well as the dataset name in bigquery
 
 ## Troubleshooting
-_I was unable to find a log section in fivetran that would help to debug any issues with the script. When something went wrong, it was sometimes necessary to strip the metrics and dimensions all the way back to one of each, and rebuild from there to zero in on which one was causing the issue._
+_I was unable to find a log section in fivetran that would help to debug any issues with the script._
 
 - Fivetran indicates that only the extract was performed
   - check metrics and dimensions specifications. Ensure each one exists in Adjust, and ensure they are typed correctly in the python script.
+  - When the issue is likely a dimension or a metric, it was sometimes necessary to strip the metrics and dimensions all the way back to one of each, and rebuild from there to zero-in on which one was causing the issue.

--- a/adjust_report_etl/README.md
+++ b/adjust_report_etl/README.md
@@ -1,0 +1,38 @@
+## Introduction
+This folder contains Fivetran custom connectors, written in Python. They are used to extract data from the Adjust marketing platform for our Premium and Feast apps, and upload to Bigquery, so that the return on investment of Adjust marketing spend can be incorporated into the Marketing Effectiveness Data Asset for MRR.
+
+## Why Python scripts and not a lambda function within our AWS stack?
+Python was the only language that we could use for the custom connector, as per fivetran constraints. We could have built a lambda function instead but decided this would result in a higher technical overhead on aspects such as scheduling and infrastructure. With the Python script, all we need to maintain is the script itself.
+
+## Stakeholders 
+Data Design working on behalf of MRR
+
+## How to test
+None of Adjust, Fivetran or Bigquery have a development environment, so the following strategies were used to dev and test the solution:
+
+- Test the extract from Adjust by running the script locally:
+`fivetran debug`
+or configuring a request in an API testing tool, such as Postman, and verifying that the parameters are correct. I found this particularly useful when trying combinations or dimensions and metrics. 
+
+- Update the script iteratively and upload to fivetran in production. Check-in with Data Design to ensure data schema is correct and records are displaying as expected.
+
+Considerations
+- Adding a dimension (an aggregator, or a field that groups the data, such as by 'country'), can significantly increase the time needed to extract and load the data.
+
+- Each dimension should comprise part of the primary key as defined in the script, otherwise some records risk being overwritten
+
+- When a new connection is created, it may be necessary to raise a PR to gain access to the dataset in bigquery (example, https://github.com/guardian/gcp-iac-terraform/pull/1009)
+
+- During development it can be helpful to be able to delete the data in the target table and rerun the sync to verify certain behaviours are as expected. Data Tech can help with this.
+
+## Uploading script to Fivetran
+- Use this command to upload the script to Fivetran:
+`fivetran deploy --api-key xxx --destination GNM --connection <connectionname> --configuration configuration.json`
+
+- Connection name automatically maps to the connection name in fivetran as well as the dataset name in bigquery
+
+## Troubleshooting
+_I was unable to find a log section in fivetran that would help to debug any issues with the script. When something went wrong, it was sometimes necessary to strip the metrics and dimensions all the way back to one of each, and rebuild from there to zero in on which one was causing the issue._
+
+- fivetran indicates that only the extract was performed
+  - check metrics and dimensions specifications. Ensure each one exists in Adjust, and ensure they are typed correctly in the python script.

--- a/adjust_report_etl/connector.py
+++ b/adjust_report_etl/connector.py
@@ -12,217 +12,213 @@ ADJUST_API_URL = 'https://automate.adjust.com/reports-service/csv_report'
 TABLE_NAME = 'data'
 
 def schema(configuration: dict):
-    return [
-        {
-            "table": TABLE_NAME,
-            "primary_key": ["campaign_id_network", "device_type"],
-            "columns": {
-                # Dimensions
-                "hour": "STRING",
-                "day": "STRING",
-                "week": "STRING",
-                "month": "STRING",
-                "year": "STRING",
-                "quarter": "STRING",
-                "os_name": "STRING",
-                "device_type": "STRING",
-                "app": "STRING",
-                "app_token": "STRING",
-                "store_id": "STRING",
-                "store_type": "STRING",
-                "currency": "STRING",
-                "currency_code": "STRING",
-                "network": "STRING",
-                "campaign": "STRING",
-                "campaign_network": "STRING",
-                "campaign_id_network": "STRING",
-                "adgroup": "STRING",
-                "adgroup_network": "STRING",
-                "adgroup_id_network": "STRING",
-                "source_network": "STRING",
-                "source_id_network": "STRING",
-                "creative": "STRING",
-                "creative_network": "STRING",
-                "creative_id_network": "STRING",
-                "country": "STRING",
-                "country_code": "STRING",
-                "region": "STRING",
-                "partner_name": "STRING",
-                "partner_id": "STRING",
-                "partner": "STRING",
-                "channel": "STRING",
-                "platform": "STRING",
+   return [
+       {
+           "table": TABLE_NAME,
+           "primary_key": ["campaign_id_network", "device_type"],
+           "columns": {
+               # Dimensions
+               "day": "STRING",
+               "week": "STRING",
+               "month": "STRING",
+               "year": "STRING",
+               "quarter": "STRING",
+               "os_name": "STRING",
+               "device_type": "STRING",
+               "app": "STRING",
+               "app_token": "STRING",
+               "store_id": "STRING",
+               "store_type": "STRING",
+               "currency": "STRING",
+               "currency_code": "STRING",
+               "network": "STRING",
+               "campaign": "STRING",
+               "campaign_network": "STRING",
+               "campaign_id_network": "STRING",
+               "adgroup": "STRING",
+               "adgroup_network": "STRING",
+               "adgroup_id_network": "STRING",
+               "source_network": "STRING",
+               "source_id_network": "STRING",
+               "creative": "STRING",
+               "creative_network": "STRING",
+               "creative_id_network": "STRING",
+               "country": "STRING",
+               "country_code": "STRING",
+               "region": "STRING",
+               "partner_name": "STRING",
+               "partner_id": "STRING",
+               "partner": "STRING",
+               "channel": "STRING",
+               "platform": "STRING",
 
-                # Metrics
-                "att_status_authorized": "INT",
-                "att_status_non_determined": "INT",
-                "att_status_denied": "INT",
-                "att_status_restricted": "INT",
-                "att_consent_rate": "FLOAT",
-                "daus": "FLOAT",
-                "maus": "FLOAT",
-                "waus": "FLOAT",
-                "base_sessions": "INT",
-                # "cancels": "INT",
-                "clicks": "INT",
-                "attribution_clicks": "INT",
-                "network_clicks": "INT",
-                "click_conversion_rate": "FLOAT",
-                "ctr": "FLOAT",
-                "deattributions": "INT",
-                "events": "INT",
-                "first_reinstalls": "INT",
-                "first_uninstalls": "INT",
-                "gdpr_forgets": "INT",
-                "impressions": "INT",
-                "attribution_impressions": "INT",
-                "network_impressions": "INT",
-                "impression_conversion_rate": "FLOAT",
-                "installs": "INT",
-                "network_installs": "INT",
-                "network_installs_diff": "INT",
-                "installs_per_mile": "FLOAT",
-                "limit_ad_tracking_installs": "INT",
-                "limit_ad_tracking_install_rate": "FLOAT",
-                "limit_ad_tracking_reattributions": "INT",
-                "limit_ad_tracking_reattribution_rate": "FLOAT",
-                "non_organic_installs": "INT",
-                "organic_installs": "INT",
-                "reattributions": "INT",
-                "reattribution_reinstalls": "INT",
-                "reinstalls": "INT",
-                # "renewals": "INT",
-                "sessions": "INT",
-                "uninstalls": "INT",
-                "uninstall_cohort": "FLOAT",
-                "network_cost": "FLOAT",
-            },
-        }
-    ]
-
+               # Metrics
+               "att_status_authorized": "INT",
+               "att_status_non_determined": "INT",
+               "att_status_denied": "INT",
+               "att_status_restricted": "INT",
+               "att_consent_rate": "FLOAT",
+               "daus": "FLOAT",
+               "maus": "FLOAT",
+               "waus": "FLOAT",
+               "base_sessions": "INT",
+               # "cancels": "INT", no access to this metric. Do we need it?
+               "clicks": "INT",
+               "attribution_clicks": "INT",
+               "network_clicks": "INT",
+               "click_conversion_rate": "FLOAT",
+               "ctr": "FLOAT",
+               "deattributions": "INT",
+               "events": "INT",
+               "first_reinstalls": "INT",
+               "first_uninstalls": "INT",
+               "gdpr_forgets": "INT",
+               "impressions": "INT",
+               "attribution_impressions": "INT",
+               "network_impressions": "INT",
+               "impression_conversion_rate": "FLOAT",
+               "installs": "INT",
+               "network_installs": "INT",
+               "network_installs_diff": "INT",
+               "installs_per_mile": "FLOAT",
+               "limit_ad_tracking_installs": "INT",
+               "limit_ad_tracking_install_rate": "FLOAT",
+               "limit_ad_tracking_reattributions": "INT",
+               "limit_ad_tracking_reattribution_rate": "FLOAT",
+               "non_organic_installs": "INT",
+               "organic_installs": "INT",
+               "reattributions": "INT",
+               "reattribution_reinstalls": "INT",
+               "reinstalls": "INT",
+               # "renewals": "INT", no access to this metric. Do we need it?
+               "sessions": "INT",
+               "uninstalls": "INT",
+               "uninstall_cohort": "FLOAT",
+               "network_cost": "FLOAT",
+           },
+       }
+   ]
 
 def update(configuration: dict, state: dict):
-    API_KEY = configuration['API_KEY']
-    APP_TOKEN = configuration['APP_TOKEN']
-    
-    AD_SPEND_MODE = 'network'
-    DATE_PERIOD = '-7d:-0d'
-    DIMENSIONS = 'hour,day,week,month,year,quarter,os_name,device_type,app,app_token,store_id,store_type,currency,currency_code,network,campaign,campaign_network,campaign_id_network,adgroup,adgroup_network,adgroup_id_network,source_network,source_id_network,creative,creative_network,creative_id_network,country,country_code,region,partner_name,partner_id,partner,channel,platform'
-    METRICS = 'network_cost,att_status_authorized,att_status_non_determined,att_status_denied,att_status_restricted,att_consent_rate,daus,maus,waus,base_sessions,clicks,attribution_clicks,network_clicks,click_conversion_rate,ctr,deattributions,events,first_reinstalls,first_uninstalls,gdpr_forgets,impressions,attribution_impressions,network_impressions,impression_conversion_rate,installs,network_installs,network_installs_diff,installs_per_mile,limit_ad_tracking_installs,limit_ad_tracking_install_rate,limit_ad_tracking_reattributions,limit_ad_tracking_reattribution_rate,non_organic_installs,organic_installs,reattributions,reattribution_reinstalls,reinstalls,sessions,uninstalls,uninstall_cohort'
+   API_KEY = configuration['API_KEY']
+   APP_TOKEN = configuration['APP_TOKEN']
+  
+   AD_SPEND_MODE = 'network'
+   DATE_PERIOD = '-30d:-0d'
+   DIMENSIONS = 'day,week,month,year,quarter,os_name,device_type,app,app_token,store_id,store_type,currency,currency_code,network,campaign,campaign_network,campaign_id_network,adgroup,adgroup_network,adgroup_id_network,source_network,source_id_network,creative,creative_network,creative_id_network,country,country_code,region,partner_name,partner_id,partner,channel,platform'
+   METRICS = 'network_cost,att_status_authorized,att_status_non_determined,att_status_denied,att_status_restricted,att_consent_rate,daus,maus,waus,base_sessions,clicks,attribution_clicks,network_clicks,click_conversion_rate,ctr,deattributions,events,first_reinstalls,first_uninstalls,gdpr_forgets,impressions,attribution_impressions,network_impressions,impression_conversion_rate,installs,network_installs,network_installs_diff,installs_per_mile,limit_ad_tracking_installs,limit_ad_tracking_install_rate,limit_ad_tracking_reattributions,limit_ad_tracking_reattribution_rate,non_organic_installs,organic_installs,reattributions,reattribution_reinstalls,reinstalls,sessions,uninstalls,uninstall_cohort'
 
-    headers = {
-        'Authorization': f'Bearer {API_KEY}',
-    }
-    
-    params = {
-        'ad_spend_mode': AD_SPEND_MODE,
-        'app_token__in': APP_TOKEN,
-        'date_period': DATE_PERIOD,
-        'dimensions': DIMENSIONS,
-        'metrics': METRICS
-    }
+   headers = {
+       'Authorization': f'Bearer {API_KEY}',
+   }
+  
+   params = {
+       'ad_spend_mode': AD_SPEND_MODE,
+       'app_token__in': APP_TOKEN,
+       'date_period': DATE_PERIOD,
+       'dimensions': DIMENSIONS,
+       'metrics': METRICS
+   }
 
-    try:
-        log.info("Fetching data from Adjust...")
-        response = requests.get(ADJUST_API_URL, headers=headers, params=params)
+   try:
+       log.info("Fetching data from Adjust...")
+       response = requests.get(ADJUST_API_URL, headers=headers, params=params)
 
-        log.info("Processing response from Adjust...")
-        response.raise_for_status()
-        
-        csv_reader = csv.DictReader(StringIO(response.text))
-        report_data = [row for row in csv_reader]
+       log.info("Processing response from Adjust...")
+       response.raise_for_status()
+      
+       csv_reader = csv.DictReader(StringIO(response.text))
+       report_data = [row for row in csv_reader]
 
-        log.info("Upserting to bigquery...")
-        for row in report_data:
+       log.info("Upserting to bigquery...")
+       for row in report_data:
 
-            yield op.upsert(table=TABLE_NAME, data={
-                # Dimensions
-                "hour": row['hour'],
-                "day": row['day'],
-                "week": row['week'],
-                "month": row['month'],
-                "year": row['year'],
-                "quarter": row['quarter'],
-                "os_name": row['os_name'],
-                "device_type": row['device_type'],
-                "app": row['app'],
-                "app_token": row['app_token'],
-                "store_id": row['store_id'],
-                "store_type": row['store_type'],
-                "currency": row['currency'],
-                "currency_code": row['currency_code'],
-                "network": row['network'],
-                "campaign": row['campaign'],
-                "campaign_network": row['campaign_network'],
-                "campaign_id_network": row['campaign_id_network'],
-                "adgroup": row['adgroup'],
-                "adgroup_network": row['adgroup_network'],
-                "adgroup_id_network": row['adgroup_id_network'],
-                "source_network": row['source_network'],
-                "source_id_network": row['source_id_network'],
-                "creative": row['creative'],
-                "creative_network": row['creative_network'],
-                "creative_id_network": row['creative_id_network'],
-                "country": row['country'],
-                "country_code": row['country_code'],
-                "region": row['region'],
-                "partner_name": row['partner_name'],
-                "partner_id": row['partner_id'],
-                "partner": row['partner'],
-                "channel": row['channel'],
-                "platform": row['platform'],
+           yield op.upsert(table=TABLE_NAME, data={
+               # Dimensions
+               "day": row['day'],
+               "week": row['week'],
+               "month": row['month'],
+               "year": row['year'],
+               "quarter": row['quarter'],
+               "os_name": row['os_name'],
+               "device_type": row['device_type'],
+               "app": row['app'],
+               "app_token": row['app_token'],
+               "store_id": row['store_id'],
+               "store_type": row['store_type'],
+               "currency": row['currency'],
+               "currency_code": row['currency_code'],
+               "network": row['network'],
+               "campaign": row['campaign'],
+               "campaign_network": row['campaign_network'],
+               "campaign_id_network": row['campaign_id_network'],
+               "adgroup": row['adgroup'],
+               "adgroup_network": row['adgroup_network'],
+               "adgroup_id_network": row['adgroup_id_network'],
+               "source_network": row['source_network'],
+               "source_id_network": row['source_id_network'],
+               "creative": row['creative'],
+               "creative_network": row['creative_network'],
+               "creative_id_network": row['creative_id_network'],
+               "country": row['country'],
+               "country_code": row['country_code'],
+               "region": row['region'],
+               "partner_name": row['partner_name'],
+               "partner_id": row['partner_id'],
+               "partner": row['partner'],
+               "channel": row['channel'],
+               "platform": row['platform'],
 
-                # Metrics
-                "network_cost": float(row['network_cost']),
-                "att_status_authorized": int(row['att_status_authorized']),
-                "att_status_non_determined": int(row['att_status_non_determined']),
-                "att_status_denied": int(row['att_status_denied']),
-                "att_status_restricted": int(row['att_status_restricted']),
-                "att_consent_rate": float(row['att_consent_rate']),
-                "daus": float(row['daus']),
-                "maus": float(row['maus']),
-                "waus": float(row['waus']),
-                "base_sessions": int(row['base_sessions']),
-                "clicks": int(row['clicks']),
-                "attribution_clicks": int(row['attribution_clicks']),
-                "network_clicks": int(row['network_clicks']),
-                "click_conversion_rate": float(row['click_conversion_rate']),
-                "ctr": float(row['ctr']),
-                "deattributions": int(row['deattributions']),
-                "events": int(row['events']),
-                "first_reinstalls": int(row['first_reinstalls']),
-                "first_uninstalls": int(row['first_uninstalls']),
-                "gdpr_forgets": int(row['gdpr_forgets']),
-                "impressions": int(row['impressions']),
-                "attribution_impressions": int(row['attribution_impressions']),
-                "network_impressions": int(row['network_impressions']),
-                "impression_conversion_rate": float(row['impression_conversion_rate']),
-                "installs": int(row['installs']),
-                "network_installs": int(row['network_installs']),
-                "network_installs_diff": int(row['network_installs_diff']),
-                "installs_per_mile": float(row['installs_per_mile']),
-                "limit_ad_tracking_installs": int(row['limit_ad_tracking_installs']),
-                "limit_ad_tracking_install_rate": float(row['limit_ad_tracking_install_rate']),
-                "limit_ad_tracking_reattributions": int(row['limit_ad_tracking_reattributions']),
-                "limit_ad_tracking_reattribution_rate": float(row['limit_ad_tracking_reattribution_rate']),
-                "non_organic_installs": int(row['non_organic_installs']),
-                "organic_installs": int(row['organic_installs']),
-                "reattributions": int(row['reattributions']),
-                "reattribution_reinstalls": int(row['reattribution_reinstalls']),
-                "reinstalls": int(row['reinstalls']),
-                "sessions": int(row['sessions']),
-                "uninstalls": int(row['uninstalls']),
-                "uninstall_cohort": float(row['uninstall_cohort']),
-            })
+               # Metrics
+               "network_cost": float(row['network_cost']),
+               "att_status_authorized": int(row['att_status_authorized']),
+               "att_status_non_determined": int(row['att_status_non_determined']),
+               "att_status_denied": int(row['att_status_denied']),
+               "att_status_restricted": int(row['att_status_restricted']),
+               "att_consent_rate": float(row['att_consent_rate']),
+               "daus": float(row['daus']),
+               "maus": float(row['maus']),
+               "waus": float(row['waus']),
+               "base_sessions": int(row['base_sessions']),
+               "clicks": int(row['clicks']),
+               "attribution_clicks": int(row['attribution_clicks']),
+               "network_clicks": int(row['network_clicks']),
+               "click_conversion_rate": float(row['click_conversion_rate']),
+               "ctr": float(row['ctr']),
+               "deattributions": int(row['deattributions']),
+               "events": int(row['events']),
+               "first_reinstalls": int(row['first_reinstalls']),
+               "first_uninstalls": int(row['first_uninstalls']),
+               "gdpr_forgets": int(row['gdpr_forgets']),
+               "impressions": int(row['impressions']),
+               "attribution_impressions": int(row['attribution_impressions']),
+               "network_impressions": int(row['network_impressions']),
+               "impression_conversion_rate": float(row['impression_conversion_rate']),
+               "installs": int(row['installs']),
+               "network_installs": int(row['network_installs']),
+               "network_installs_diff": int(row['network_installs_diff']),
+               "installs_per_mile": float(row['installs_per_mile']),
+               "limit_ad_tracking_installs": int(row['limit_ad_tracking_installs']),
+               "limit_ad_tracking_install_rate": float(row['limit_ad_tracking_install_rate']),
+               "limit_ad_tracking_reattributions": int(row['limit_ad_tracking_reattributions']),
+               "limit_ad_tracking_reattribution_rate": float(row['limit_ad_tracking_reattribution_rate']),
+               "non_organic_installs": int(row['non_organic_installs']),
+               "organic_installs": int(row['organic_installs']),
+               "reattributions": int(row['reattributions']),
+               "reattribution_reinstalls": int(row['reattribution_reinstalls']),
+               "reinstalls": int(row['reinstalls']),
+               "sessions": int(row['sessions']),
+               "uninstalls": int(row['uninstalls']),
+               "uninstall_cohort": float(row['uninstall_cohort']),
+           })
 
-
-    except requests.exceptions.HTTPError as err:
-        log.warning(f'HTTP error occurred: {err}')
-        log.warning(f'Response content: {response.text}')
-    except json.JSONDecodeError as json_err:
-        log.warning(f'JSON decoding error: {json_err}')
-        log.warning(f'Raw response content: {response.text}')
-    except Exception as err:
-        log.warning(f'Other error occurred: {err}')
+   except requests.exceptions.HTTPError as err:
+       log.warning(f'HTTP error occurred: {err}')
+       log.warning(f'Response content: {response.text}')
+   except json.JSONDecodeError as json_err:
+       log.warning(f'JSON decoding error: {json_err}')
+       log.warning(f'Raw response content: {response.text}')
+   except Exception as err:
+       log.warning(f'Other error occurred: {err}')
 
 connector = Connector(update=update, schema=schema)

--- a/adjust_report_etl/connector.py
+++ b/adjust_report_etl/connector.py
@@ -1,0 +1,228 @@
+import requests
+import json
+import csv
+from io import StringIO
+from fivetran_connector_sdk import Connector
+from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Operations as op
+
+log.LOG_LEVEL = log.Level.INFO
+
+ADJUST_API_URL = 'https://automate.adjust.com/reports-service/csv_report'
+TABLE_NAME = 'data'
+
+def schema(configuration: dict):
+    return [
+        {
+            "table": TABLE_NAME,
+            "primary_key": ["campaign_id_network", "device_type"],
+            "columns": {
+                # Dimensions
+                "hour": "STRING",
+                "day": "STRING",
+                "week": "STRING",
+                "month": "STRING",
+                "year": "STRING",
+                "quarter": "STRING",
+                "os_name": "STRING",
+                "device_type": "STRING",
+                "app": "STRING",
+                "app_token": "STRING",
+                "store_id": "STRING",
+                "store_type": "STRING",
+                "currency": "STRING",
+                "currency_code": "STRING",
+                "network": "STRING",
+                "campaign": "STRING",
+                "campaign_network": "STRING",
+                "campaign_id_network": "STRING",
+                "adgroup": "STRING",
+                "adgroup_network": "STRING",
+                "adgroup_id_network": "STRING",
+                "source_network": "STRING",
+                "source_id_network": "STRING",
+                "creative": "STRING",
+                "creative_network": "STRING",
+                "creative_id_network": "STRING",
+                "country": "STRING",
+                "country_code": "STRING",
+                "region": "STRING",
+                "partner_name": "STRING",
+                "partner_id": "STRING",
+                "partner": "STRING",
+                "channel": "STRING",
+                "platform": "STRING",
+
+                # Metrics
+                "att_status_authorized": "INT",
+                "att_status_non_determined": "INT",
+                "att_status_denied": "INT",
+                "att_status_restricted": "INT",
+                "att_consent_rate": "FLOAT",
+                "daus": "FLOAT",
+                "maus": "FLOAT",
+                "waus": "FLOAT",
+                "base_sessions": "INT",
+                # "cancels": "INT",
+                "clicks": "INT",
+                "attribution_clicks": "INT",
+                "network_clicks": "INT",
+                "click_conversion_rate": "FLOAT",
+                "ctr": "FLOAT",
+                "deattributions": "INT",
+                "events": "INT",
+                "first_reinstalls": "INT",
+                "first_uninstalls": "INT",
+                "gdpr_forgets": "INT",
+                "impressions": "INT",
+                "attribution_impressions": "INT",
+                "network_impressions": "INT",
+                "impression_conversion_rate": "FLOAT",
+                "installs": "INT",
+                "network_installs": "INT",
+                "network_installs_diff": "INT",
+                "installs_per_mile": "FLOAT",
+                "limit_ad_tracking_installs": "INT",
+                "limit_ad_tracking_install_rate": "FLOAT",
+                "limit_ad_tracking_reattributions": "INT",
+                "limit_ad_tracking_reattribution_rate": "FLOAT",
+                "non_organic_installs": "INT",
+                "organic_installs": "INT",
+                "reattributions": "INT",
+                "reattribution_reinstalls": "INT",
+                "reinstalls": "INT",
+                # "renewals": "INT",
+                "sessions": "INT",
+                "uninstalls": "INT",
+                "uninstall_cohort": "FLOAT",
+                "network_cost": "FLOAT",
+            },
+        }
+    ]
+
+
+def update(configuration: dict, state: dict):
+    API_KEY = configuration['API_KEY']
+    APP_TOKEN = configuration['APP_TOKEN']
+    
+    AD_SPEND_MODE = 'network'
+    DATE_PERIOD = '-7d:-0d'
+    DIMENSIONS = 'hour,day,week,month,year,quarter,os_name,device_type,app,app_token,store_id,store_type,currency,currency_code,network,campaign,campaign_network,campaign_id_network,adgroup,adgroup_network,adgroup_id_network,source_network,source_id_network,creative,creative_network,creative_id_network,country,country_code,region,partner_name,partner_id,partner,channel,platform'
+    METRICS = 'network_cost,att_status_authorized,att_status_non_determined,att_status_denied,att_status_restricted,att_consent_rate,daus,maus,waus,base_sessions,clicks,attribution_clicks,network_clicks,click_conversion_rate,ctr,deattributions,events,first_reinstalls,first_uninstalls,gdpr_forgets,impressions,attribution_impressions,network_impressions,impression_conversion_rate,installs,network_installs,network_installs_diff,installs_per_mile,limit_ad_tracking_installs,limit_ad_tracking_install_rate,limit_ad_tracking_reattributions,limit_ad_tracking_reattribution_rate,non_organic_installs,organic_installs,reattributions,reattribution_reinstalls,reinstalls,sessions,uninstalls,uninstall_cohort'
+
+    headers = {
+        'Authorization': f'Bearer {API_KEY}',
+    }
+    
+    params = {
+        'ad_spend_mode': AD_SPEND_MODE,
+        'app_token__in': APP_TOKEN,
+        'date_period': DATE_PERIOD,
+        'dimensions': DIMENSIONS,
+        'metrics': METRICS
+    }
+
+    try:
+        log.info("Fetching data from Adjust...")
+        response = requests.get(ADJUST_API_URL, headers=headers, params=params)
+
+        log.info("Processing response from Adjust...")
+        response.raise_for_status()
+        
+        csv_reader = csv.DictReader(StringIO(response.text))
+        report_data = [row for row in csv_reader]
+
+        log.info("Upserting to bigquery...")
+        for row in report_data:
+
+            yield op.upsert(table=TABLE_NAME, data={
+                # Dimensions
+                "hour": row['hour'],
+                "day": row['day'],
+                "week": row['week'],
+                "month": row['month'],
+                "year": row['year'],
+                "quarter": row['quarter'],
+                "os_name": row['os_name'],
+                "device_type": row['device_type'],
+                "app": row['app'],
+                "app_token": row['app_token'],
+                "store_id": row['store_id'],
+                "store_type": row['store_type'],
+                "currency": row['currency'],
+                "currency_code": row['currency_code'],
+                "network": row['network'],
+                "campaign": row['campaign'],
+                "campaign_network": row['campaign_network'],
+                "campaign_id_network": row['campaign_id_network'],
+                "adgroup": row['adgroup'],
+                "adgroup_network": row['adgroup_network'],
+                "adgroup_id_network": row['adgroup_id_network'],
+                "source_network": row['source_network'],
+                "source_id_network": row['source_id_network'],
+                "creative": row['creative'],
+                "creative_network": row['creative_network'],
+                "creative_id_network": row['creative_id_network'],
+                "country": row['country'],
+                "country_code": row['country_code'],
+                "region": row['region'],
+                "partner_name": row['partner_name'],
+                "partner_id": row['partner_id'],
+                "partner": row['partner'],
+                "channel": row['channel'],
+                "platform": row['platform'],
+
+                # Metrics
+                "network_cost": float(row['network_cost']),
+                "att_status_authorized": int(row['att_status_authorized']),
+                "att_status_non_determined": int(row['att_status_non_determined']),
+                "att_status_denied": int(row['att_status_denied']),
+                "att_status_restricted": int(row['att_status_restricted']),
+                "att_consent_rate": float(row['att_consent_rate']),
+                "daus": float(row['daus']),
+                "maus": float(row['maus']),
+                "waus": float(row['waus']),
+                "base_sessions": int(row['base_sessions']),
+                "clicks": int(row['clicks']),
+                "attribution_clicks": int(row['attribution_clicks']),
+                "network_clicks": int(row['network_clicks']),
+                "click_conversion_rate": float(row['click_conversion_rate']),
+                "ctr": float(row['ctr']),
+                "deattributions": int(row['deattributions']),
+                "events": int(row['events']),
+                "first_reinstalls": int(row['first_reinstalls']),
+                "first_uninstalls": int(row['first_uninstalls']),
+                "gdpr_forgets": int(row['gdpr_forgets']),
+                "impressions": int(row['impressions']),
+                "attribution_impressions": int(row['attribution_impressions']),
+                "network_impressions": int(row['network_impressions']),
+                "impression_conversion_rate": float(row['impression_conversion_rate']),
+                "installs": int(row['installs']),
+                "network_installs": int(row['network_installs']),
+                "network_installs_diff": int(row['network_installs_diff']),
+                "installs_per_mile": float(row['installs_per_mile']),
+                "limit_ad_tracking_installs": int(row['limit_ad_tracking_installs']),
+                "limit_ad_tracking_install_rate": float(row['limit_ad_tracking_install_rate']),
+                "limit_ad_tracking_reattributions": int(row['limit_ad_tracking_reattributions']),
+                "limit_ad_tracking_reattribution_rate": float(row['limit_ad_tracking_reattribution_rate']),
+                "non_organic_installs": int(row['non_organic_installs']),
+                "organic_installs": int(row['organic_installs']),
+                "reattributions": int(row['reattributions']),
+                "reattribution_reinstalls": int(row['reattribution_reinstalls']),
+                "reinstalls": int(row['reinstalls']),
+                "sessions": int(row['sessions']),
+                "uninstalls": int(row['uninstalls']),
+                "uninstall_cohort": float(row['uninstall_cohort']),
+            })
+
+
+    except requests.exceptions.HTTPError as err:
+        log.warning(f'HTTP error occurred: {err}')
+        log.warning(f'Response content: {response.text}')
+    except json.JSONDecodeError as json_err:
+        log.warning(f'JSON decoding error: {json_err}')
+        log.warning(f'Raw response content: {response.text}')
+    except Exception as err:
+        log.warning(f'Other error occurred: {err}')
+
+connector = Connector(update=update, schema=schema)

--- a/adjust_report_etl/connector.py
+++ b/adjust_report_etl/connector.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import csv
+
 from io import StringIO
 from fivetran_connector_sdk import Connector
 from fivetran_connector_sdk import Logging as log
@@ -8,217 +9,165 @@ from fivetran_connector_sdk import Operations as op
 
 log.LOG_LEVEL = log.Level.INFO
 
-ADJUST_API_URL = 'https://automate.adjust.com/reports-service/csv_report'
 TABLE_NAME = 'data'
 
 def schema(configuration: dict):
-   return [
-       {
-           "table": TABLE_NAME,
-           "primary_key": ["campaign_id_network", "device_type"],
-           "columns": {
-               # Dimensions
-               "day": "STRING",
-               "week": "STRING",
-               "month": "STRING",
-               "year": "STRING",
-               "quarter": "STRING",
-               "os_name": "STRING",
-               "device_type": "STRING",
-               "app": "STRING",
-               "app_token": "STRING",
-               "store_id": "STRING",
-               "store_type": "STRING",
-               "currency": "STRING",
-               "currency_code": "STRING",
-               "network": "STRING",
-               "campaign": "STRING",
-               "campaign_network": "STRING",
-               "campaign_id_network": "STRING",
-               "adgroup": "STRING",
-               "adgroup_network": "STRING",
-               "adgroup_id_network": "STRING",
-               "source_network": "STRING",
-               "source_id_network": "STRING",
-               "creative": "STRING",
-               "creative_network": "STRING",
-               "creative_id_network": "STRING",
-               "country": "STRING",
-               "country_code": "STRING",
-               "region": "STRING",
-               "partner_name": "STRING",
-               "partner_id": "STRING",
-               "partner": "STRING",
-               "channel": "STRING",
-               "platform": "STRING",
+    return [
+        {
+            "table": TABLE_NAME,
+            "primary_key": [
+                "adgroup",
+                "adgroup_network",
+                "app",
+                "app_token",
+                "campaign",
+                "campaign_network",
+                "channel",
+                "country",
+                "creative",
+                "creative_network",
+                "currency", 
+                "day",
+                "network",
+                "partner_name",
+                "source_network",
+                "store_type"
+            ],
 
-               # Metrics
-               "att_status_authorized": "INT",
-               "att_status_non_determined": "INT",
-               "att_status_denied": "INT",
-               "att_status_restricted": "INT",
-               "att_consent_rate": "FLOAT",
-               "daus": "FLOAT",
-               "maus": "FLOAT",
-               "waus": "FLOAT",
-               "base_sessions": "INT",
-               # "cancels": "INT", no access to this metric. Do we need it?
-               "clicks": "INT",
-               "attribution_clicks": "INT",
-               "network_clicks": "INT",
-               "click_conversion_rate": "FLOAT",
-               "ctr": "FLOAT",
-               "deattributions": "INT",
-               "events": "INT",
-               "first_reinstalls": "INT",
-               "first_uninstalls": "INT",
-               "gdpr_forgets": "INT",
-               "impressions": "INT",
-               "attribution_impressions": "INT",
-               "network_impressions": "INT",
-               "impression_conversion_rate": "FLOAT",
-               "installs": "INT",
-               "network_installs": "INT",
-               "network_installs_diff": "INT",
-               "installs_per_mile": "FLOAT",
-               "limit_ad_tracking_installs": "INT",
-               "limit_ad_tracking_install_rate": "FLOAT",
-               "limit_ad_tracking_reattributions": "INT",
-               "limit_ad_tracking_reattribution_rate": "FLOAT",
-               "non_organic_installs": "INT",
-               "organic_installs": "INT",
-               "reattributions": "INT",
-               "reattribution_reinstalls": "INT",
-               "reinstalls": "INT",
-               # "renewals": "INT", no access to this metric. Do we need it?
-               "sessions": "INT",
-               "uninstalls": "INT",
-               "uninstall_cohort": "FLOAT",
-               "network_cost": "FLOAT",
-           },
-       }
-   ]
+            "columns": {
+                # Dimensions
+                "adgroup": "STRING",
+                "adgroup_network": "STRING",
+                "app": "STRING",
+                "app_token": "STRING",
+                "campaign": "STRING",
+                "campaign_network": "STRING",
+                "channel": "STRING",
+                "country": "STRING",
+                "creative": "STRING",
+                "creative_network": "STRING",
+                "currency": "STRING",
+                "day": "STRING",
+                "network": "STRING",
+                "partner_name": "STRING",
+                "source_network": "STRING",
+                "store_type": "STRING",
+
+                # Metrics
+                "clicks": "INT",
+                "impressions": "INT",
+                "installs": "INT",
+                "cost": "FLOAT",
+                "ad_revenue": "FLOAT",
+                "revenue": "FLOAT",
+                "att_status_authorized": "INT",
+                "att_status_denied": "INT",
+            },
+        }
+    ]
 
 def update(configuration: dict, state: dict):
-   API_KEY = configuration['API_KEY']
-   APP_TOKEN = configuration['APP_TOKEN']
-  
-   AD_SPEND_MODE = 'network'
-   DATE_PERIOD = '-30d:-0d'
-   DIMENSIONS = 'day,week,month,year,quarter,os_name,device_type,app,app_token,store_id,store_type,currency,currency_code,network,campaign,campaign_network,campaign_id_network,adgroup,adgroup_network,adgroup_id_network,source_network,source_id_network,creative,creative_network,creative_id_network,country,country_code,region,partner_name,partner_id,partner,channel,platform'
-   METRICS = 'network_cost,att_status_authorized,att_status_non_determined,att_status_denied,att_status_restricted,att_consent_rate,daus,maus,waus,base_sessions,clicks,attribution_clicks,network_clicks,click_conversion_rate,ctr,deattributions,events,first_reinstalls,first_uninstalls,gdpr_forgets,impressions,attribution_impressions,network_impressions,impression_conversion_rate,installs,network_installs,network_installs_diff,installs_per_mile,limit_ad_tracking_installs,limit_ad_tracking_install_rate,limit_ad_tracking_reattributions,limit_ad_tracking_reattribution_rate,non_organic_installs,organic_installs,reattributions,reattribution_reinstalls,reinstalls,sessions,uninstalls,uninstall_cohort'
+    
+    ADJUST_API_URL = 'https://automate.adjust.com/reports-service/csv_report'
 
-   headers = {
-       'Authorization': f'Bearer {API_KEY}',
-   }
-  
-   params = {
-       'ad_spend_mode': AD_SPEND_MODE,
-       'app_token__in': APP_TOKEN,
-       'date_period': DATE_PERIOD,
-       'dimensions': DIMENSIONS,
-       'metrics': METRICS
-   }
+    AD_SPEND_MODE = 'network'
+    DATE_PERIOD = '2023-04-01:-0d'
 
-   try:
-       log.info("Fetching data from Adjust...")
-       response = requests.get(ADJUST_API_URL, headers=headers, params=params)
+    DIMENSIONS = ','.join([
+        "adgroup",
+        "adgroup_network",
+        "app",
+        "app_token",
+        "campaign",
+        "campaign_network",
+        "channel",
+        "country",
+        "creative",
+        "creative_network",
+        "currency",
+        "day",
+        "network",
+        "partner_name",
+        "source_network",
+        "store_type"
+    ])
+    
+    METRICS = ','.join([
+        "clicks",
+        "impressions",
+        "installs",
+        "cost",
+        "ad_revenue",
+        "revenue",
+        "att_status_authorized",
+        "att_status_denied",
+    ])
 
-       log.info("Processing response from Adjust...")
-       response.raise_for_status()
-      
-       csv_reader = csv.DictReader(StringIO(response.text))
-       report_data = [row for row in csv_reader]
+    try:
+        API_KEY = configuration['API_KEY']
+        headers = {
+            'Authorization': f'Bearer {API_KEY}',
+        }
+        
+        APP_TOKEN = configuration['APP_TOKEN']
+        params = {
+            'ad_spend_mode': AD_SPEND_MODE,
+            'app_token__in': APP_TOKEN,
+            'date_period': DATE_PERIOD,
+            'dimensions': DIMENSIONS,
+            'metrics': METRICS
+        }
 
-       log.info("Upserting to bigquery...")
-       for row in report_data:
+        log.info("Fetching data from Adjust...")
+        response = requests.get(ADJUST_API_URL, headers=headers, params=params)
 
-           yield op.upsert(table=TABLE_NAME, data={
-               # Dimensions
-               "day": row['day'],
-               "week": row['week'],
-               "month": row['month'],
-               "year": row['year'],
-               "quarter": row['quarter'],
-               "os_name": row['os_name'],
-               "device_type": row['device_type'],
-               "app": row['app'],
-               "app_token": row['app_token'],
-               "store_id": row['store_id'],
-               "store_type": row['store_type'],
-               "currency": row['currency'],
-               "currency_code": row['currency_code'],
-               "network": row['network'],
-               "campaign": row['campaign'],
-               "campaign_network": row['campaign_network'],
-               "campaign_id_network": row['campaign_id_network'],
-               "adgroup": row['adgroup'],
-               "adgroup_network": row['adgroup_network'],
-               "adgroup_id_network": row['adgroup_id_network'],
-               "source_network": row['source_network'],
-               "source_id_network": row['source_id_network'],
-               "creative": row['creative'],
-               "creative_network": row['creative_network'],
-               "creative_id_network": row['creative_id_network'],
-               "country": row['country'],
-               "country_code": row['country_code'],
-               "region": row['region'],
-               "partner_name": row['partner_name'],
-               "partner_id": row['partner_id'],
-               "partner": row['partner'],
-               "channel": row['channel'],
-               "platform": row['platform'],
+        log.info(f"Received response with status code: {response.status_code}")
+        response.raise_for_status()
+        
+        log.info("Processing Adjust data...")
+        csv_reader = csv.DictReader(StringIO(response.text))
+        report_data = [row for row in csv_reader]
 
-               # Metrics
-               "network_cost": float(row['network_cost']),
-               "att_status_authorized": int(row['att_status_authorized']),
-               "att_status_non_determined": int(row['att_status_non_determined']),
-               "att_status_denied": int(row['att_status_denied']),
-               "att_status_restricted": int(row['att_status_restricted']),
-               "att_consent_rate": float(row['att_consent_rate']),
-               "daus": float(row['daus']),
-               "maus": float(row['maus']),
-               "waus": float(row['waus']),
-               "base_sessions": int(row['base_sessions']),
-               "clicks": int(row['clicks']),
-               "attribution_clicks": int(row['attribution_clicks']),
-               "network_clicks": int(row['network_clicks']),
-               "click_conversion_rate": float(row['click_conversion_rate']),
-               "ctr": float(row['ctr']),
-               "deattributions": int(row['deattributions']),
-               "events": int(row['events']),
-               "first_reinstalls": int(row['first_reinstalls']),
-               "first_uninstalls": int(row['first_uninstalls']),
-               "gdpr_forgets": int(row['gdpr_forgets']),
-               "impressions": int(row['impressions']),
-               "attribution_impressions": int(row['attribution_impressions']),
-               "network_impressions": int(row['network_impressions']),
-               "impression_conversion_rate": float(row['impression_conversion_rate']),
-               "installs": int(row['installs']),
-               "network_installs": int(row['network_installs']),
-               "network_installs_diff": int(row['network_installs_diff']),
-               "installs_per_mile": float(row['installs_per_mile']),
-               "limit_ad_tracking_installs": int(row['limit_ad_tracking_installs']),
-               "limit_ad_tracking_install_rate": float(row['limit_ad_tracking_install_rate']),
-               "limit_ad_tracking_reattributions": int(row['limit_ad_tracking_reattributions']),
-               "limit_ad_tracking_reattribution_rate": float(row['limit_ad_tracking_reattribution_rate']),
-               "non_organic_installs": int(row['non_organic_installs']),
-               "organic_installs": int(row['organic_installs']),
-               "reattributions": int(row['reattributions']),
-               "reattribution_reinstalls": int(row['reattribution_reinstalls']),
-               "reinstalls": int(row['reinstalls']),
-               "sessions": int(row['sessions']),
-               "uninstalls": int(row['uninstalls']),
-               "uninstall_cohort": float(row['uninstall_cohort']),
-           })
+        log.info("Upserting rows to bigquery...")
+        for row in report_data:
+            yield op.upsert(table=TABLE_NAME, data={
+                # Dimensions
+                "adgroup": row['adgroup'],
+                "adgroup_network": row['adgroup_network'],
+                "app": row['app'],
+                "app_token": row['app_token'],
+                "campaign": row['campaign'],
+                "campaign_network": row['campaign_network'],
+                "channel": row['channel'],
+                "country": row['country'],
+                "creative": row['creative'],
+                "creative_network": row['creative_network'],
+                "currency": row['currency'],
+                "day": row['day'],
+                "network": row['network'],
+                "partner_name": row['partner_name'],
+                "source_network": row['source_network'],
+                "store_type": row['store_type'],
 
-   except requests.exceptions.HTTPError as err:
-       log.warning(f'HTTP error occurred: {err}')
-       log.warning(f'Response content: {response.text}')
-   except json.JSONDecodeError as json_err:
-       log.warning(f'JSON decoding error: {json_err}')
-       log.warning(f'Raw response content: {response.text}')
-   except Exception as err:
-       log.warning(f'Other error occurred: {err}')
+                # Metrics
+                "clicks": int(row['clicks']),
+                "impressions": int(row['impressions']),
+                "installs": int(row['installs']),
+                "cost": float(row['cost']),
+                "ad_revenue": float(row['ad_revenue']),
+                "revenue": float(row['revenue']),
+                "att_status_authorized": int(row['att_status_authorized']),
+                "att_status_denied": int(row['att_status_denied']),
+            })
+        log.info(f"Completed upserting {len(report_data)} rows to BigQuery.")
+
+    except requests.exceptions.HTTPError as err:
+        log.warning(f'HTTP error occurred: {err}')
+        log.warning(f'Response content: {response.text}')
+    except json.JSONDecodeError as json_err:
+        log.warning(f'JSON decoding error: {json_err}')
+        log.warning(f'Raw response content: {response.text}')
+    except Exception as err:
+        log.warning(f'Other error occurred: {err}')
 
 connector = Connector(update=update, schema=schema)


### PR DESCRIPTION
## What does this change?
Two new Fivetran custom connectors, written in Python, to extract data from the Adjust marketing platform for our Premium and Feast apps, and upload to Bigquery, so that the return on investment of Adjust marketing spend can be incorporated into the Marketing Effectiveness Data Asset for MRR.

<img width="739" alt="Screenshot 2024-11-25 at 12 21 17" src="https://github.com/user-attachments/assets/543bbc3f-101b-4fae-8457-77624fc0b719">

### What's new?
**Fivetran connectors**
[adjust_feast](https://fivetran.com/dashboard/connectors/mercy_sandy/status?groupId=catarrhal_fighting&service=connector_sdk&syncChartPeriod=1%20Day)
[adjust_premium](https://fivetran.com/dashboard/connectors?filters=eyJkZXN0aW5hdGlvbnMiOltdLCJncm91cGluZyI6eyJjb2x1bW4iOiJub25lIiwic29ydGVkQXNjIjp0cnVlfSwic2VhcmNoIjoiIiwic29ydGluZyI6eyJhc2MiOnRydWUsImNvbHVtbiI6Im5hbWUifSwic291cmNlcyI6W10sInN0YXR1c2VzIjpbXX0%3D)

**Bigquery datasets and tables**
datatech-fivetran.adjust_feast.csv_report
datatech-fivetran.adjust_premium.csv_report

### Why use Python?
Python was the only language that we could use for the custom connector, as per fivetran constraints. 

### Why not a lambda function within our AWS stack?
We could have built a lambda function instead but decided this would result in a higher technical overhead on aspects such as scheduling and infrastructure. With the Python script, all we need to maintain is the script itself.

## Stakeholders 
Data Design working on behalf of MRR

## How has this been tested?
None of Adjust, Fivetran or Bigquery have a development environment, so the following strategies were used to dev and test the solution:

- Test the extract from Adjust by running the script locally:
`fivetran debug`
or configuring a request in an API testing tool, such as Postman, and verifying that the parameters are correct. I found this particularly useful when trying combinations or dimensions and metrics. 

- Update the script iteratively and upload to fivetran in production. Check-in with Data Design to ensure data schema is correct and records are displaying as expected.

## Related PRs
[Access to Feast app data in bigquery](https://github.com/guardian/gcp-iac-terraform/pull/1008)
[Access to Premium app data in bigquery](https://github.com/guardian/gcp-iac-terraform/pull/1009)

### Other Documentation
[Building a Fivetran Connector](https://fivetran.com/docs/connectors/connector-sdk/detailed-guide)
[Fivetran Connector quickstart examples](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/quickstart_examples)
[Demo](https://drive.google.com/file/d/1E5l9w9aIsCvMKMWSRSJ5ug2FzkNGjtgD/view?t=29m30s)
