### PR TITLE
rename ReadUserSubscription into UserSubscriptionEmpty

### DIFF
--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -146,7 +146,7 @@ Resources:
           Stack: !Sub ${Stack}
           Stage: !Sub ${Stage}
           ExportBucket: !Ref UserSubscriptionExportBucket
-          ClassName: ReadUserSubscription
+          ClassName: UserSubscription
       Description: Export the user subscription table to the datalake
       MemorySize: 512
       Timeout: 900

--- a/typescript/src/export/exportSubscriptions.ts
+++ b/typescript/src/export/exportSubscriptions.ts
@@ -18,7 +18,7 @@ export async function handler(): Promise<any> {
             console.log("Reading subscription from subscriptions");
             stream = new DynamoStream(dynamoMapper.scan(ReadSubscription));
             break;
-        case "ReadUserSubscription":
+        case "UserSubscription":
             console.log("Reading user subscription from user subscription");
             stream = new DynamoStream(dynamoMapper.scan(UserSubscriptionEmpty));
             break;

--- a/typescript/src/export/exportSubscriptions.ts
+++ b/typescript/src/export/exportSubscriptions.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register'
 import {dynamoMapper, s3} from "../utils/aws";
 import {ReadSubscription} from "../models/subscription";
-import {ReadUserSubscription} from "../models/userSubscription";
+import {UserSubscriptionEmpty} from "../models/userSubscription";
 import zlib from 'zlib'
 import {Stage} from "../utils/appIdentity";
 import {DynamoStream} from "./dynamoStream";
@@ -20,7 +20,7 @@ export async function handler(): Promise<any> {
             break;
         case "ReadUserSubscription":
             console.log("Reading user subscription from user subscription");
-            stream = new DynamoStream(dynamoMapper.scan(ReadUserSubscription));
+            stream = new DynamoStream(dynamoMapper.scan(UserSubscriptionEmpty));
             break;
         default:
             throw new Error(`Invalid ClassName value ${className}`);

--- a/typescript/src/link/deleteLink.ts
+++ b/typescript/src/link/deleteLink.ts
@@ -12,6 +12,14 @@ async function handleSoftOptInsError(message: string) {
 }
 
 async function getUserLinks(subscriptionId: string) {
+
+    // ( comment group #488db8c1 )
+    // TODO:
+    // In PR: https://github.com/guardian/mobile-purchases/pull/1698
+    // we performed a renaming of ReadSubscription to UserSubscriptionEmpty
+    // With that said it should now be possible to use UserSubscription instead of
+    // UserSubscriptionEmpty as first argument of the dynamoMapper.query(
+
     const userLinks = await dynamoMapper.query(UserSubscriptionEmpty, {subscriptionId}, {indexName: "subscriptionId-userId"});
     return userLinks;
 }

--- a/typescript/src/models/userSubscription.ts
+++ b/typescript/src/models/userSubscription.ts
@@ -25,11 +25,13 @@ export class UserSubscription {
 
 }
 
-export class UserSubscriptionEmpty extends UserSubscription {
+// Note: 
+//   UserSubscriptionEmpty is a convenience class for when you need to create an empty UserSubscription object.
+//   It's not meant to stand in places where we a UserSubscription would suffice.
 
+export class UserSubscriptionEmpty extends UserSubscription {
     constructor() {
         super("", "", "");
     }
-
 }
 

--- a/typescript/src/models/userSubscription.ts
+++ b/typescript/src/models/userSubscription.ts
@@ -25,7 +25,7 @@ export class UserSubscription {
 
 }
 
-export class ReadUserSubscription extends UserSubscription {
+export class UserSubscriptionEmpty extends UserSubscription {
 
     constructor() {
         super("", "", "");

--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -28,6 +28,13 @@ interface SubscriptionStatusResponse {
 async function getUserSubscriptionIds(userId: string): Promise<string[]> {
     const subs: string[] = [];
 
+    // ( comment group #488db8c1 )
+    // TODO:
+    // In PR: https://github.com/guardian/mobile-purchases/pull/1698
+    // we performed a renaming of ReadSubscription to UserSubscriptionEmpty
+    // With that said it should now be possible to use UserSubscription instead of
+    // UserSubscriptionEmpty as first argument of the dynamoMapper.query(
+
     const subscriptionResults = dynamoMapper.query(UserSubscriptionEmpty, {userId: userId});
 
     for await (const sub of subscriptionResults) {

--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register'
 import {HTTPResponses} from "../models/apiGatewayHttp";
 import {Subscription, ReadSubscription} from "../models/subscription";
-import {ReadUserSubscription} from "../models/userSubscription";
+import {UserSubscriptionEmpty} from "../models/userSubscription";
 import {dynamoMapper} from "../utils/aws"
 import {getUserId, getAuthToken, UserIdResolution} from "../utils/guIdentityApi";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
@@ -28,7 +28,7 @@ interface SubscriptionStatusResponse {
 async function getUserSubscriptionIds(userId: string): Promise<string[]> {
     const subs: string[] = [];
 
-    const subscriptionResults = dynamoMapper.query(ReadUserSubscription, {userId: userId});
+    const subscriptionResults = dynamoMapper.query(UserSubscriptionEmpty, {userId: userId});
 
     for await (const sub of subscriptionResults) {
         subs.push(sub.subscriptionId)

--- a/typescript/tests/link/deleteLink.test.ts
+++ b/typescript/tests/link/deleteLink.test.ts
@@ -1,5 +1,5 @@
 import { DynamoDBRecord, DynamoDBStreamEvent } from "aws-lambda";
-import { ReadUserSubscription } from "../../src/models/userSubscription";
+import { UserSubscriptionEmpty } from "../../src/models/userSubscription";
 import { handler } from "../../src/link/deleteLink";
 
 jest.mock('@aws/dynamodb-data-mapper', () => {
@@ -110,7 +110,7 @@ describe("handler", () => {
         const result = await handler(event);
 
         expect(mockDataMapper.query).toHaveBeenCalledTimes(1);
-        expect(mockDataMapper.query).toHaveBeenCalledWith(ReadUserSubscription, { subscriptionId: "1" }, { indexName: "subscriptionId-userId" });
+        expect(mockDataMapper.query).toHaveBeenCalledWith(UserSubscriptionEmpty, { subscriptionId: "1" }, { indexName: "subscriptionId-userId" });
 
         expect(mockDataMapper.delete).toHaveBeenCalledTimes(1);
         expect(mockDataMapper.delete).toHaveBeenCalledWith({"subscriptionId": "1", "userId": "123"});


### PR DESCRIPTION
This PR is the sister change of the refactoring we applied here: https://github.com/guardian/mobile-purchases/pull/1697

In this case the renaming does an equally good job at highlighting where there was a type confusion, and in particular the  signature of functions that should have taken a `UserSubscription` instead of the old `ReadUserSubscription` are updated. We also update instances of `ReadUserSubscription[]` into `UserSubscription[]`

