### PR TITLE
The interesting story of the Google purchase tokens

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,10 @@
 
 mobile-purchases performs at least two primary functions.
 
-1. Processing subscription information coming from the mobile applications, both the iOS and Android application, using a set of lambdas that are described in the main [architecture document](./ARCHITECTURE.md).
-
+1. Processing subscription information coming from the mobile applications, both the iOS and Android application, using a set of lambdas that are described in the main [architecture document](ARCHITECTURE.md).
+    
 2. Performs the [server side signature of promotional offers](promotional-offers.md).
+
+### Additional Pieces
+
+- [The interesting story of the Google purchase tokens](google-purchase-tokens.md)

--- a/docs/google-purchase-tokens.md
+++ b/docs/google-purchase-tokens.md
@@ -1,0 +1,228 @@
+(Nov 2024, originally written as part of the Feast integration)
+
+In this file, we are going to clarify the difference between google purchase tokens and subscriptions ids. For this we are going follow their journey from a HTTP request from the Play Store backend to our DynamoDBs. This documentation is meant to help understanding what is happening and describes the current code. Efforts should be put into keeping it in sync with the code, and if one day a refactoring eliminates some of the effects and problems highlighted here, then do delete this file.
+
+## Google pubsub Part 1
+
+### Initial steps
+
+Here we are following this workflow 
+
+![](ARCHITECTURE-FILES/pubsub.png)
+
+The handler for the google notifications from the Play Store is `src/pubsub/google.ts`
+
+The handler is
+
+```
+export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+    return parseStoreAndSend(
+        request,
+        parsePayload,
+        toDynamoEvent,
+        toSqsSubReference,
+        fetchMetadata
+    )
+}
+```
+
+The `parseStoreAndSend` function essentially constucts a payload for the `subscription-events-v2` table and the SQS queue:
+
+```
+const notification = parsePayload(request.body)
+const queueUrl = process.env.QueueUrl
+
+const metaData = await fetchMetadata(notification)
+const dynamoEvent = toDynamoEvent(notification, metaData)
+const dynamoPromise = storeInDynamo(dynamoEvent)
+const sqsEvent = toSqsEvent(notification)
+const sqsPromise = sendToSqsFunction(queueUrl, sqsEvent)
+```
+
+We first build `notification: SubscriptionNotification`, where 
+
+```
+{
+    version: string
+    packageName: string
+    eventTimeMillis: string
+    subscriptionNotification: {
+        version: string,
+        notificationType: number,
+        purchaseToken: string,
+        subscriptionId: string
+    }
+}
+```
+
+Note that a `notification: SubscriptionNotification` has all the data needed to call 
+
+```
+fetchGoogleSubscription(subscriptionId: string, purchaseToken: string, packageName: string).
+```
+
+Using the notification, we use `fetchMetadata` (which calls `fetchGoogleSubscription`), to return a `GoogleSubscriptionMetaData`
+
+```
+interface GoogleSubscriptionMetaData {
+    freeTrial: boolean
+}
+```
+
+### Publishing to subscription-events-v2
+
+To see what goes to the `subscription-events-v2` table, have a look at the function
+
+```
+toDynamoEvent(notification: SubscriptionNotification, metaData?: GoogleSubscriptionMetaData): SubscriptionEvent
+```
+
+which generates
+
+```
+SubscriptionEvent(
+    subscriptionId         | notification.subscriptionNotification.purchaseToken # <-- Here is the purchase token!
+    timestampAndType       | -
+    date                   | -
+    timestamp              | -
+    eventType              | -
+    platform               | -
+    appId                  | notification.packageName                            # <-- Here is the package name!
+    freeTrial?             | -
+    googlePayload          | notification                                        # <-- There subscription Id is in there! (so are the other pieces: purchaseToken and packageName)
+    applePayload?          | -
+    ttl                    | -
+    promotional_offer_id   | -
+    promotional_offer_name | -
+    product_id             | -
+    purchase_date_ms       | -
+    expires_date_ms        | -
+)
+```
+
+That object is put in the table `mobile-purchases-PROD-subscription-events-v2`
+
+### Posting onto the SQS queue
+
+The situation here is simple as we simply take the `SubscriptionNotification` and build a `GoogleSubscriptionReference` 
+
+```
+GoogleSubscriptionReference {
+    packageName: string
+    purchaseToken: string
+    subscriptionId: string
+}
+```
+
+which is then put onto the queue.
+
+## Google pubsub Part 2
+
+Here we are still following the workflow 
+
+![](ARCHITECTURE-FILES/pubsub.png)
+
+but now focusing on populating the two `subscriptions` and `user-subscriptions` Dynamo tables from the second lambda.
+
+### google (classic)
+
+Here we are having a look at `src/update-subs/google.ts`
+
+The work here is done by 
+
+```
+record => parseAndStoreSubscriptionUpdate(record, getGoogleSubResponse)
+```
+
+Where record carries a `GoogleSubscriptionReference` generated in Part 1.
+
+```
+GoogleSubscriptionReference {
+    packageName: string,
+    purchaseToken: string,
+    subscriptionId: string
+}
+```
+
+Using that information we query for a `GoogleResponseBody`
+
+```
+ GoogleResponseBody {
+    startTimeMillis: string,
+    expiryTimeMillis: string,
+    userCancellationTimeMillis: string,
+    autoRenewing: boolean,
+    paymentState: 0 | 1 | 2 | 3
+}
+```
+
+and essentially combining the `GoogleSubscriptionReference` and the `GoogleResponseBody` we get a 
+
+```
+Subscription(
+    subscriptionId        | purchaseToken                                         # <-- Here is the purchase token!
+    startTimestamp        | -
+    endTimestamp          | -
+    cancellationTimestamp | -
+    autoRenewing          | -
+    productId             | subscriptionId                                        # <-- Here is the subscriptionId
+    platform              | googlePackageNameToPlatform(packageName)?.toString()  # package name is now visible as platform
+    freeTrial             | -
+    billingPeriod         | -
+    googlePayload         | -
+    receipt               | -
+    applePayload          | -
+    ttl                   | -
+)
+```
+
+We have now clarified the source of the data that goes into the `subscriptions` table, at least in the case of google subscriptions. And note the indiosyncrasy that the subscription identifier is carried by the `productId` attribute and the purchase token is carried by the `subscriptionId` attribute.
+
+### google (feast variant)
+
+Here we are having a look at `src/feast/update-subs/google.ts`
+
+In this case we populate both the `subscriptions` table and the `user-subscriptions` tables.
+
+To populate the `subscriptions` table we build the following subscription (where, as above, we indicate, the locations of the purchase token, the subscription identifier and the platform)
+
+```
+Subscription(
+    subscriptionId        | purchaseToken                            # <-- Here is the purchase token!
+    startTimestamp        | -
+    endTimestamp          | -
+    cancellationTimestamp | -
+    autoRenewing          | -
+    productId             | googleSubscription.productId
+    platform              | googlePackageNameToPlatform(packageName) # package name is now visible as platform
+    freeTrial             | -
+    billingPeriod         | -
+    googlePayload         | -
+    receipt               | -
+    applePayload          | -
+    ttl                   | -
+)
+```
+
+Note that this subscription is more "correct", in the sense that the `productId` attribute is now a product identifier, but we have lost the subscription identifier. This means that in the classic case, using the information from a subscription, we could recover the information needed to call `fetchGoogleSubscription`, but in the feast variant case, that's not possible.
+
+To populate the user-subscriptions table, we build a `UserSubscription` with the following line
+
+```
+userSubscription = new UserSubscription(identityId, subscription.subscriptionId, new Date().toISOString())
+```
+
+Interestingly the `subscription` that we use the `subscriptionId` of is the subscription that we built above, and among other things the subscriptionId is a purchase token. This means that the `UserSubscription` we are buildling
+
+```
+UserSubscription {
+    userId: string
+    subscriptionId: string      # <-- Here is the purchase token!
+    creationTimestamp: string
+```
+
+has a `subscriptionId` field that is equal to the purchase token of the corresponding feast subscription.
+
+In total there is a net loss of information that occurred when the feast variant of the google pubsub code was written, and we have lost the subscription identifier.
+
+nb: This file describes the code as the time these lines are written but we are going to do the work of recording and recovering that information in a coming PR.

