### PR TITLE
Feast IAP acquisitions: Part 6.1, post feast google subscriptions to the acquisition api

### DIFF
--- a/docs/google-identifiers.md
+++ b/docs/google-identifiers.md
@@ -1,4 +1,4 @@
-In this file we explain an interesting idiosyncrasy affecting the Google pubsub logic and how it has affected how models.
+In this file we explain an interesting idiosyncrasy affecting the Google pubsub logic and how it has affected our models.
 
 ### Purchase tokens are the subscriptions unique identifiers
 

--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -107,7 +107,7 @@ const googleSubscriptionToAcquisitionApiPayload = (subscription: Subscription): 
     // We do not have access to the currency in the Google Subscription object
     // mapping of country to currency is not ideal but the best solution for now
 
-    const currency = "GBP";  
+    const currency = countryToCurrency(country);  
 
     const componentId = undefined;
     const componentType = undefined;

--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -3,9 +3,55 @@ import { Subscription } from "../../models/subscription";
 import { GoogleSubscription, fetchGoogleSubscriptionV2 } from "../../services/google-play-v2";
 import { googlePackageNameToPlatform } from "../../services/appToPlatform";
 import { dateToSecondTimestamp, thirtyMonths } from "../../utils/dates";
+import { restClient } from "../../utils/restClient";
+import { getConfigValue } from "../../utils/ssmConfig"
+import { Stage } from "../../utils/appIdentity"
 
 // This function is duplicated from the copy in src/update-subs/google.ts
 // This will be corrected in the future refactoring
+
+type AcquisitionApiPayloadQueryParameter = {
+    name: string,
+    value: string
+}
+
+// This schema simply follows the one given here: 
+// direct link: https://github.com/guardian/support-frontend/blob/main/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+// permalink  : https://github.com/guardian/support-frontend/blob/4d8c76a16bddd01ab91e59f89adbcf0867923c69/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+
+type AcquisitionApiPayload = {
+    eventTimeStamp: string,
+    product: string,
+    amount?: number,
+    country: string,
+    currency: string,
+    componentId?: string,
+    componentType?: string,
+    campaignCode?: string,
+    source?: string,
+    referrerUrl?: string,
+    abTests: void[], // this will have to be updated later if we want to use it
+    paymentFrequency: string,
+    paymentProvider?: void, // this will have to be updated later if we want to use it
+    printOptions?: void, // this will have to be updated later if we want to use it
+    browserId?: string,
+    identityId?: string,
+    pageViewId?: string,
+    referrerPageViewId?: string,
+    labels: void[],
+    promoCode?: string,
+    reusedExistingPaymentMethod: boolean,
+    readerType: string,
+    acquisitionType: string,
+    zuoraSubscriptionNumber?: string,
+    contributionId?: string,
+    paymentId: string, // optional in the acquisition API model, but required by Data Design, see comment id: e3f790af 
+    queryParameters: AcquisitionApiPayloadQueryParameter[],
+    platform?: string,
+    postalCode?: string,
+    state?: string,
+    email?: string
+}
 
 const googleSubscriptionToSubscription = (
     purchaseToken: string,
@@ -29,6 +75,135 @@ const googleSubscriptionToSubscription = (
     )
 };
 
