### PR TITLE
update feast google acquisitions mappings

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -145,7 +145,8 @@ const countryToCurrency = (country: string): string => {
 }
 
 const basePlanIdToPaymentFrequencyMap = {
-    "feast-annual" : "ANNUALLY"
+    "feast-annual" : "ANNUALLY",
+    "feast-monthly": "MONTHLY",
 }
 
 const basePlanIdToPaymentFrequency = (basePlanId: string): string => {

--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -134,6 +134,8 @@ const countryToCurrencyMap = {
     "AU": "AUD", // Australia - Australian Dollar
     "BR": "BRL",  // Brazil - Brazilian Real
     "ID": "IDR", // Indonesia - Rupiah
+    "HK": "HKD", // Hong Kong - Hong Kong Dollar,
+    "NZ": "NZD", // New Zealand - New Zealand Dollar
 };
 
 const countryToCurrency = (country: string): string => {

--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -133,6 +133,7 @@ const countryToCurrencyMap = {
     "CA": "CAD", // Canada - Canadian Dollar
     "AU": "AUD", // Australia - Australian Dollar
     "BR": "BRL",  // Brazil - Brazilian Real
+    "ID": "IDR", // Indonesia - Rupiah
 };
 
 const countryToCurrency = (country: string): string => {


### PR DESCRIPTION
### Part 1

When I implemented the basePlanIdToPaymentFrequencyMap (https://github.com/guardian/mobile-purchases/pull/1730/files#diff-d1e09ed56736bbf810e382b6d27d27c9cd420e45dfd799b13a846cca33f5b7f2R148) , I only encoded the `feast-annual`, because at the time I didn't have confirmation of the label for monthlies. 

We had a failure with

```
"[fd8665bb] basePlanId feast-monthly is not supported"
```

This now adds the key for monthlies. 

### Part 2

Add country codes `ID`, `HK` and `NZ` to `countryToCurrencyMap`

We had a failure with 

```
[acba643d] Country ID is not supported
[acba643d] Country HK is not supported
[acba643d] Country NZ is not supported
```