### PR TITLE
Feast IAP acquisitions: Part 2, Introspection of DynamoDBStreamEvents

### DIFF
--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -1,7 +1,23 @@
-import type { DynamoDBStreamEvent } from 'aws-lambda';
+import type { DynamoDBRecord, DynamoDBStreamEvent } from 'aws-lambda';
 
 export const handler = async (event: DynamoDBStreamEvent): Promise<String> => {
-    const message: String = 'Feast Acquisition Events Router Lambda has been called';
-    console.log(message)
-    return message;
+    console.log('[c9900d41] Feast Acquisition Events Router Lambda has been called');
+
+    const records = event.Records; // retrieve records from DynamoDBStreamEvent
+
+    let processedCount = 0;
+
+    const processRecordPromises = records.map(async (record: DynamoDBRecord) => {
+        const eventName = record.eventName;
+        const identityId = record?.dynamodb?.NewImage?.userId?.S || "";
+        const subscriptionId = record?.dynamodb?.NewImage?.subscriptionId?.S || "";
+        console.log(`Processing: ${eventName} record for identityId: ${identityId} and subscriptionId: ${subscriptionId}`);
+        processedCount ++;
+    });
+
+    await Promise.all(processRecordPromises);
+
+    console.log(`Processed ${processedCount} records from DynamoDBStreamEvent`);
+
+    return 'Success';
 }

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -44,7 +44,7 @@ export class Subscription {
     @attribute()
     ttl?: number;
 
-    tableName: string
+    tableName: string;
 
     constructor(
         subscriptionId: string,


### PR DESCRIPTION
This is Part 2 (Introspection of DynamoDBStreamEvent for Feast IAP acquisitions), of the publishing of Feast subscription data for android and iOS to the fact_acquisition_events project that started here https://github.com/guardian/mobile-purchases/pull/1667

Here we simply update the primary router to observe DynamoDBStreamEvents. 