+const countryToCurr = {
+    "US": "USD", // United States - Dollar
+    "GB": "GBP", // United Kingdom - Pound Sterling
+    "DE": "EUR", // Germany - Euro
+    "FR": "EUR", // France - Euro
+    "JP": "JPY", // Japan - Yen
+    "CN": "CNY", // China - Yuan Renminbi
+    "IN": "INR", // India - Indian Rupee
+    "CA": "CAD", // Canada - Canadian Dollar
+    "AU": "AUD", // Australia - Australian Dollar
+    "BR": "BRL"  // Brazil - Brazilian Real
+};
+
+const countryToCurrency = (country: string): string => {
+    const supportedCountries = Object.keys(countryToCurr);
+    if (supportedCountries.includes(country)) {
+        return countryToCurr[country as keyof typeof countryToCurr];
+    }
+    // Throwing an error here is not ideal, but it will do for the moment...
+    throw new Error(`[acba643d] Country ${country} is not supported`);
+}
+
+const googleSubscriptionToAcquisitionApiPayload = (subscription: Subscription): AcquisitionApiPayload => {
+    
+    const eventTimeStamp = subscription.startTimestamp;
+    const product = "FEAST_APP";
+    const amount = undefined; // Tom said to leave it undefined
+    const country = subscription.googlePayload?.rawResponse?.regionCode ?? "GB";
+
+    // We do not have access to the currency in the Google Subscription object
+    // mapping of country to currency is not ideal but the best solution for now
+
+    const currency = "GBP";  
+
+    const componentId = undefined;
+    const componentType = undefined;
+    const campaignCode = undefined;
+    const source = undefined;
+    const referrerUrl = undefined;
+    const abTests: void[] = [];
+
+    // from rawResponse.lineItems.offerDetails.basePlanId: feast-annual
+    // We are going to be mapping to one of the allowed values
+    // "ONE_OFF"
+    // "MONTHLY"
+    // "QUARTERLY"
+    // "SIX_MONTHLY"
+    // "ANNUALLY"
+    // TODO: implement the mapping.
+    const paymentFrequency = "ANNUALLY";
+
+    const paymentProvider = undefined;
+    const printOptions = undefined;
+    const browserId = undefined;
+    const identityId = undefined;
+    const pageViewId = undefined;
+    const referrerPageViewId = undefined;
+    const labels: void[] = [];
+    const promoCode = undefined;
+    const reusedExistingPaymentMethod = false;
+    const readerType = "Direct";
+    const acquisitionType = "PURCHASE";
+    const zuoraSubscriptionNumber = undefined;
+    const contributionId = undefined;
+
+    // Comment: { id: e3f790af, author: Pascal, date: 2024-12-12 }
+    // He have a special request from Data Design to use the paymentId field to pass the subscriptionId
+    // Don't ask...
+    // And in particular, although the acquisition API model says that the paymentId is optional,
+    // since it's expected to bet set by Data Design, we are declaring it to be medatory here.
+    const paymentId = subscription.subscriptionId;
+
+    const queryParameters: AcquisitionApiPayloadQueryParameter[] = [];
+    const platform = undefined;
+    const postalCode = undefined;
+    const state = undefined;
+    const email = undefined;
+
+    const payload: AcquisitionApiPayload = {
+        eventTimeStamp,
+        product,
+        amount,
+        country,
+        currency,
+        componentId,
+        componentType,
+        campaignCode,
+        source,
+        referrerUrl,
+        abTests,
+        paymentFrequency,
+        paymentProvider,
+        printOptions,
+        browserId,
+        identityId,
+        pageViewId,
+        referrerPageViewId,
+        labels,
+        promoCode,
+        reusedExistingPaymentMethod,
+        readerType,
+        acquisitionType,
+        zuoraSubscriptionNumber,
+        contributionId,
+        paymentId,
+        queryParameters,
+        platform,
+        postalCode,
+        state,
+        email,
+    }
+    return payload;
+}
+
+const postPayload = async (payload: AcquisitionApiPayload) => {
+    // Date: 12 Dec 2024
+    // We are only performing that operation on PROD, because we do not have a code endpoint 
+    // the parameter `acquisitionApiUrl` has only been defined for stage PROD in Paremeter Store
+    if (Stage === "PROD") {
+        const url = await getConfigValue<string>("acquisitionApiUrl");
+        console.log(`[9118860a] acquisition api url: ${url}`);
+        const additionalHeaders = {"Content-Type": "application/json"};
+        const body = JSON.stringify(payload);
+        await restClient.client.post(url, body, additionalHeaders);
+    } else{
+        console.log(`[69460012] postPayload has been called with payload: ${JSON.stringify(payload)}`);
+    }
+}
+
 const processSQSRecord = async (record: SQSRecord): Promise<void> => {
     console.log(`[48bb04a0] calling processRecord (Google version) with record ${JSON.stringify(record)}`);
     const subscriptionFromQueue: Subscription = JSON.parse(record.body);
@@ -40,6 +215,9 @@ const processSQSRecord = async (record: SQSRecord): Promise<void> => {
     console.log(`[4fe9b14b] subscriptionFromGoogle: ${JSON.stringify(subscriptionFromGoogle)}`);
     const subscriptionUpdated: Subscription = googleSubscriptionToSubscription(purchaseToken, packageName, subscriptionFromGoogle);
     console.log(`[2ba4a5a7] subscriptionUpdated: ${JSON.stringify(subscriptionUpdated)}`);
+    const payload = googleSubscriptionToAcquisitionApiPayload(subscriptionUpdated);
+    console.log(`[d522f940] acquisition api payload: ${JSON.stringify(payload)}`);
+    await postPayload(payload);
 }
 
 export const handler = async (event: SQSEvent): Promise<void> => {

--- a/typescript/src/feast/update-subs/common.ts
+++ b/typescript/src/feast/update-subs/common.ts
@@ -1,6 +1,6 @@
 import { UserSubscription } from "../../models/userSubscription"
 import { dynamoMapper, sendToSqs } from "../../utils/aws"
-import {Subscription} from '../../models/subscription';
+import { Subscription } from '../../models/subscription';
 
 export const storeUserSubscriptionInDynamo = (userSubscription: UserSubscription): Promise<void> => {
     return dynamoMapper.put({ item: userSubscription }).then(_ => {})

--- a/typescript/src/link/apple.ts
+++ b/typescript/src/link/apple.ts
@@ -1,10 +1,10 @@
 import 'source-map-support/register'
 
-import {parseAndStoreLink, SubscriptionCheckData} from "./link";
-import {UserSubscription} from "../models/userSubscription";
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
-import {parseAppleLinkPayload} from "./apple-utils"
-import {AppleLinkPayload} from "./apple-utils"
+import { parseAndStoreLink, SubscriptionCheckData } from "./link";
+import { UserSubscription } from "../models/userSubscription";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { parseAppleLinkPayload } from "./apple-utils"
+import { AppleLinkPayload } from "./apple-utils"
 import { Platform } from '../models/platform';
 
 function toUserSubscription(userId: string, payload: AppleLinkPayload): UserSubscription[] {

--- a/typescript/src/pubsub/apple-common.ts
+++ b/typescript/src/pubsub/apple-common.ts
@@ -1,7 +1,7 @@
-import {Option} from "../utils/option";
-import {PendingRenewalInfo} from "../services/appleValidateReceipts";
-import type {Result} from "@guardian/types";
-import {ok, err, ResultKind} from "@guardian/types";
+import { Option} from "../utils/option";
+import { PendingRenewalInfo } from "../services/appleValidateReceipts";
+import type { Result } from "@guardian/types";
+import { ok, err, ResultKind } from "@guardian/types";
 
 // this is the definition of a receipt as received by the server to server notification system.
 // Not to be confused with apple's receipt validation receipt info (although they do look similar, they are different)

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -1,12 +1,12 @@
 import 'source-map-support/register'
-import {SQSEvent, SQSRecord} from 'aws-lambda'
-import {parseAndStoreSubscriptionUpdate} from "./updatesub";
-import {Subscription} from "../models/subscription";
-import {dateToSecondTimestamp, thirtyMonths} from "../utils/dates";
-import {AppleSubscriptionReference} from "../models/subscriptionReference";
-import {AppleValidationResponse, validateReceipt} from "../services/appleValidateReceipts";
-import {appleBundleToPlatform} from "../services/appToPlatform";
-import {PRODUCT_BILLING_PERIOD} from "../services/productBillingPeriod";
+import { SQSEvent, SQSRecord } from 'aws-lambda'
+import { parseAndStoreSubscriptionUpdate } from "./updatesub";
+import { Subscription } from "../models/subscription";
+import { dateToSecondTimestamp, thirtyMonths } from "../utils/dates";
+import { AppleSubscriptionReference } from "../models/subscriptionReference";
+import { AppleValidationResponse, validateReceipt } from "../services/appleValidateReceipts";
+import { appleBundleToPlatform } from "../services/appToPlatform";
+import { PRODUCT_BILLING_PERIOD } from "../services/productBillingPeriod";
 
 export function toAppleSubscription(response: AppleValidationResponse): Subscription {
     const latestReceiptInfo = response.latestReceiptInfo;

--- a/typescript/src/utils/ssmConfig.ts
+++ b/typescript/src/utils/ssmConfig.ts
@@ -1,6 +1,6 @@
-import {ssm} from "./aws";
-import {App, Stack, Stage} from "./appIdentity";
-import {Option} from "./option";
+import { ssm } from "./aws";
+import { App, Stack, Stage } from "./appIdentity";
+import { Option } from "./option";
 
 type Config = {[key: string]: any};
 


### PR DESCRIPTION
Project: Feast subscription data for android and iOS

Part 1: Add Lambda and SQS cloudformation for apple and google handlers: https://github.com/guardian/mobile-purchases/pull/1667
Part 2: Introspection of DynamoDBStreamEvents: https://github.com/guardian/mobile-purchases/pull/1695
Part 3: Feast subscriptions dispatch logic: https://github.com/guardian/mobile-purchases/pull/1696
Part 4: Feast subscriptions SQS insertion: https://github.com/guardian/mobile-purchases/pull/1700
Part 5: Apple and Google API lookups
- 5.1. Introspection: https://github.com/guardian/mobile-purchases/pull/1701
- 5.2. Apple API documentation, and implementation of Apple API look up ( https://github.com/guardian/mobile-purchases/pull/1703 )
- 5.3 Google API documentation, and implementation of Google API look up ( https://github.com/guardian/mobile-purchases/pull/1707 )

Part 6: Post Apple and Google subscriptions to the acquisition API
- 6.1 Google subscriptions

In this change we are completing mobile-purchases-feast-google-acquisition-events by transforming the augmented Google subscriptions to `AcquisitionApiPayload` and posting them to the acquisition API. For the moment we are limiting ourselves only to mandatory attributes. 