### PR TITLE
update storefront mapping

### DIFF
--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -129,6 +129,7 @@ const storefrontToCountryMap = {
   UKR: 'UA', // Ukraine
   VAT: 'VA', // Vatican City
   HKG: 'HK', // Hong Kong
+  JOR: 'JO', // Jordan
 };
 
 const storefrontToCountry = (storefront: string): string => {


### PR DESCRIPTION
Update Feast Apple storefront mapping. Follow up of https://github.com/guardian/mobile-purchases/pull/1732