### PR TITLE
update the productId to billing period mapping

### DIFF
--- a/typescript/src/services/productBillingPeriod.ts
+++ b/typescript/src/services/productBillingPeriod.ts
@@ -29,4 +29,5 @@ export const PRODUCT_BILLING_PERIOD: {[productId: string]: string} = {
     "uk.co.guardain.Feast.yearly.discounted": "P1Y",
     "uk.co.guardian.Feast.monthly": "P1M",
     "uk.co.guardian.Feast.monthly.discounted": "P1M",
+    "guardian.subscription.month.meteredoffer": "P1M",
 };


### PR DESCRIPTION
Noticed that we have a missing key in the productId to billing period mapping, causing a warning in the logs

```
2024-11-28T10:25:55.413Z	83ed54d8-7dc3-5b86-851d-0b1a3a9cbd40	WARN	Unable to get the billing period, unknown google subscription ID guardian.subscription.month.meteredoffer
```