### PR TITLE
rename ReadSubscription into SubscriptionEmpty

### DIFF
--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -116,7 +116,7 @@ Resources:
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
           ExportBucket: !Ref SubscriptionExportBucket
-          ClassName: ReadSubscription
+          ClassName: Subscription
       Description: Export subscription table to the datalake
       MemorySize: 10240
       Timeout: 900

--- a/typescript/src/export/exportEvents.ts
+++ b/typescript/src/export/exportEvents.ts
@@ -3,7 +3,7 @@ import {dynamoMapper, s3} from "../utils/aws";
 import zlib from 'zlib'
 import {Stage} from "../utils/appIdentity";
 import {DynamoStream} from "./dynamoStream";
-import {ReadSubscriptionEvent, SubscriptionEvent} from "../models/subscriptionEvent";
+import {SubscriptionEventEmpty, SubscriptionEvent} from "../models/subscriptionEvent";
 import {plusDays} from "../utils/dates";
 
 function cleanupEvent(subEvent: SubscriptionEvent): any {
@@ -28,7 +28,7 @@ export async function handler(event?: ManualBackfillEvent): Promise<any> {
         yesterday = event.date;
     }
 
-    const iterator = dynamoMapper.query(ReadSubscriptionEvent,{date: yesterday}, {indexName: "date-timestamp-index-v2"});
+    const iterator = dynamoMapper.query(SubscriptionEventEmpty,{date: yesterday}, {indexName: "date-timestamp-index-v2"});
     const stream = new DynamoStream(iterator, cleanupEvent);
 
     let zippedStream = zlib.createGzip();

--- a/typescript/src/export/exportSubscriptions.ts
+++ b/typescript/src/export/exportSubscriptions.ts
@@ -1,6 +1,6 @@
 import 'source-map-support/register'
 import {dynamoMapper, s3} from "../utils/aws";
-import {ReadSubscription} from "../models/subscription";
+import {SubscriptionEmpty} from "../models/subscription";
 import {ReadUserSubscription} from "../models/userSubscription";
 import zlib from 'zlib'
 import {Stage} from "../utils/appIdentity";
@@ -16,7 +16,7 @@ export async function handler(): Promise<any> {
     switch (className) {
         case "ReadSubscription":
             console.log("Reading subscription from subscriptions");
-            stream = new DynamoStream(dynamoMapper.scan(ReadSubscription));
+            stream = new DynamoStream(dynamoMapper.scan(SubscriptionEmpty));
             break;
         case "ReadUserSubscription":
             console.log("Reading user subscription from user subscription");

--- a/typescript/src/export/exportSubscriptions.ts
+++ b/typescript/src/export/exportSubscriptions.ts
@@ -14,7 +14,7 @@ export async function handler(): Promise<any> {
     const className = process.env['ClassName'];
     let stream = null;
     switch (className) {
-        case "ReadSubscription":
+        case "Subscription":
             console.log("Reading subscription from subscriptions");
             stream = new DynamoStream(dynamoMapper.scan(SubscriptionEmpty));
             break;

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -1,6 +1,6 @@
 import {HTTPResponses} from '../models/apiGatewayHttp';
 import {UserSubscription} from "../models/userSubscription";
-import {ReadSubscription} from "../models/subscription";
+import {SubscriptionEmpty} from "../models/subscription";
 import {dynamoMapper, sqs} from "../utils/aws";
 import {getUserId, getAuthToken} from "../utils/guIdentityApi";
 import {SubscriptionReference} from "../models/subscriptionReference";
@@ -21,7 +21,7 @@ async function enqueueUnstoredPurchaseToken(subChecks: SubscriptionCheckData[]):
         return 0;
     }
 
-    const dynamoResult = dynamoMapper.batchGet(subChecks.map(sub => new ReadSubscription().setSubscriptionId(sub.subscriptionId)));
+    const dynamoResult = dynamoMapper.batchGet(subChecks.map(sub => new SubscriptionEmpty().setSubscriptionId(sub.subscriptionId)));
 
     type IndexedSubscriptionCheckData = {[id: string]: SubscriptionCheckData};
     const indexedReferences: IndexedSubscriptionCheckData = subChecks.reduce((agg, value) => {

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -83,13 +83,13 @@ export class Subscription {
     }
 }
 
-export class ReadSubscription extends Subscription {
+export class SubscriptionEmpty extends Subscription {
 
     constructor() {
         super("", "", "", undefined, false, "", undefined, undefined, undefined)
     }
 
-    setSubscriptionId(subscriptionId: string): ReadSubscription {
+    setSubscriptionId(subscriptionId: string): SubscriptionEmpty {
         this.subscriptionId = subscriptionId;
         return this;
     }

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -83,6 +83,13 @@ export class Subscription {
     }
 }
 
+// Note:
+//     SubscriptionEmpty is a convenience class to help with the instanciation of an empty Subscription object.
+//     It's often used to create a argument of dynamoMapper.get (we instanciate it and then
+//     set the subscriptionId, before passing the resulting object to dynamoMapper.get).
+//     It is not meant to stand where a Subscription is the right type, notably as the return type of dynamoMapper.get.
+//     Function dynamoMapper.get will return a Subscription object, not a SubscriptionEmpty object.
+
 export class SubscriptionEmpty extends Subscription {
 
     constructor() {

--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -77,7 +77,7 @@ export class SubscriptionEvent {
     }
 }
 
-export class ReadSubscriptionEvent extends SubscriptionEvent {
+export class SubscriptionEventEmpty extends SubscriptionEvent {
     constructor() {
         super("", "", "", "", "", "", "", undefined,{}, {}, 0, "", "", "", 0, 0);
     }

--- a/typescript/src/soft-opt-ins/acquisitions.ts
+++ b/typescript/src/soft-opt-ins/acquisitions.ts
@@ -1,7 +1,7 @@
 import {DynamoDBRecord, DynamoDBStreamEvent} from "aws-lambda";
 import {Stage} from "../utils/appIdentity";
 import { processAcquisition } from "./processSubscription";
-import {ReadSubscription} from "../models/subscription";
+import { SubscriptionEmpty, Subscription } from "../models/subscription";
 import {dynamoMapper, sendToSqs} from "../utils/aws";
 
 export async function handler(event: DynamoDBStreamEvent): Promise<any> {
@@ -28,10 +28,10 @@ export async function handler(event: DynamoDBStreamEvent): Promise<any> {
 
             console.log(`identityId: ${identityId}, subscriptionId: ${subscriptionId}`);
 
-            let itemToQuery = new ReadSubscription();
+            let itemToQuery = new SubscriptionEmpty();
             itemToQuery.setSubscriptionId(subscriptionId);
 
-            let subscriptionRecord: ReadSubscription;
+            let subscriptionRecord: Subscription;
 
             try {
                 subscriptionRecord = await dynamoMapper.get(itemToQuery);

--- a/typescript/src/soft-opt-ins/dlq-processor.ts
+++ b/typescript/src/soft-opt-ins/dlq-processor.ts
@@ -1,6 +1,6 @@
 import {dynamoMapper, sendToSqs, sqs} from "../utils/aws";
 import { processAcquisition } from "./processSubscription";
-import {ReadSubscription} from "../models/subscription";
+import { SubscriptionEmpty, Subscription } from "../models/subscription";
 
 interface MessageBody {
     identityId: string;
@@ -69,13 +69,13 @@ export async function handler(event: any): Promise<void> {
 
             console.log(`identityId: ${identityId}, subscriptionId: ${subscriptionId}, timestamp: ${timestamp}`);
 
-            let itemToQuery = new ReadSubscription();
-            itemToQuery.setSubscriptionId(subscriptionId);
+            let subEmpty = new SubscriptionEmpty();
+            subEmpty.setSubscriptionId(subscriptionId);
 
-            let subscriptionRecord: ReadSubscription;
+            let subscriptionRecord: Subscription;
 
             try {
-                subscriptionRecord = await dynamoMapper.get(itemToQuery);
+                subscriptionRecord = await dynamoMapper.get(subEmpty);
             } catch (error) {
                 console.log(`Subscription ${subscriptionId} record not found in the subscriptions table. Error: `, error);
                 continue;

--- a/typescript/src/soft-opt-ins/processSubscription.ts
+++ b/typescript/src/soft-opt-ins/processSubscription.ts
@@ -1,5 +1,5 @@
 import {sendToSqsComms, sendToSqsSoftOptIns, SoftOptInEvent} from "../utils/aws";
-import {ReadSubscription} from "../models/subscription";
+import { Subscription } from "../models/subscription";
 import {Region, Stage} from "../utils/appIdentity";
 import fetch from 'node-fetch';
 import { Response } from 'node-fetch';
@@ -98,7 +98,7 @@ const buildBrazeEmailMessage = (emailAddress: string, identityId: string, platfo
 };
 
 // returns true if message successfully processed
-export async function processAcquisition(subscriptionRecord: ReadSubscription, identityId: string): Promise<boolean> {
+export async function processAcquisition(subscriptionRecord: Subscription, identityId: string): Promise<boolean> {
     const subscriptionId = subscriptionRecord.subscriptionId;
 
     // Check if the subscription is active

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -10,7 +10,7 @@ import {fetchGoogleSubscriptionV2} from "../services/google-play-v2";
 import {Subscription} from '../models/subscription';
 import {fromGooglePackageName} from "../services/appToPlatform";
 import {dateToSecondTimestamp, optionalMsToDate, thirtyMonths} from "../utils/dates";
-import {ReadSubscription} from "../models/subscription";
+import {SubscriptionEmpty} from "../models/subscription";
 import {dynamoMapper} from "../utils/aws";
 import {createHash} from 'crypto'
 
@@ -91,7 +91,7 @@ async function getSubscriptionStatusFromGoogle(subscriptionId: string, purchaseT
 async function getSubscriptionStatusFromDynamo(purchaseToken: string, purchaseTokenHash: string): Promise<SubscriptionStatus | null> {
     try {
         console.log(`Fetching subscription from Dynamo for purchaseToken hash: ${purchaseTokenHash}`)
-        let itemToQuery = new ReadSubscription()
+        let itemToQuery = new SubscriptionEmpty()
         itemToQuery.setSubscriptionId(purchaseToken)
         const subscription = await dynamoMapper.get(itemToQuery)
         const subscriptionExpiryDate = new Date(subscription.endTimestamp)

--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -1,6 +1,6 @@
 import 'source-map-support/register'
 import {HTTPResponses} from "../models/apiGatewayHttp";
-import {Subscription, ReadSubscription} from "../models/subscription";
+import {Subscription, SubscriptionEmpty} from "../models/subscription";
 import {ReadUserSubscription} from "../models/userSubscription";
 import {dynamoMapper} from "../utils/aws"
 import {getUserId, getAuthToken, UserIdResolution} from "../utils/guIdentityApi";
@@ -37,8 +37,8 @@ async function getUserSubscriptionIds(userId: string): Promise<string[]> {
 }
 
 async function getSubscriptions(subscriptionIds: string[]) : Promise<SubscriptionStatusResponse>  {
-    const subs: ReadSubscription[] = [];
-    const toGet = subscriptionIds.map(subscriptionId => new ReadSubscription().setSubscriptionId(subscriptionId));
+    const subs: SubscriptionEmpty[] = [];
+    const toGet = subscriptionIds.map(subscriptionId => new SubscriptionEmpty().setSubscriptionId(subscriptionId));
 
     for await (const sub of dynamoMapper.batchGet(toGet)  ) {
         subs.push(sub)

--- a/typescript/tests/soft-opt-ins/acquisition.test.ts
+++ b/typescript/tests/soft-opt-ins/acquisition.test.ts
@@ -1,7 +1,7 @@
 import {isPostAcquisition} from "../../src/soft-opt-ins/processSubscription";
 import {handler} from "../../src/soft-opt-ins/acquisitions";
 import {DynamoDBStreamEvent} from "aws-lambda";
-import {ReadSubscription} from "../../src/models/subscription";
+import { Subscription, SubscriptionEmpty } from "../../src/models/subscription";
 import { Platform } from "../../src/models/platform";
 
 jest.mock('@aws/dynamodb-data-mapper', () => {
@@ -141,7 +141,7 @@ describe('handler', () => {
         const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
         const mockSQS = new (require('aws-sdk/clients/sqs'))();
 
-        const sub = new ReadSubscription();
+        const sub = new SubscriptionEmpty();
         sub.subscriptionId = '12345';
         sub.startTimestamp = "2023-03-14 07:24:38 UTC";
         sub.endTimestamp = "2023-03-14 07:24:38 UTC";
@@ -152,9 +152,9 @@ describe('handler', () => {
 
         expect(mockDataMapper.get).toHaveBeenCalledTimes(1);
 
-        let expectedQuery = new ReadSubscription();
-        expectedQuery.setSubscriptionId("12345")
-        expect(mockDataMapper.get).toHaveBeenCalledWith(expectedQuery);
+        let subEmpty = new SubscriptionEmpty();
+        subEmpty.setSubscriptionId("12345")
+        expect(mockDataMapper.get).toHaveBeenCalledWith(subEmpty);
 
         expect(mockSQS.sendMessage).toHaveBeenCalledTimes(1);
 
@@ -204,7 +204,7 @@ describe('handler', () => {
         // get the mock instances
         const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
         const mockSQS = new (require('aws-sdk/clients/sqs'))();
-        const sub = new ReadSubscription();
+        const sub = new SubscriptionEmpty();
         sub.subscriptionId = subscriptionId;
         sub.startTimestamp = "2023-03-14 07:24:38 UTC";
         sub.endTimestamp = "2023-03-14 07:24:38 UTC";
@@ -214,7 +214,7 @@ describe('handler', () => {
         await handler(event);
 
         expect(mockDataMapper.get).toHaveBeenCalledTimes(1);
-        let expectedQuery = new ReadSubscription();
+        let expectedQuery = new SubscriptionEmpty();
         expectedQuery.setSubscriptionId(subscriptionId)
         expect(mockDataMapper.get).toHaveBeenCalledWith(expectedQuery);
 
@@ -277,7 +277,7 @@ describe('handler', () => {
         // get the mock instances
         const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
         const mockSQS = new (require('aws-sdk/clients/sqs'))();
-        const sub = new ReadSubscription();
+        const sub = new SubscriptionEmpty();
         sub.subscriptionId = subscriptionId;
         sub.startTimestamp = "2023-03-14 07:24:38 UTC";
         sub.endTimestamp = "2023-03-14 07:24:38 UTC";
@@ -287,7 +287,7 @@ describe('handler', () => {
         await handler(event);
 
         expect(mockDataMapper.get).toHaveBeenCalledTimes(1);
-        let expectedQuery = new ReadSubscription();
+        let expectedQuery = new SubscriptionEmpty();
         expectedQuery.setSubscriptionId(subscriptionId)
         expect(mockDataMapper.get).toHaveBeenCalledWith(expectedQuery);
 
@@ -350,7 +350,7 @@ describe('handler', () => {
         const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
         const mockSQS = new (require('aws-sdk/clients/sqs'))();
 
-        const sub = new ReadSubscription();
+        const sub = new SubscriptionEmpty();
         sub.subscriptionId = '12345';
         sub.startTimestamp = "2023-03-01 07:24:38 UTC";
         sub.endTimestamp = "2025-03-01 07:24:38 UTC";
@@ -361,9 +361,9 @@ describe('handler', () => {
 
         expect(mockDataMapper.get).toHaveBeenCalledTimes(1);
 
-        let expectedQuery = new ReadSubscription();
-        expectedQuery.setSubscriptionId("12345")
-        expect(mockDataMapper.get).toHaveBeenCalledWith(expectedQuery);
+        let subEmpty = new SubscriptionEmpty();
+        subEmpty.setSubscriptionId("12345")
+        expect(mockDataMapper.get).toHaveBeenCalledWith(subEmpty);
 
         expect(mockSQS.sendMessage).toHaveBeenCalledTimes(2);
 

--- a/typescript/tests/soft-opt-ins/dlq-processor.test.ts
+++ b/typescript/tests/soft-opt-ins/dlq-processor.test.ts
@@ -1,5 +1,5 @@
 import {messageIsOneDayOld} from "../../src/soft-opt-ins/dlq-processor";
-import {ReadSubscription} from "../../src/models/subscription";
+import {SubscriptionEmpty} from "../../src/models/subscription";
 import {handler} from "../../src/soft-opt-ins/dlq-processor";
 import SQS from 'aws-sdk/clients/sqs';
 
@@ -153,7 +153,7 @@ describe('handler', () => {
         const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
         const mockSQS = new SQS();
 
-        const sub = new ReadSubscription();
+        const sub = new SubscriptionEmpty();
         sub.subscriptionId = '12345';
         sub.startTimestamp = "2023-03-01 07:24:38 UTC";
         sub.endTimestamp = "2025-03-01 07:24:38 UTC";
@@ -190,7 +190,7 @@ describe('handler', () => {
 
         expect(mockDataMapper.get).toHaveBeenCalledTimes(1);
 
-        let expectedQuery = new ReadSubscription();
+        let expectedQuery = new SubscriptionEmpty();
         expectedQuery.setSubscriptionId("12345")
         expect(mockDataMapper.get).toHaveBeenCalledWith(expectedQuery);
 
@@ -206,7 +206,7 @@ describe('handler', () => {
         const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
         const mockSQS = new SQS();
 
-        const sub = new ReadSubscription();
+        const sub = new SubscriptionEmpty();
         sub.subscriptionId = '12345';
         sub.startTimestamp = "2023-03-01 07:24:38 UTC";
         sub.endTimestamp = "2025-03-01 07:24:38 UTC";
@@ -253,7 +253,7 @@ describe('handler', () => {
         const mockDataMapper = new (require('@aws/dynamodb-data-mapper').DataMapper)();
         const mockSQS = new SQS();
 
-        const sub = new ReadSubscription();
+        const sub = new SubscriptionEmpty();
         sub.subscriptionId = '12345';
         sub.startTimestamp = "2023-03-01 07:24:38 UTC";
         sub.endTimestamp = "2025-03-01 07:24:38 UTC";
@@ -290,7 +290,7 @@ describe('handler', () => {
 
         expect(mockDataMapper.get).toHaveBeenCalledTimes(1);
 
-        let expectedQuery = new ReadSubscription();
+        let expectedQuery = new SubscriptionEmpty();
         expectedQuery.setSubscriptionId("12345")
         expect(mockDataMapper.get).toHaveBeenCalledWith(expectedQuery);
 

--- a/typescript/tests/user/user.test.ts
+++ b/typescript/tests/user/user.test.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { handler } from "../../src/user/user";
-import { ReadSubscription } from "../../src/models/subscription";
+import { SubscriptionEmpty } from "../../src/models/subscription";
 import { plusDays } from "../../src/utils/dates";
 
 const TEST_SECRET = 'test_secret';
@@ -54,7 +54,7 @@ describe("The user subscriptions lambda", () => {
                 subscriptionId,
             };
         });
-        const sub = new ReadSubscription();
+        const sub = new SubscriptionEmpty();
         sub.subscriptionId = subscriptionId;
         sub.platform = "ios-feast";
         sub.productId = "product-id";


### PR DESCRIPTION
In this PR we repair an unfortunate misnaming that was introduced 5 years ago, and that created some misunderstanding in the entire code base. 

Let's look at the code at it currently is

```
let itemToQuery = new ReadSubscription();
itemToQuery.setSubscriptionId(subscriptionId);

let subscriptionRecord: ReadSubscription;
subscriptionRecord = await dynamoMapper.get(itemToQuery);
```

In the above sample `itemToQuery` is a `ReadSubscription`. It is not obvious what a `ReadSubscription` is. Is it the type of a subscription returned from the Dynamo Table ?, or the name of a service ? What we know for sure is that it's passed to `dynamoMapper.get`, so it's not a subscription that was just retrieved from the database and not the name of a service.

The story behind `ReadSubscription` is that it's simply a convenience extension of `Subscription` which was introduced to facilitate the instantiation of a new empty Subscription. For this all the fields are set to "" or `undefined` and one method is added to set the important attribute, the `subscriptionId`.

Another problem with the above code is then typing the return value of `dynamoMapper.get` as a `ReadSubscription`, instead of a `Subscription` 

In fact none of the two above imperfections are really a problem, because admittedly a `ReadSubscription` can be used everywhere a `Subscription` can. The problem is that `ReadSubscription` found its way in an unfortunate place, the signature of function with Subscription parameters, for instance 

```
export async function processAcquisition(subscriptionRecord: ReadSubscription, identityId: string): Promise<boolean>
```

To repair this injustice, we rename `ReadSubscription` into `SubscriptionEmpty`, which does a better job at describing that it's a Subscription with zero default values. We also update the signature of `processAcquisition` to be what it should have been 

```
export async function processAcquisition(subscriptionRecord: Subscription, identityId: string): Promise<boolean>
```

And our code sample from the beginning become the much more logical 

```
let itemToQuery = new SubscriptionEmpty();
itemToQuery.setSubscriptionId(subscriptionId);

let subscriptionRecord: Subscription;
subscriptionRecord = await dynamoMapper.get(itemToQuery);
```

Which clearly indicates that we instantiate a `SubscriptionEmpty` of which we are immediately going to update the subscription it, and then that instance of `SubscriptionEmpty` will be used as into of the get function to retrieve a `Subscription`. 