### PR TITLE
Feast IAP acquisitions: Part 3

### DIFF
--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -46,6 +46,8 @@ export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
             return;
         }
 
+        console.log(`subscription ${JSON.stringify(subscription)}`);
+
         const isFeast = subscription.platform === Platform.IosFeast || subscription.platform === Platform.AndroidFeast;
         
         // We are only interested in feast subscriptions

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -8,11 +8,11 @@ export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
     let processedCount = 0;
 
     const processRecordPromises = records.map(async (record: DynamoDBRecord) => {
+        console.log(`Processing: record: ${JSON.stringify(record)}`);
         const eventName = record.eventName;
         const identityId = record?.dynamodb?.NewImage?.userId?.S || "";
         const subscriptionId = record?.dynamodb?.NewImage?.subscriptionId?.S || "";
         console.log(`Processing: ${eventName} record for identityId: ${identityId} and subscriptionId: ${subscriptionId}`);
-        console.log(`Processing: record: ${JSON.stringify(record)}`);
         processedCount ++;
     });
 

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -1,22 +1,110 @@
 import type { DynamoDBRecord, DynamoDBStreamEvent } from 'aws-lambda';
+import { Subscription, ReadSubscription } from "../../models/subscription";
+import { dynamoMapper } from "../../utils/aws";
+import { Platform } from "../../models/platform";
+
+const processAcquisition = async (subscription: Subscription): Promise <boolean> => {
+    console.log(`Processing acquisition for subscription: ${JSON.stringify(subscription)}`);
+    return false;
+}
 
 export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
     console.log('[c9900d41] Feast Acquisition Events Router Lambda has been called');
 
     const records = event.Records; // retrieve records from DynamoDBStreamEvent
 
-    let processedCount = 0;
+    let insertReceivedCount = 0;
+    let insertProcessedCount = 0;
 
     const processRecordPromises = records.map(async (record: DynamoDBRecord) => {
         console.log(`Processing: record: ${JSON.stringify(record)}`);
+
         const eventName = record.eventName;
+
+        // We are only interested in the "INSERT" eventName
+        if (eventName !== "INSERT") {
+            console.log(`Skipping: ${eventName} record`);
+            return;
+        }
+
+        insertReceivedCount ++;
+
         const identityId = record?.dynamodb?.NewImage?.userId?.S || "";
         const subscriptionId = record?.dynamodb?.NewImage?.subscriptionId?.S || "";
         console.log(`Processing: ${eventName} record for identityId: ${identityId} and subscriptionId: ${subscriptionId}`);
-        processedCount ++;
+        
+        let emptySubscription = new ReadSubscription();
+        emptySubscription.setSubscriptionId(subscriptionId);
+
+        let subscription: Subscription;
+
+        try {
+            subscription = await dynamoMapper.get(emptySubscription);
+        } catch (error) {
+            console.log(`[d2c0251e] Subscription ${subscriptionId} record not found in the subscriptions table. Error: `, error);
+            // We are exiting but TODO: we are going to write to the deadl letter queue.
+            return;
+        }
+
+        const isFeast = subscription.platform === Platform.IosFeast || subscription.platform === Platform.AndroidFeast;
+        
+        // We are only interested in feast subscriptions
+        if (!isFeast) {
+            console.log(`Skipping non Feast subscription ${subscriptionId}`);
+            return;
+        }
+
+        const result = await processAcquisition(subscription);
+        if (!result) {
+            // We are exiting but TODO: we are going to write to the deadl letter queue.
+            return;
+        }
+
+        insertProcessedCount ++; 
     });
 
     await Promise.all(processRecordPromises);
 
-    console.log(`Processed ${processedCount} records from DynamoDBStreamEvent`);
+    console.log(`Sucessfully processed ${insertProcessedCount} insertions from a collection of ${insertReceivedCount} from DynamoDBStreamEvent`);
 }
+
+// --------------------------------------------------------------------------
+// Documentation
+// --------------------------------------------------------------------------
+
+/*
+Example (sanited) of a DynamoDBStreamEvent's single record
+{
+    "eventID": "88269a13666b1e308cfa9a2a605872b4",
+    "eventName": "INSERT",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "eu-west-1",
+    "dynamodb": {
+        "ApproximateCreationDateTime": 1731345389,
+        "Keys": {
+            "subscriptionId": {
+                "S": "0987654321"
+            },
+            "userId": {
+                "S": "1234567890"
+            }
+        },
+        "NewImage": {
+            "creationTimestamp": {
+                "S": "2024-11-11T17:16:29.237Z"
+            },
+            "subscriptionId": {
+                "S": "0987654321"
+            },
+            "userId": {
+                "S": "1234567890"
+            }
+        },
+        "SequenceNumber": "8935985800002395190001559217",
+        "SizeBytes": 129,
+        "StreamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:eu-west-1:201359054765:table/mobile-purchases-PROD-user-subscriptions/stream/2023-03-29T15:54:42.240"
+}
+*/

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -1,6 +1,6 @@
 import type { DynamoDBRecord, DynamoDBStreamEvent } from 'aws-lambda';
 
