### PR TITLE
Feast IAP acquisitions: Part 6.2, post feast Apple subscriptions to the acquisition api

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.5.1",
+    "ts-node": "^10.4.0",
     "typescript": "^4.9.5",
     "webpack": "^5.97.1",
-    "webpack-cli": "^6.0.1",
-    "ts-node": "^10.4.0"
+    "webpack-cli": "^6.0.1"
   },
   "dependencies": {
     "@aws/dynamodb-data-mapper": "^0.7.3",
@@ -41,6 +41,7 @@
     "@types/aws-lambda": "8.10.147",
     "@types/node": "^22.10.5",
     "aws-sdk": "^2.1692.0",
+    "jsonwebtoken": "^9.0.2",
     "node-fetch": "2.6.7",
     "source-map-support": "^0.5.21",
     "typed-rest-client": "^2.1.0",

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -35,7 +35,79 @@ interface AppleExtendedData {
 }
 
 const storefrontToCountryMap = {
-    "GBR" : "GB", // United Kingdom
+    "GBR": "GB", // United Kingdom
+    "USA": "US", // United States
+    "CAN": "CA", // Canada
+    "AUS": "AU", // Australia
+    "DEU": "DE", // Germany
+    "FRA": "FR", // France
+    "ITA": "IT", // Italy
+    "ESP": "ES", // Spain
+    "NLD": "NL", // Netherlands
+    "BRA": "BR", // Brazil
+    "IND": "IN", // India
+    "JPN": "JP", // Japan
+    "KOR": "KR", // South Korea
+    "CHN": "CN", // China
+    "RUS": "RU", // Russia
+    "MEX": "MX", // Mexico
+    "ZAF": "ZA", // South Africa
+    "ARG": "AR", // Argentina
+    "CHE": "CH", // Switzerland
+    "TUR": "TR", // Turkey
+    "POL": "PL", // Poland
+    "SWE": "SE", // Sweden
+    "NOR": "NO", // Norway
+    "DNK": "DK", // Denmark
+    "FIN": "FI", // Finland
+    "IRL": "IE", // Ireland
+    "AUT": "AT", // Austria
+    "BEL": "BE", // Belgium
+    "PRT": "PT", // Portugal
+    "HUN": "HU", // Hungary
+    "CZE": "CZ", // Czech Republic
+    "SVK": "SK", // Slovakia
+    "GRC": "GR", // Greece
+    "ROU": "RO", // Romania
+    "BGR": "BG", // Bulgaria
+    "HRV": "HR", // Croatia
+    "EST": "EE", // Estonia
+    "LVA": "LV", // Latvia
+    "LTU": "LT", // Lithuania
+    "SVN": "SI", // Slovenia
+    "LUX": "LU", // Luxembourg
+    "CYP": "CY", // Cyprus
+    "MLT": "MT", // Malta
+    "SAU": "SA", // Saudi Arabia
+    "ARE": "AE", // United Arab Emirates
+    "IDN": "ID", // Indonesia
+    "THA": "TH", // Thailand
+    "VNM": "VN", // Vietnam
+    "PHL": "PH", // Philippines
+    "SGP": "SG", // Singapore
+    "MYS": "MY", // Malaysia
+    "NZL": "NZ", // New Zealand
+    "ISR": "IL", // Israel
+    "EGY": "EG", // Egypt
+    "CHL": "CL", // Chile
+    "COL": "CO", // Colombia
+    "PER": "PE", // Peru
+    "VEN": "VE", // Venezuela
+    "KWT": "KW", // Kuwait
+    "QAT": "QA", // Qatar
+    "OMN": "OM", // Oman
+    "MAR": "MA", // Morocco
+    "TUN": "TN", // Tunisia
+    "JAM": "JM", // Jamaica
+    "PAN": "PA", // Panama
+    "URY": "UY", // Uruguay
+    "ECU": "EC", // Ecuador
+    "KEN": "KE", // Kenya
+    "NGA": "NG", // Nigeria
+    "GHA": "GH", // Ghana
+    "UGA": "UG", // Uganda
+    "TZA": "TZ", // Tanzania
+    "ETH": "ET", // Ethiopia
 };
 
 const storefrontToCountry = (storefront: string): string => {

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -108,6 +108,20 @@ const storefrontToCountryMap = {
     "UGA": "UG", // Uganda
     "TZA": "TZ", // Tanzania
     "ETH": "ET", // Ethiopia
+    "SRB": "RS", // Serbia
+    "ALB": "AL", // Albania
+    "AND": "AD", // Andorra
+    "BLR": "BY", // Belarus
+    "BIH": "BA", // Bosnia and Herzegovina
+    "ISL": "IS", // Iceland
+    "XKX": "XK", // Kosovo
+    "LIE": "LI", // Liechtenstein
+    "MCO": "MC", // Monaco
+    "MNE": "ME", // Montenegro
+    "MKD": "MK", // North Macedonia
+    "SMR": "SM", // San Marino
+    "UKR": "UA", // Ukraine
+    "VAT": "VA", // Vatican City
 };
 
 const storefrontToCountry = (storefront: string): string => {

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -120,7 +120,7 @@ const storefrontToCountry = (storefront: string): string => {
 }
 
 const productIdToPaymentFrequencyMap = {
-    "uk.co.guardian.Feast.annual" : "ANNUALLY",
+    "uk.co.guardian.Feast.yearly" : "ANNUALLY",
     "uk.co.guardian.Feast.monthly": "MONTHLY",
 }
 

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -149,6 +149,9 @@ const appleSubscriptionToExtendedData = async (subscription: Subscription): Prom
                         "signedTransactionInfo": "eyJhbGciOeUJEWlhKMGF[removed]"
     */
 
+    // extracting signedTransactionInfo
+    // Currently doing it by hand but it will be validated with zod in a coming refactoring
+
     const data = json.data
     if (data === undefined) {
         throw new Error("[92d086b6] json.data is undefined");

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -69,7 +69,9 @@ const appleSubscriptionToExtendedData = async (subscription: Subscription): Prom
 
     console.log(`[940dc079] ${new Date}`);
 
-    const transactionId = "220002304451105";
+    const transactionId = subscription.applePayload["latest_receipt_info"][0]["transaction_id"];
+    console.log(`[116fa7d4] transactionId: ${transactionId}`);
+
     const url = `https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/${transactionId}`;
     console.log(`[5330931d] url: ${url}`);
 

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -122,6 +122,7 @@ const storefrontToCountry = (storefront: string): string => {
 const productIdToPaymentFrequencyMap = {
     "uk.co.guardian.Feast.yearly" : "ANNUALLY",
     "uk.co.guardian.Feast.monthly": "MONTHLY",
+    "uk.co.guardian.Feast.monthly.discounted": "MONTHLY",
 }
 
 const productIdToPaymentFrequency = (productId: string): string => {

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -5,29 +5,161 @@ import { ValidationOptions, AppleValidationResponse, validateReceipt } from "../
 import { toAppleSubscription } from "../../update-subs/apple";
 import { AcquisitionApiPayload, AcquisitionApiPayloadQueryParameter } from "./common";
 import { postPayloadToAcquisitionAPI } from "./common";
+import fetch from 'node-fetch';
+import { getConfigValue } from "../../utils/ssmConfig";
 
-const appleSubscriptionToAcquisitionApiPayload = (subscription: Subscription): AcquisitionApiPayload => {
+// AppleExtendedData is built from the answer from
+// https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/{transactionId}
+// and contains information that are required to build an AcquisitionApiPayload
+interface AppleExtendedData {
+    transactionId: string,
+    country: string, // country as two letter code
+    currency: string, // currency as three letter code
+    paymentFrequency: string,
+        // Same values as AcquisitionApiPayload.paymentFrequency
+        // "ONE_OFF"
+        // "MONTHLY"
+        // "QUARTERLY"
+        // "SIX_MONTHLY"
+        // "ANNUALLY"
+}
+
+const appleSubscriptionToExtendedData = async (subscription: Subscription): Promise<AppleExtendedData> => {
+    /*
+        This function takes a Subscription and return the extra data that is retrieved from the Apple API
+        at https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/{transactionId}
+    */
+
+    console.log(`[940dc079] ${new Date}`);
+
+    const transactionId = "220002304451105";
+    const url = `https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/${transactionId}`;
+    console.log(`[5330931d] url: ${url}`);
+
+    // /mobile-purchases/PROD/mobile/pascalAuthExperimental
+    const auth = await getConfigValue<string>("pascalAuthExperimental");
+    const params = {
+        method: 'GET',
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${auth}`
+        }
+    }
+
+    let json;
+
+    try {
+        console.log(`[0f984ea0] ${JSON.stringify(params)}`);
+        const response = await fetch(url, params);
+        if (response.ok) {
+            json = await response.json();
+        } else {
+            console.error(`[661fe1aa] error: fetch failed: ${response.status}`);
+        }
+    } catch (error) {
+        if (error instanceof Error) {
+            console.error(`[c63b76d3] error: fetch failed: ${error.message}`);
+        } else {
+            console.error(`[e9848cd6] error: fetch failed: ${JSON.stringify(error)}`);
+        }
+    }
+
+    console.log(`[55ca8e2c] ${JSON.stringify(json)}`);
+
+    /*
+    {
+        "environment": "Production",
+        "bundleId": "uk.co.guardian.Feast",
+        "appAppleId": 603350f961c5,
+        "data": [
+            {
+                "subscriptionGroupIdentifier": "21396030",
+                "lastTransactions": [
+                    {
+                        "originalTransactionId": "220002304451105",
+                        "status": 2,
+                        "signedTransactionInfo": "eyJhbGciOeUJEWlhKMGF[removed]"
+    */
+
+    const data = json.data
+    if (data === undefined) {
+        throw new Error("[92d086b6] json.data is undefined");
+    }                
+    if (data.length === 0) {
+        throw new Error("[2ee57da0] json.data is empty");
+    }
+    const item1 = data[0];
+    const lastTransactions = item1.lastTransactions;
+    if (lastTransactions === undefined) {
+        throw new Error("[553620b1] json.data[0].lastTransactions is undefined");
+    }
+    if (lastTransactions.length === 0) {
+        throw new Error("[2b6cd147] json.data[0].lastTransactions is empty");
+    }
+    const item2 = lastTransactions[0];
+    const signedTransactionInfo = item2.signedTransactionInfo;
+    if (signedTransactionInfo === undefined) {
+        throw new Error("[f147df3e] json.data[0].lastTransactions[0].signedTransactionInfo is undefined");
+    }
+
+    console.log(`[c5dabbcc] ${signedTransactionInfo}`);
+
+    /*
+        payload (anonymized) from the answer
+
+        {
+            "transactionId": "2200001105",
+            "originalTransactionId": "2200001105",
+            "webOrderLineItemId": "22048309784",
+            "bundleId": "uk.co.guardian.Feast",
+            "productId": "uk.co.guardian.Feast.monthly",
+            "subscriptionGroupIdentifier": "21396030",
+            "purchaseDate": 1732526628000,
+            "originalPurchaseDate": 1732526630000,
+            "expiresDate": 1733736228000,
+            "quantity": 1,
+            "type": "Auto-Renewable Subscription",
+            "appAccountToken": "3b70e18e-de6c-46a8-83b5-3e317d6c7b84",
+            "inAppOwnershipType": "PURCHASED",
+            "signedDate": 1735899829949,
+            "offerType": 1,
+            "environment": "Production",
+            "transactionReason": "PURCHASE",
+            "storefront": "GBR",
+            "storefrontId": "143444",
+            "price": 0,
+            "currency": "GBP",
+            "offerDiscountType": "FREE_TRIAL"
+        }
+    */
+
+    const country = "UK"; // function of `answer.storefront`
+    const currency = "GBP";
+    const paymentFrequency = "MONTHLY"; // function of `answer.productId`
+    return {
+        transactionId,
+        country,
+        currency,
+        paymentFrequency
+    };
+}
+
+const appleSubscriptionToAcquisitionApiPayload = async (subscription: Subscription): Promise<AcquisitionApiPayload> => {
+
+    const extendedData = await appleSubscriptionToExtendedData(subscription);
 
     const eventTimeStamp = subscription.startTimestamp;
     const product = "FEAST_APP";
     const amount = undefined; // Tom said to leave it undefined
-
-    // TODO:
-    const country = "UK"; // We are going to fix that at some point
-
-    // TODO:
-    const currency = "GBP"; // We are going to fix that at some point
-
+    const country = extendedData.country;
+    const currency = extendedData.currency;
     const componentId = undefined;
     const componentType = undefined;
     const campaignCode = undefined;
     const source = undefined;
     const referrerUrl = undefined;
     const abTests: void[] = [];
-
-    // TODO:
-    const paymentFrequency = "MONTHLY"; // We are going to fix that at some point
-
+    const paymentFrequency = extendedData.paymentFrequency
     const paymentProvider = undefined;
     const printOptions = undefined;
     const browserId = undefined;
@@ -100,13 +232,14 @@ const processSQSRecord = async (record: SQSRecord): Promise<void> => {
     }
     const appleValidationResponses: AppleValidationResponse[] = await validateReceipt(receipt, validationOptions, App.Feast);
     console.log(`[2dc25207] AppleValidationResponses: ${JSON.stringify(appleValidationResponses)}`);
-    appleValidationResponses.forEach(async appleValidationResponse => {
+    const promises = appleValidationResponses.map(async appleValidationResponse => {
         const appleSubscription: Subscription = toAppleSubscription(appleValidationResponse)
         console.log(`[a41a0078] appleSubscription: ${JSON.stringify(appleSubscription)}`);
-        const payload = appleSubscriptionToAcquisitionApiPayload(appleSubscription);
+        const payload = await appleSubscriptionToAcquisitionApiPayload(appleSubscription);
         console.log(`[ffdce775] acquisition api payload: ${JSON.stringify(payload)}`);
         await postPayloadToAcquisitionAPI(payload);
     })
+    await Promise.all(promises);
 }
 
 export const handler = async (event: SQSEvent): Promise<void> => {

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -69,11 +69,14 @@ const appleSubscriptionToExtendedData = async (subscription: Subscription): Prom
 
     console.log(`[940dc079] ${new Date}`);
 
-    const transactionId = subscription.applePayload["latest_receipt_info"][0]["transaction_id"];
+    const transactionId = subscription.applePayload["latest_receipt_info"][0]["transaction_id"]; // This extraction will be abstracted in a function in a coming refactoring
     console.log(`[116fa7d4] transactionId: ${transactionId}`);
 
     const url = `https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/${transactionId}`;
     console.log(`[5330931d] url: ${url}`);
+
+    // Generating the JWT token
+    // https://developer.apple.com/documentation/appstoreserverapi/generating-json-web-tokens-for-api-requests
 
     const issuerId = await getConfigValue<string>("feastAppleStoreKitConfigIssuerId");
     const keyId = await getConfigValue<string>("feastAppleStoreKitConfigKeyId"); 
@@ -87,10 +90,12 @@ const appleSubscriptionToExtendedData = async (subscription: Subscription): Prom
         typ: "JWT"
     }
   
+    const unixtime = Math.floor(Date.now() / 1000);
+
     const jwt_payload = {
         iss: issuerId,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: unixtime,
+        exp: unixtime + 3600, // one hour expiration
         aud: audience,
         bid: appBundleId
     }

--- a/typescript/src/feast/acquisition-events/common.ts
+++ b/typescript/src/feast/acquisition-events/common.ts
@@ -26,7 +26,14 @@ export type AcquisitionApiPayload = {
     source?: string,
     referrerUrl?: string,
     abTests: void[], // this will have to be updated later if we want to use it
-    paymentFrequency: string,
+
+    paymentFrequency: string, // TODO: make it a set of values
+        // "ONE_OFF"
+        // "MONTHLY"
+        // "QUARTERLY"
+        // "SIX_MONTHLY"
+        // "ANNUALLY"
+
     paymentProvider?: void, // this will have to be updated later if we want to use it
     printOptions?: void, // this will have to be updated later if we want to use it
     browserId?: string,

--- a/typescript/src/feast/acquisition-events/common.ts
+++ b/typescript/src/feast/acquisition-events/common.ts
@@ -1,3 +1,7 @@
+import { restClient } from "../../utils/restClient";
+import { getConfigValue } from "../../utils/ssmConfig";
+import { Stage } from "../../utils/appIdentity";
+
 // This function is duplicated from the copy in src/update-subs/google.ts
 // This will be corrected in the future refactoring
 
@@ -42,4 +46,19 @@ export type AcquisitionApiPayload = {
     postalCode?: string,
     state?: string,
     email?: string
+}
+
+export const postPayloadToAcquisitionAPI = async (payload: AcquisitionApiPayload) => {
+    // Date: 12 Dec 2024
+    // We are only performing that operation on PROD, because we do not have a code endpoint 
+    // the parameter `acquisitionApiUrl` has only been defined for stage PROD in Paremeter Store
+    if (Stage === "PROD") {
+        const url = await getConfigValue<string>("acquisitionApiUrl");
+        console.log(`[9118860a] acquisition api url: ${url}`);
+        const additionalHeaders = {"Content-Type": "application/json"};
+        const body = JSON.stringify(payload);
+        await restClient.client.post(url, body, additionalHeaders);
+    } else{
+        console.log(`[69460012] postPayload has been called with payload: ${JSON.stringify(payload)}`);
+    }
 }

--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -158,14 +158,7 @@ const basePlanIdToPaymentFrequency = (basePlanId: string): string => {
 const extractBasePlanId = (subscription: Subscription): string => {
     // The logic of this code is based on the idea that we can determine the Payment Frequency from the basePlanId 
     // which can be found in the rawResponse of the Google Subscription object
-    // -> rawResponse.lineItems[0].offerDetails.basePlanId: feast-annual
-
-    // It needs to be mapped to one of the allowed values:
-    // "ONE_OFF"
-    // "MONTHLY"
-    // "QUARTERLY"
-    // "SIX_MONTHLY"
-    // "ANNUALLY"
+    // -> rawResponse.lineItems[0].offerDetails.basePlanId: feast-annual or feast-monthly
 
     const lineItems = subscription.googlePayload?.rawResponse?.lineItems;
 

--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -4,54 +4,9 @@ import { GoogleSubscription, fetchGoogleSubscriptionV2 } from "../../services/go
 import { googlePackageNameToPlatform } from "../../services/appToPlatform";
 import { dateToSecondTimestamp, thirtyMonths } from "../../utils/dates";
 import { restClient } from "../../utils/restClient";
-import { getConfigValue } from "../../utils/ssmConfig"
-import { Stage } from "../../utils/appIdentity"
-
-// This function is duplicated from the copy in src/update-subs/google.ts
-// This will be corrected in the future refactoring
-
-type AcquisitionApiPayloadQueryParameter = {
-    name: string,
-    value: string
-}
-
-// This schema simply follows the one given here: 
-// direct link: https://github.com/guardian/support-frontend/blob/main/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
-// permalink  : https://github.com/guardian/support-frontend/blob/4d8c76a16bddd01ab91e59f89adbcf0867923c69/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
-
-type AcquisitionApiPayload = {
-    eventTimeStamp: string,
-    product: string,
-    amount?: number,
-    country: string,
-    currency: string,
-    componentId?: string,
-    componentType?: string,
-    campaignCode?: string,
-    source?: string,
-    referrerUrl?: string,
-    abTests: void[], // this will have to be updated later if we want to use it
-    paymentFrequency: string,
-    paymentProvider?: void, // this will have to be updated later if we want to use it
-    printOptions?: void, // this will have to be updated later if we want to use it
-    browserId?: string,
-    identityId?: string,
-    pageViewId?: string,
-    referrerPageViewId?: string,
-    labels: void[],
-    promoCode?: string,
-    reusedExistingPaymentMethod: boolean,
-    readerType: string,
-    acquisitionType: string,
-    zuoraSubscriptionNumber?: string,
-    contributionId?: string,
-    paymentId: string, // optional in the acquisition API model, but required by Data Design, see comment id: e3f790af 
-    queryParameters: AcquisitionApiPayloadQueryParameter[],
-    platform?: string,
-    postalCode?: string,
-    state?: string,
-    email?: string
-}
+import { getConfigValue } from "../../utils/ssmConfig";
+import { Stage } from "../../utils/appIdentity";
+import { AcquisitionApiPayload, AcquisitionApiPayloadQueryParameter } from "./types";
 
 const googleSubscriptionToSubscription = (
     purchaseToken: string,

--- a/typescript/src/feast/acquisition-events/types.ts
+++ b/typescript/src/feast/acquisition-events/types.ts
@@ -1,0 +1,45 @@
+// This function is duplicated from the copy in src/update-subs/google.ts
+// This will be corrected in the future refactoring
+
+export type AcquisitionApiPayloadQueryParameter = {
+    name: string,
+    value: string
+}
+
+// This schema simply follows the one given here: 
+// direct link: https://github.com/guardian/support-frontend/blob/main/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+// permalink  : https://github.com/guardian/support-frontend/blob/4d8c76a16bddd01ab91e59f89adbcf0867923c69/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+
+export type AcquisitionApiPayload = {
+    eventTimeStamp: string,
+    product: string,
+    amount?: number,
+    country: string,
+    currency: string,
+    componentId?: string,
+    componentType?: string,
+    campaignCode?: string,
+    source?: string,
+    referrerUrl?: string,
+    abTests: void[], // this will have to be updated later if we want to use it
+    paymentFrequency: string,
+    paymentProvider?: void, // this will have to be updated later if we want to use it
+    printOptions?: void, // this will have to be updated later if we want to use it
+    browserId?: string,
+    identityId?: string,
+    pageViewId?: string,
+    referrerPageViewId?: string,
+    labels: void[],
+    promoCode?: string,
+    reusedExistingPaymentMethod: boolean,
+    readerType: string,
+    acquisitionType: string,
+    zuoraSubscriptionNumber?: string,
+    contributionId?: string,
+    paymentId: string, // optional in the acquisition API model, but required by Data Design, see comment id: e3f790af 
+    queryParameters: AcquisitionApiPayloadQueryParameter[],
+    platform?: string,
+    postalCode?: string,
+    state?: string,
+    email?: string
+}

--- a/typescript/src/utils/restClient.ts
+++ b/typescript/src/utils/restClient.ts
@@ -1,3 +1,3 @@
 import * as restm from "typed-rest-client/RestClient";
 
-export const restClient = new restm.RestClient('guardian-mobile-purchases', undefined,undefined, {socketTimeout: 10000});
+export const restClient = new restm.RestClient('guardian-mobile-purchases', undefined, undefined, {socketTimeout: 10000});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3161,6 +3161,31 @@ json5@2.x, json5@^2.2.2:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonwebtoken@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"
+  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
 jwa@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz"
@@ -3181,6 +3206,14 @@ jwks-rsa@^3.1.0:
     jose "^4.14.6"
     limiter "^1.1.5"
     lru-memoizer "^2.2.0"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 jws@^4.0.0:
   version "4.0.0"
@@ -3258,6 +3291,41 @@ lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
   integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash@4.x, lodash@^4.7.0:
   version "4.17.21"
@@ -3413,6 +3481,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -3957,6 +4030,11 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.5.4:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 serialize-javascript@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
Project: Feast subscription data for android and iOS

Part 1: Add Lambda and SQS cloudformation for apple and google handlers: https://github.com/guardian/mobile-purchases/pull/1667
Part 2: Introspection of DynamoDBStreamEvents: https://github.com/guardian/mobile-purchases/pull/1695
Part 3: Feast subscriptions dispatch logic: https://github.com/guardian/mobile-purchases/pull/1696
Part 4: Feast subscriptions SQS insertion: https://github.com/guardian/mobile-purchases/pull/1700
Part 5: Apple and Google API lookups
- 5.1. Introspection: https://github.com/guardian/mobile-purchases/pull/1701
- 5.2. Apple API documentation, and implementation of Apple API look up ( https://github.com/guardian/mobile-purchases/pull/1703 )
- 5.3 Google API documentation, and implementation of Google API look up ( https://github.com/guardian/mobile-purchases/pull/1707 )

Part 6: Post Apple and Google subscriptions to the acquisition API
- 6.1 Google subscriptions ( https://github.com/guardian/mobile-purchases/pull/1713 )
- 6.2 Apple subscriptions

This change implement the making of the payload to send apple subscriptions to the acquisition API. This is a more complex change than what one would expect because of a number of factors:

1. api.storekit is required to extract the country and currency of a subscription. A complexity we did not have in the case of Google. 

2. We introduce a number of new Parameter Store variables that encode the data required to build the right JsonWebToken. 

3. We introduce a new library to build JSON Web Tokens. 

4. We also introduce two new maps `productIdToPaymentFrequencyMap` and `storefrontToCountryMap`. We are not over specifying them and we will get an alarm when we get non recognised data, as we did for Google subscriptions. 

For all intents and purposes this is still a prototype, so expect refactorings soon.
