### PR TITLE
Add IL (Israel) to countryToCurrencyMap

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -136,6 +136,7 @@ const countryToCurrencyMap = {
 	SA: 'SAR', // Saudi Arabia - Saudi Riyal
 	RU: 'RUB', // Russia - Russian Ruble
 	BZ: 'BZD', // Belize - Belize Dollar
+	IL: 'ILS', // Israel - Israeli Shekel
 };
 
 const countryToCurrency = (country: string): string => {


### PR DESCRIPTION
Add Israel to the country to currency map for google feast acquisitions (follow up of https://github.com/guardian/mobile-purchases/pull/1713)