--- a/typescript/src/services/google-play-v2.ts
+++ b/typescript/src/services/google-play-v2.ts
@@ -1,8 +1,7 @@
 import aws = require("../utils/aws");
 import S3 from 'aws-sdk/clients/s3'
-import {Stage} from "../utils/appIdentity";
-
-import {androidpublisher, auth} from '@googleapis/androidpublisher';
+import { Stage } from "../utils/appIdentity";
+import { androidpublisher, auth } from '@googleapis/androidpublisher';
 import { mapAndroidProductId } from "../utils/mapAndroidProductId";
 
 export type GoogleSubscription = {

--- a/typescript/src/update-subs/google.ts
+++ b/typescript/src/update-subs/google.ts
@@ -51,11 +51,11 @@ export const googleResponseBodyToSubscription = (
 
 export async function getGoogleSubResponse(record: SQSRecord): Promise<Subscription[]> {
 
-    const sub = JSON.parse(record.body) as GoogleSubscriptionReference;
+    const subscriptionReference = JSON.parse(record.body) as GoogleSubscriptionReference;
 
     let response;
     try {
-        response = await fetchGoogleSubscription(sub.subscriptionId, sub.purchaseToken, sub.packageName);
+        response = await fetchGoogleSubscription(subscriptionReference.subscriptionId, subscriptionReference.purchaseToken, subscriptionReference.packageName);
     } catch (exception: any) {
         if (exception.statusCode === 410) {
             console.log(`Purchase expired a very long time ago, ignoring`);
@@ -68,12 +68,12 @@ export async function getGoogleSubResponse(record: SQSRecord): Promise<Subscript
         }
     }
 
-    let billingPeriod = PRODUCT_BILLING_PERIOD[sub.subscriptionId];
+    let billingPeriod = PRODUCT_BILLING_PERIOD[subscriptionReference.subscriptionId];
     if (billingPeriod === undefined) {
-        console.warn(`Unable to get the billing period, unknown google subscription ID ${sub.subscriptionId}`);
+        console.warn(`Unable to get the billing period, unknown google subscription ID ${subscriptionReference.subscriptionId}`);
     }
 
-    const subscription = googleResponseBodyToSubscription(sub.purchaseToken, sub.packageName, sub.subscriptionId, billingPeriod, response);
+    const subscription = googleResponseBodyToSubscription(subscriptionReference.purchaseToken, subscriptionReference.packageName, subscriptionReference.subscriptionId, billingPeriod, response);
     return [subscription];
 }
 


### PR DESCRIPTION
Here we add a text file to clarify a piece of idiosyncrasy in the existing code that became apparent during the making of the Google API lookup of the feast integration ( https://github.com/guardian/mobile-purchases/pull/1707 ).

This comes as a separate documentation because although we will be upgrading the pipeline to capture the data that we need to make an Google API call using information contained in a Feast google subscription, the problem around the purchase token and the subscription id in the case of classic google pubsub is not going away anytime soon and this will help future visitors of the code to realize that it's not a problem with them. 

ps: also added a bit of linting and refactoring.
