### PR TITLE
Add missing key: com.guardian.subscription.monthly.11.freetrial

### DIFF
--- a/typescript/src/services/productBillingPeriod.ts
+++ b/typescript/src/services/productBillingPeriod.ts
@@ -5,8 +5,9 @@ export const PRODUCT_BILLING_PERIOD: {[productId: string]: string} = {
 
     // com.guardian.subscription*
     "com.guardian.subscription.6monthly.12": "P6M",
-    "com.guardian.subscription.annual.13": "P1Y",
     "com.guardian.subscription.monthly.10": "P1M",
+    "com.guardian.subscription.monthly.11.freetrial": "P1M",
+    "com.guardian.subscription.annual.13": "P1Y",
 
     // uk.co.guardian.gia*
     "uk.co.guardian.gia.1month": "P1M",


### PR DESCRIPTION
Add missing key com.guardian.subscription.monthly.11.freetrial to the product Id to billing period mapping

```
2024-11-28T11:44:47.113Z	c130380f-d85f-5077-97e8-67cd81b384c8	WARN	Unable to get the billing period, unknown google subscription ID com.guardian.subscription.monthly.11.freetrial
```