### PR TITLE
add 2 missing keys to product to billing period mapping

### DIFF
--- a/typescript/src/services/productBillingPeriod.ts
+++ b/typescript/src/services/productBillingPeriod.ts
@@ -19,9 +19,11 @@ export const PRODUCT_BILLING_PERIOD: {[productId: string]: string} = {
     "uk.co.guardian.gla.1month.2017Q2.variantB": "P1M",
     "uk.co.guardian.gla.1month.2018April.withFreeTrial": "P1M",
     "uk.co.guardian.gla.1month.2018May.withFreeTrial": "P1M",
+    "uk.co.guardian.gla.1month.2018May.stepUp": "P1M",
     "uk.co.guardian.gla.6months": "P6M",
     "uk.co.guardian.gla.6months.2018May.withFreeTrial": "P6M",
     "uk.co.guardian.gla.12months.2018Dec.withFreeTrial": "P1Y",
+    "uk.co.guardian.gla.12months.2018Dec.stepUp": "P1Y",
 
     // uk.co.guardian.subscription*
     "uk.co.guardian.subscription": "P1M",


### PR DESCRIPTION
Add missing keys to product id to billing period mapping
- uk.co.guardian.gla.1month.2018May.stepUp
- uk.co.guardian.gla.12months.2018Dec.stepUp