### PR TITLE
add more countries to currency distribution

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -125,18 +125,58 @@ const countryToCurrencyMap = {
     "UA": "UAH", // Ukraine
     "VA": "EUR", // Vatican City
 
-    // Rest of the world
+    // More Europe
+    "AM": "AMD", // Armenia - Armenian Dram
+    "AZ": "AZN", // Azerbaijan - Azerbaijani Manat
+    "GE": "GEL", // Georgia - Georgian Lari
+    "KZ": "KZT", // Kazakhstan - Kazakhstani Tenge
+
+    // Rest of the world (big economies)
     "US": "USD", // United States - Dollar
     "JP": "JPY", // Japan - Yen
     "CN": "CNY", // China - Yuan Renminbi
     "IN": "INR", // India - Indian Rupee
     "CA": "CAD", // Canada - Canadian Dollar
     "AU": "AUD", // Australia - Australian Dollar
-    "BR": "BRL",  // Brazil - Brazilian Real
+    "NZ": "NZD", // New Zealand - New Zealand Dollar
+    "BR": "BRL", // Brazil - Brazilian Real
+
+    // Asia
+    "BD": "BDT", // Bangladesh - Bangladeshi Taka
+    "PK": "PKR", // Pakistan - Pakistani Rupee
+    "SG": "SGD", // Singapore - Singapore Dollar
+    "KR": "KRW", // South Korea - South Korean Won
+    "MY": "MYR", // Malaysia - Malaysian Ringgit
+    "TH": "THB", // Thailand - Thai Baht
+    "VN": "VND", // Vietnam - Vietnamese Dong
+    "LK": "LKR", // Sri Lanka - Sri Lankan Rupee
+    "AE": "AED", // United Arab Emirates - Dirham
+    "PH": "PHP", // Philippines - Philippine Peso
     "ID": "IDR", // Indonesia - Rupiah
     "HK": "HKD", // Hong Kong - Hong Kong Dollar,
-    "NZ": "NZD", // New Zealand - New Zealand Dollar
-    "PH": "PHP", // Philippines - Philippine Peso
+
+    // Africa
+    "ZA": "ZAR", // South Africa - South African Rand
+    "NG": "NGN", // Nigeria - Nigerian Naira
+    "EG": "EGP", // Egypt - Egyptian Pound
+    "KE": "KES", // Kenya - Kenyan Shilling
+    "ET": "ETB", // Ethiopia - Ethiopian Birr
+
+    // Americas
+    "MX": "MXN", // Mexico - Mexican Peso
+    "AR": "ARS", // Argentina - Argentine Peso
+    "CL": "CLP", // Chile - Chilean Peso
+    "CO": "COP", // Colombia - Colombian Peso
+    "PE": "PEN", // Peru - Peruvian Sol
+
+    // Oceania
+    "FJ": "FJD", // Fiji - Fijian Dollar
+    "PG": "PGK", // Papua New Guinea - Papua New Guinean Kina
+
+    // Other
+    "SA": "SAR", // Saudi Arabia - Saudi Riyal
+    "RU": "RUB", // Russia - Russian Ruble
+    "BZ": "BZD", // Belize - Belize Dollar
 };
 
 const countryToCurrency = (country: string): string => {

--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -136,6 +136,7 @@ const countryToCurrencyMap = {
     "ID": "IDR", // Indonesia - Rupiah
     "HK": "HKD", // Hong Kong - Hong Kong Dollar,
     "NZ": "NZD", // New Zealand - New Zealand Dollar
+    "PH": "PHP", // Philippines - Philippine Peso
 };
 
 const countryToCurrency = (country: string): string => {


### PR DESCRIPTION
Another addition to the country -> currency mapping of the Feast Acquisition ongoing integration

Follow up of: https://github.com/guardian/mobile-purchases/pull/1734
