### PR TITLE
Do not handle missing identityId in braze as an error

### DIFF
--- a/typescript/src/services/braze.ts
+++ b/typescript/src/services/braze.ts
@@ -5,9 +5,14 @@ function apiKeyForBraze(): Promise<string> {
   return getConfigValue<string>('braze-api-key');
 }
 
+export interface IdentityIdFromBraze {
+  // Optional because there are cases where no identity account exists for a user in Braze
+  identityId?: string;
+}
+
 export async function getIdentityIdFromBraze(
   externalId: string,
-): Promise<string> {
+): Promise<IdentityIdFromBraze> {
   const apiKey = await apiKeyForBraze();
 
   const params = {
@@ -29,11 +34,10 @@ export async function getIdentityIdFromBraze(
       const json = await response.json();
       const identityId = json?.users?.[0]?.custom_attributes?.identity_id;
       if (identityId) {
-        return identityId;
+        return { identityId };
       }
-      throw new Error(
-        `Response from Braze for Braze ID '${externalId}' did not contain an identity_id`,
-      );
+      console.log(`Response from Braze for Braze ID '${externalId}' did not contain an identity_id`);
+      return {};
     } else {
       throw new Error(
         'Received a non-ok response from Braze attempting to fetch user',


### PR DESCRIPTION
This is to address the alarm:

`mobile-purchases-PROD-FeastAppleSubscriptionDlqDepthAlarm-DpuQdAMu2yds has triggered!`

We sometimes have events that fail because no identity ID exists for a braze user. There is nothing we can do if this happens, so the lambda should just succeed at this point.

Example error:
`ERROR Unexpected error, will throw to retry: Error: Response from Braze for Braze ID '[UUID]' did not contain an identity_id at /var/task/feast-apple-update-subscriptions.js:2:675699`