### PR TITLE
Linting and Refactoring

### DIFF
--- a/typescript/src/feast/pubsub/google.ts
+++ b/typescript/src/feast/pubsub/google.ts
@@ -1,6 +1,6 @@
 import type {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import { HTTPResponses } from "../../models/apiGatewayHttp";
-import { MetaData,
+import { GoogleSubscriptionMetaData,
     SubscriptionNotification,
     fetchMetadata as defaultFetchMetadata,
     parsePayload,
@@ -21,7 +21,7 @@ const defaultStoreEventInDynamo = (event: SubscriptionEvent): Promise<void> => {
 export function buildHandler(
     sendMessageToSqs: (queueUrl: string, message: GoogleSubscriptionReference) => Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> = sendToSqs,
     storeEventInDynamo: (event: SubscriptionEvent) => Promise<void> = defaultStoreEventInDynamo,
-    fetchMetadata: (notification: SubscriptionNotification) => Promise<MetaData | undefined> = defaultFetchMetadata
+    fetchMetadata: (notification: SubscriptionNotification) => Promise<GoogleSubscriptionMetaData | undefined> = defaultFetchMetadata
 ): (request: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult> {
     return async (request: APIGatewayProxyEvent) => {
         const secret = process.env.Secret;

--- a/typescript/src/link/google.ts
+++ b/typescript/src/link/google.ts
@@ -1,8 +1,8 @@
 import 'source-map-support/register'
-import {Platform} from "../models/platform";
-import {parseAndStoreLink, SubscriptionCheckData} from "./link";
-import {UserSubscription} from "../models/userSubscription";
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import { Platform } from "../models/platform";
+import { parseAndStoreLink, SubscriptionCheckData } from "./link";
+import { UserSubscription } from "../models/userSubscription";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 
 type GoogleSubscription = {
     purchaseToken: string

--- a/typescript/src/link/link.ts
+++ b/typescript/src/link/link.ts
@@ -85,14 +85,6 @@ export async function parseAndStoreLink<A, B>(
                 }
                 case "success": {
                     const userId = resolution.userId as string;
-
-                    // --------------------------------
-                    // Date: 21 June 2023
-                    // Author: Pascal
-                    // I am temporarily adding an extra amount of logging while doing an investigation
-                    console.log(`[db1c1255] userId: ${userId}`);
-                    // --------------------------------
-
                     const insertCount = await persistUserSubscriptionLinks(toUserSubscription(userId, payload));
                     const sqsCount = await enqueueUnstoredPurchaseToken(toSqsPayload(payload));
                     console.log(`put ${insertCount} links in the DB, and sent ${sqsCount} subscription refs to SQS`);

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -2,7 +2,6 @@ import {hashKey, attribute} from '@aws/dynamodb-data-mapper-annotations';
 import {DynamoDbTable} from "@aws/dynamodb-data-mapper";
 import {App, Stage} from "../utils/appIdentity";
 
-
 export class Subscription {
 
     @hashKey()

--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -1,6 +1,6 @@
-import {hashKey, rangeKey, attribute} from '@aws/dynamodb-data-mapper-annotations';
-import {DynamoDbTable} from "@aws/dynamodb-data-mapper";
-import {App, Stage} from "../utils/appIdentity";
+import { hashKey, rangeKey, attribute } from '@aws/dynamodb-data-mapper-annotations';
+import { DynamoDbTable } from "@aws/dynamodb-data-mapper";
+import { App, Stage } from "../utils/appIdentity";
 
 export class SubscriptionEvent {
     @hashKey()

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -1,12 +1,12 @@
 import 'source-map-support/register'
-import {parseStoreAndSend} from "./pubsub";
-import {SubscriptionEvent} from "../models/subscriptionEvent";
-import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
-import {AppleSubscriptionReference} from "../models/subscriptionReference";
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
-import {appleBundleToPlatform} from "../services/appToPlatform";
+import { parseStoreAndSend } from "./pubsub";
+import { SubscriptionEvent } from "../models/subscriptionEvent";
+import { dateToSecondTimestamp, thirtyMonths } from "../utils/dates";
+import { AppleSubscriptionReference } from "../models/subscriptionReference";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { appleBundleToPlatform } from "../services/appToPlatform";
 import { Stage } from '../utils/appIdentity';
-import {StatusUpdateNotification, parsePayload} from "./apple-common";
+import { StatusUpdateNotification, parsePayload } from "./apple-common";
 
 export function toDynamoEvent(notification: StatusUpdateNotification): SubscriptionEvent {
     const now = new Date();

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -1,11 +1,10 @@
 import 'source-map-support/register'
-import {SubscriptionEvent} from "../models/subscriptionEvent";
-import {dateToSecondTimestamp, optionalMsToDate, thirtyMonths} from "../utils/dates";
-import {GoogleSubscriptionReference} from "../models/subscriptionReference";
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
-import {Option} from "../utils/option";
-import {googlePackageNameToPlatform} from "../services/appToPlatform";
-import {fetchGoogleSubscription, GOOGLE_PAYMENT_STATE} from "../services/google-play";
+import { SubscriptionEvent } from "../models/subscriptionEvent";
+import { dateToSecondTimestamp, optionalMsToDate, thirtyMonths } from "../utils/dates";
+import { GoogleSubscriptionReference } from "../models/subscriptionReference";
+import { Option } from "../utils/option";
+import { googlePackageNameToPlatform } from "../services/appToPlatform";
+import { fetchGoogleSubscription, GOOGLE_PAYMENT_STATE } from "../services/google-play";
 import { z } from "zod";
 import { Ignorable } from './ignorable';
 

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -46,7 +46,7 @@ const DeveloperNotificationSchema = z.union([
 );
 export type DeveloperNotification = z.infer<typeof DeveloperNotificationSchema>;
 
-export interface MetaData {
+export interface GoogleSubscriptionMetaData {
     freeTrial: boolean
 }
 
@@ -88,7 +88,7 @@ export const GOOGLE_SUBS_EVENT_TYPE: {[_: number]: string} = {
     13: "SUBSCRIPTION_EXPIRED"
 };
 
-export async function fetchMetadata(notification: SubscriptionNotification): Promise<MetaData | undefined> {
+export async function fetchMetadata(notification: SubscriptionNotification): Promise<GoogleSubscriptionMetaData | undefined> {
     try {
         const subscription = await fetchGoogleSubscription(
             notification.subscriptionNotification.subscriptionId,
@@ -113,7 +113,7 @@ export async function fetchMetadata(notification: SubscriptionNotification): Pro
     }
 }
 
-export function toDynamoEvent(notification: SubscriptionNotification, metaData?: MetaData): SubscriptionEvent {
+export function toDynamoEvent(notification: SubscriptionNotification, metaData?: GoogleSubscriptionMetaData): SubscriptionEvent {
     const eventTime = optionalMsToDate(notification.eventTimeMillis);
     if (!eventTime) {
         // this is tested while parsing the payload in order to return HTTP 400 early.

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -1,6 +1,6 @@
 import 'source-map-support/register'
-import {parseStoreAndSend} from "./pubsub";
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import { parseStoreAndSend } from "./pubsub";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { fetchMetadata, parsePayload, toDynamoEvent, toSqsSubReference } from './google-common';
 
 export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {

--- a/typescript/src/scripts/android-price-rise/googleClient.ts
+++ b/typescript/src/scripts/android-price-rise/googleClient.ts
@@ -1,4 +1,4 @@
-import {androidpublisher, androidpublisher_v3, auth} from '@googleapis/androidpublisher';
+import { androidpublisher, androidpublisher_v3, auth } from '@googleapis/androidpublisher';
 import SSM = require("aws-sdk/clients/ssm");
 import { GoogleAuth } from 'google-auth-library';
 

--- a/typescript/src/services/google-play-v2.ts
+++ b/typescript/src/services/google-play-v2.ts
@@ -131,9 +131,9 @@ export async function fetchGoogleSubscriptionV2(
         }
     } catch (error: any) {
         if (error?.status == 400 || error?.status == 404 || error?.status == 410) {
-            console.error(`fetchGoogleSubscription error: invalid purchase token; subscription not found; or no such package name (status = ${error.status})`, error)
+            console.error(`fetchGoogleSubscriptionV2 error: invalid purchase token; subscription not found; or no such package name (status = ${error.status})`, error)
         } else {
-            console.error(`fetchGoogleSubscription error:`, error)
+            console.error(`fetchGoogleSubscriptionV2 error:`, error)
         }
         throw error
     }

--- a/typescript/src/services/google-play.ts
+++ b/typescript/src/services/google-play.ts
@@ -1,7 +1,7 @@
 import aws = require("../utils/aws");
 import S3 from 'aws-sdk/clients/s3'
-import {Stage} from "../utils/appIdentity";
-import {restClient} from "../utils/restClient";
+import { Stage } from "../utils/appIdentity";
+import { restClient } from "../utils/restClient";
 
 export const GOOGLE_PAYMENT_STATE = {
     PAYMENT_PENDING: 0,
@@ -15,14 +15,14 @@ export interface AccessToken {
     date: Date
 }
 
-export function getParams(stage: string): S3.Types.GetObjectRequest {
+function getParams(stage: string): S3.Types.GetObjectRequest {
   return {
       Bucket: "gu-mobile-access-tokens",
       Key: `${stage}/google-play-developer-api/access_token.json`
   }
 }
 
-export function getAccessToken(params: S3.Types.GetObjectRequest) : Promise<AccessToken> {
+function getAccessToken(params: S3.Types.GetObjectRequest) : Promise<AccessToken> {
     return aws.s3.getObject(params).promise()
         .then( s3OutPut => {
             if(s3OutPut.Body) {
@@ -37,7 +37,7 @@ export function getAccessToken(params: S3.Types.GetObjectRequest) : Promise<Acce
         })
 }
 
-export function buildGoogleUrl(subscriptionId: string, purchaseToken: string, packageName: string) {
+function buildGoogleUrl(subscriptionId: string, purchaseToken: string, packageName: string) {
     const baseUrl = `https://www.googleapis.com/androidpublisher/v3/applications/${packageName}/purchases/subscriptions`;
     return `${baseUrl}/${subscriptionId}/tokens/${purchaseToken}`;
 }
@@ -54,6 +54,5 @@ export async function fetchGoogleSubscription(subscriptionId: string, purchaseTo
     const url = buildGoogleUrl(subscriptionId, purchaseToken, packageName);
     const accessToken = await getAccessToken(getParams(Stage));
     const response = await restClient.get<GoogleResponseBody>(url, {additionalHeaders: {Authorization: `Bearer ${accessToken.token}`}});
-
     return response.result;
 }

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -4,15 +4,15 @@ import {
     HttpRequestHeaders,
     PathParameters
 } from '../models/apiGatewayHttp';
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
-import {fetchGoogleSubscription} from "../services/google-play";
-import {fetchGoogleSubscriptionV2} from "../services/google-play-v2";
-import {Subscription} from '../models/subscription';
-import {googlePackageNameToPlatform} from "../services/appToPlatform";
-import {dateToSecondTimestamp, optionalMsToDate, thirtyMonths} from "../utils/dates";
-import {SubscriptionEmpty} from "../models/subscription";
-import {dynamoMapper} from "../utils/aws";
-import {createHash} from 'crypto'
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { fetchGoogleSubscription } from "../services/google-play";
+import { fetchGoogleSubscriptionV2 } from "../services/google-play-v2";
+import { Subscription } from '../models/subscription';
+import { googlePackageNameToPlatform } from "../services/appToPlatform";
+import { dateToSecondTimestamp, optionalMsToDate, thirtyMonths } from "../utils/dates";
+import { SubscriptionEmpty } from "../models/subscription";
+import { dynamoMapper } from "../utils/aws";
+import { createHash } from 'crypto'
 
 type SubscriptionStatus = {
     "subscriptionHasLapsed": boolean

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -1,13 +1,13 @@
 import 'source-map-support/register'
-import {SQSEvent, SQSRecord} from 'aws-lambda';
-import {parseAndStoreSubscriptionUpdate} from './updatesub';
-import {Subscription} from "../models/subscription";
-import {ProcessingError} from "../models/processingError";
-import {dateToSecondTimestamp, optionalMsToDate, thirtyMonths} from "../utils/dates";
-import {GoogleSubscriptionReference} from "../models/subscriptionReference";
-import {googlePackageNameToPlatform} from "../services/appToPlatform";
-import {fetchGoogleSubscription, GOOGLE_PAYMENT_STATE, GoogleResponseBody} from "../services/google-play";
-import {PRODUCT_BILLING_PERIOD} from "../services/productBillingPeriod";
+import { SQSEvent, SQSRecord } from 'aws-lambda';
+import { parseAndStoreSubscriptionUpdate } from './updatesub';
+import { Subscription } from "../models/subscription";
+import { ProcessingError } from "../models/processingError";
+import { dateToSecondTimestamp, optionalMsToDate, thirtyMonths } from "../utils/dates";
+import { GoogleSubscriptionReference } from "../models/subscriptionReference";
+import { googlePackageNameToPlatform } from "../services/appToPlatform";
+import { fetchGoogleSubscription, GOOGLE_PAYMENT_STATE, GoogleResponseBody } from "../services/google-play";
+import { PRODUCT_BILLING_PERIOD } from "../services/productBillingPeriod";
 
 export const googleResponseBodyToSubscription = (
     purchaseToken: string,

--- a/typescript/src/update-subs/updatesub.ts
+++ b/typescript/src/update-subs/updatesub.ts
@@ -1,8 +1,8 @@
-import {SQSRecord} from 'aws-lambda'
-import {Subscription} from '../models/subscription';
-import {dynamoMapper, sendToSqs} from "../utils/aws";
-import {ProcessingError} from "../models/processingError";
-import {GracefulProcessingError} from "../models/GracefulProcessingError";
+import { SQSRecord } from 'aws-lambda'
+import { Subscription } from '../models/subscription';
+import { dynamoMapper, sendToSqs } from "../utils/aws";
+import { ProcessingError } from "../models/processingError";
+import { GracefulProcessingError } from "../models/GracefulProcessingError";
 
 export function putSubscription(subscription: Subscription): Promise<Subscription> {
     return dynamoMapper.put({item: subscription}).then(result => result.item)


### PR DESCRIPTION
In this change

1. We apply some code linting (this repo doesn't, yet, have a linter, future work, this is just to make the diff to https://github.com/guardian/mobile-purchases/pull/1707 smaller)
2.  Rename `MetaData` in google.ts into `GoogleSubscriptionMetaData` to make function signatures, less mysterious (notably in places, away from google.ts, where the type is imported).
3. Clean dead code.

 