### PR TITLE
add missing key uk.co.guardian.gla.12months.2023Mar.metered

### DIFF
--- a/typescript/src/services/productBillingPeriod.ts
+++ b/typescript/src/services/productBillingPeriod.ts
@@ -24,6 +24,7 @@ export const PRODUCT_BILLING_PERIOD: {[productId: string]: string} = {
     "uk.co.guardian.gla.6months.2018May.withFreeTrial": "P6M",
     "uk.co.guardian.gla.12months.2018Dec.withFreeTrial": "P1Y",
     "uk.co.guardian.gla.12months.2018Dec.stepUp": "P1Y",
+    "uk.co.guardian.gla.12months.2023Mar.metered": "P1Y",
 
     // uk.co.guardian.subscription*
     "uk.co.guardian.subscription": "P1M",


### PR DESCRIPTION
Add missing key `uk.co.guardian.gla.12months.2023Mar.metered` to the product Id to billing period mapping.

"""
2024-11-28T13:53:40.821Z	7cc4ca78-7ad8-50b8-ba51-95ba02f9bed0	WARN	Unable to get the billing period, unknown product ID uk.co.guardian.gla.12months.2023Mar.metered
"""