### PR TITLE
Correct toPlatform function names

### DIFF
--- a/typescript/src/feast/update-subs/google.ts
+++ b/typescript/src/feast/update-subs/google.ts
@@ -5,7 +5,7 @@ import { GracefulProcessingError } from "../../models/GracefulProcessingError";
 import { putSubscription } from "../../update-subs/updatesub";
 import { GoogleSubscription, fetchGoogleSubscriptionV2 } from "../../services/google-play-v2";
 import { GoogleSubscriptionReference } from "../../models/subscriptionReference";
-import { fromGooglePackageName } from "../../services/appToPlatform";
+import { googlePackageNameToPlatform } from "../../services/appToPlatform";
 import { dateToSecondTimestamp, optionalMsToDate, thirtyMonths } from "../../utils/dates";
 import { getIdentityIdFromBraze } from "../../services/braze";
 import { storeUserSubscriptionInDynamo, queueHistoricalSubscription } from "./common";
@@ -25,7 +25,7 @@ const googleSubscriptionToSubscription = (
         googleSubscription.userCancellationTime?.toISOString(),
         googleSubscription.autoRenewing,
         googleSubscription.productId,
-        fromGooglePackageName(packageName),
+        googlePackageNameToPlatform(packageName),
         googleSubscription.freeTrial,
         googleSubscription.billingPeriodDuration,
         googleSubscription,

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -4,7 +4,7 @@ import {SubscriptionEvent} from "../models/subscriptionEvent";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
-import {fromAppleBundle} from "../services/appToPlatform";
+import {appleBundleToPlatform} from "../services/appToPlatform";
 import { Stage } from '../utils/appIdentity';
 import {StatusUpdateNotification, parsePayload} from "./apple-common";
 
@@ -13,7 +13,7 @@ export function toDynamoEvent(notification: StatusUpdateNotification): Subscript
     const eventType = notification.notification_type;
     const receiptInfo = notification.unified_receipt.latest_receipt_info;
     console.log(`notification is from ${notification.environment}, latest_receipt_info is undefined: ${notification.unified_receipt.latest_receipt_info === undefined}`);
-    const platform = fromAppleBundle(notification.bid);
+    const platform = appleBundleToPlatform(notification.bid);
     if (!platform) {
         console.warn(`Unknown bundle id ${notification.bid}`)
     }

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -4,7 +4,7 @@ import {dateToSecondTimestamp, optionalMsToDate, thirtyMonths} from "../utils/da
 import {GoogleSubscriptionReference} from "../models/subscriptionReference";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {Option} from "../utils/option";
-import {fromGooglePackageName} from "../services/appToPlatform";
+import {googlePackageNameToPlatform} from "../services/appToPlatform";
 import {fetchGoogleSubscription, GOOGLE_PAYMENT_STATE} from "../services/google-play";
 import { z } from "zod";
 import { Ignorable } from './ignorable';
@@ -124,7 +124,7 @@ export function toDynamoEvent(notification: SubscriptionNotification, metaData?:
     const date = eventTimestamp.substring(0, 10);
     const eventType = notification.subscriptionNotification.notificationType;
     const eventTypeString = GOOGLE_SUBS_EVENT_TYPE[eventType] ?? eventType.toString();
-    const platform = fromGooglePackageName(notification.packageName)?.toString();
+    const platform = googlePackageNameToPlatform(notification.packageName)?.toString();
     if (!platform) {
         console.warn(`Unknown package name ${notification.packageName}`)
     }

--- a/typescript/src/services/appToPlatform.ts
+++ b/typescript/src/services/appToPlatform.ts
@@ -7,7 +7,7 @@ const bundleToPlatform: {[bundle: string]: Platform} = {
     "uk.co.guardian.Feast": Platform.IosFeast
 };
 
-export function fromAppleBundle(bundle?: string): Platform | undefined {
+export function appleBundleToPlatform(bundle?: string): Platform | undefined {
     return (bundle) ? bundleToPlatform[bundle] : undefined;
 }
 
@@ -19,6 +19,6 @@ const packageToPlatform: {[packageName: string]: Platform} = {
     "uk.co.guardian.feast": Platform.AndroidFeast
 };
 
-export function fromGooglePackageName(packageName: string): Platform | undefined {
+export function googlePackageNameToPlatform(packageName: string): Platform | undefined {
     return packageToPlatform[packageName];
 }

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -8,7 +8,7 @@ import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import {fetchGoogleSubscription} from "../services/google-play";
 import {fetchGoogleSubscriptionV2} from "../services/google-play-v2";
 import {Subscription} from '../models/subscription';
-import {fromGooglePackageName} from "../services/appToPlatform";
+import {googlePackageNameToPlatform} from "../services/appToPlatform";
 import {dateToSecondTimestamp, optionalMsToDate, thirtyMonths} from "../utils/dates";
 import {SubscriptionEmpty} from "../models/subscription";
 import {dynamoMapper} from "../utils/aws";
@@ -122,7 +122,7 @@ async function updateParallelTestTable(purchaseToken: string, packageName: strin
                 googleSubscription.userCancellationTime?.toISOString(),
                 googleSubscription.autoRenewing,
                 googleSubscription.productId,
-                fromGooglePackageName(packageName),
+                googlePackageNameToPlatform(packageName),
                 googleSubscription.freeTrial,
                 googleSubscription.billingPeriodDuration,
                 googleSubscription,

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -5,7 +5,7 @@ import {Subscription} from "../models/subscription";
 import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
 import {AppleSubscriptionReference} from "../models/subscriptionReference";
 import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";
-import {fromAppleBundle} from "../services/appToPlatform";
+import {appleBundleToPlatform} from "../services/appToPlatform";
 import {PRODUCT_BILLING_PERIOD} from "../services/productBillingPeriod";
 
 export function toAppleSubscription(response: AppleValidationResponse): Subscription {
@@ -33,7 +33,7 @@ export function toAppleSubscription(response: AppleValidationResponse): Subscrip
         cancellationDate,
         autoRenewStatus,
         latestReceiptInfo.productId,
-        fromAppleBundle(response.latestReceiptInfo.bundleId)?.toString(),
+        appleBundleToPlatform(response.latestReceiptInfo.bundleId)?.toString(),
         latestReceiptInfo.trialPeriod || latestReceiptInfo.inIntroOfferPeriod,
         billingPeriod,
         null,

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -5,7 +5,7 @@ import {Subscription} from "../models/subscription";
 import {ProcessingError} from "../models/processingError";
 import {dateToSecondTimestamp, optionalMsToDate, thirtyMonths} from "../utils/dates";
 import {GoogleSubscriptionReference} from "../models/subscriptionReference";
-import {fromGooglePackageName} from "../services/appToPlatform";
+import {googlePackageNameToPlatform} from "../services/appToPlatform";
 import {fetchGoogleSubscription, GOOGLE_PAYMENT_STATE, GoogleResponseBody} from "../services/google-play";
 import {PRODUCT_BILLING_PERIOD} from "../services/productBillingPeriod";
 
@@ -38,7 +38,7 @@ export const googleResponseBodyToSubscription = (
         optionalMsToDate(googleResponse.userCancellationTimeMillis)?.toISOString(),
         googleResponse.autoRenewing,
         subscriptionId,
-        fromGooglePackageName(packageName)?.toString(),
+        googlePackageNameToPlatform(packageName)?.toString(),
         freeTrial,
         billingPeriod,
         googleResponse,

--- a/typescript/src/utils/mapAndroidProductId.ts
+++ b/typescript/src/utils/mapAndroidProductId.ts
@@ -1,12 +1,12 @@
 import { Platform } from "../models/platform";
-import { fromGooglePackageName } from "../services/appToPlatform";
+import { googlePackageNameToPlatform } from "../services/appToPlatform";
 
 // Map the product_id for test Feast purchases so that they can be easily
 // identified downstream. For other (non-Feast) Android test purchases the
 // product_id is already distinct and there are mechanisms for filtering out in
 // the lake.
 export const mapAndroidProductId = (productId: string, packageName: string, isTestPurchase: boolean): string => {
-    if (isTestPurchase && fromGooglePackageName(packageName) === Platform.AndroidFeast) {
+    if (isTestPurchase && googlePackageNameToPlatform(packageName) === Platform.AndroidFeast) {
         return "dev_testing_feast";
     }
 


### PR DESCRIPTION
This change gives better names to the two functions in appToPlatform.ts. 

They were named using Scala conventions where typically the functions names would be used together with the namespace they belong to. In Scala these two functions would have been defined in a `Platform` object and use as `Platform.fromGooglePackageName`, which is descriptive, but the name `fromGooglePackageName` alone in the middle of TypeScript code is confusing, and even knowing that it was imported from `appToPlatform` doesn't give much intuitive sense of its signature or semantics.

(This is part of the "making the world a better place, one PR at a time" series). 