-export const handler = async (event: DynamoDBStreamEvent): Promise<String> => {
+export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
     console.log('[c9900d41] Feast Acquisition Events Router Lambda has been called');
 
     const records = event.Records; // retrieve records from DynamoDBStreamEvent
@@ -18,6 +18,4 @@ export const handler = async (event: DynamoDBStreamEvent): Promise<String> => {
     await Promise.all(processRecordPromises);
 
     console.log(`Processed ${processedCount} records from DynamoDBStreamEvent`);
-
-    return 'Success';
 }

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -42,7 +42,7 @@ export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
             subscription = await dynamoMapper.get(emptySubscription);
         } catch (error) {
             console.log(`[d2c0251e] Subscription ${subscriptionId} record not found in the subscriptions table. Error: `, error);
-            // We are exiting but TODO: we are going to write to the deadl letter queue.
+            // We are exiting but TODO: we are going to write to the dead letter queue.
             return;
         }
 

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -58,7 +58,7 @@ export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
 
         const result = await processAcquisition(subscription);
         if (!result) {
-            // We are exiting but TODO: we are going to write to the deadl letter queue.
+            // We are exiting but TODO: we are going to write to the dead letter queue.
             return;
         }
 

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -41,7 +41,7 @@ export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
         try {
             subscription = await dynamoMapper.get(emptySubscription);
         } catch (error) {
-            console.log(`[d2c0251e] Subscription ${subscriptionId} record not found in the subscriptions table. Error: `, error);
+            console.log(`[d2c0251e] Subscription ${subscriptionId}, error: `, error);
             // We are exiting but TODO: we are going to write to the dead letter queue.
             return;
         }

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -12,6 +12,7 @@ export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
         const identityId = record?.dynamodb?.NewImage?.userId?.S || "";
         const subscriptionId = record?.dynamodb?.NewImage?.subscriptionId?.S || "";
         console.log(`Processing: ${eventName} record for identityId: ${identityId} and subscriptionId: ${subscriptionId}`);
+        console.log(`Processing: record: ${JSON.stringify(record)}`);
         processedCount ++;
     });
 

--- a/typescript/src/feast/acquisition-events/router.ts
+++ b/typescript/src/feast/acquisition-events/router.ts
@@ -109,4 +109,35 @@ Example (sanited) of a DynamoDBStreamEvent's single record
     },
     "eventSourceARN": "arn:aws:dynamodb:eu-west-1:201359054765:table/mobile-purchases-PROD-user-subscriptions/stream/2023-03-29T15:54:42.240"
 }
+
+Possible event names: "INSERT", "MODIFY", "REMOVE"
+
+Subscription Example (sanited):
+{
+    "subscriptionId": "bjbl[sanited]iLNPQ",
+    "startTimestamp": "2020-06-12T07:00:59.108Z",
+    "endTimestamp": "2025-06-19T09:00:35.482Z",
+    "autoRenewing": true,
+    "productId": "com.guardian.subscription.annual.13",
+    "platform": "android",
+    "freeTrial": false,
+    "billingPeriod": "P1Y",
+    "googlePayload": {
+        "startTimeMillis": "1591945259108",
+        "priceAmountMicros": "94990000",
+        "orderId": "GPA.[sanited]09414..4",
+        "expiryTimeMillis": "1750323635482",
+        "countryCode": "US",
+        "kind": "androidpublisher#subscriptionPurchase",
+        "acknowledgementState": 1,
+        "developerPayload": null,
+        "paymentState": 1,
+        "priceCurrencyCode": "USD",
+        "autoRenewing": true
+    },
+    "applePayload": null,
+    "ttl": 1829206836,
+    "tableName": "subscriptions"
+}
+
 */

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -84,8 +84,11 @@ export class Subscription {
 }
 
 // TODO: The name "ReadSubscription" is a little bit unfortunate.
-// It's basically an object that is passed to dynamoMapper.get function
-// Should probably give it a better name.
+// It's basically an empty subscription that is passed to dynamoMapper.get function
+// Should probably rename it to EmptySubscription.
+// I have noticed that it's miunderstood as a subscription that is being read from the database.
+// For instance in the following code snippet: https://github.com/guardian/mobile-purchases/blob/ccc257c28a7d7a75b9dadfb47f214b074fd8ba50/typescript/src/soft-opt-ins/processSubscription.ts#L101
+// Where in fact that function should take a plain Subscription.
 
 export class ReadSubscription extends Subscription {
 

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -83,6 +83,10 @@ export class Subscription {
     }
 }
 
+// TODO: The name "ReadSubscription" is a little bit unfortunate.
+// It's basically an object that is passed to dynamoMapper.get function
+// Should probably give it a better name.
+
 export class ReadSubscription extends Subscription {
 
     constructor() {


### PR DESCRIPTION
Project: Feast subscription data for android and iOS

Part 1: https://github.com/guardian/mobile-purchases/pull/1667
Part 2: https://github.com/guardian/mobile-purchases/pull/1695

Part 3:
In this part we implement the logic of the processing of inserted subscriptions, if they are feast subscriptions. 