### PR TITLE
Register new product id for payment frequency map

### DIFF
--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -135,6 +135,7 @@ const storefrontToCountry = (storefront: string): string => {
 
 const productIdToPaymentFrequencyMap = {
     "uk.co.guardian.Feast.yearly" : "ANNUALLY",
+    "uk.co.guardain.Feast.yearly.discounted": "ANNUALLY",
     "uk.co.guardian.Feast.monthly": "MONTHLY",
     "uk.co.guardian.Feast.monthly.discounted": "MONTHLY",
 }


### PR DESCRIPTION
Feast acquisitions. Follow up of part 6.2 ( https://github.com/guardian/mobile-purchases/pull/1732 )