### PR TITLE
increase acquisition retry time to 8 hours

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1479,7 +1479,7 @@ Resources:
             Stream:
               Fn::ImportValue: !Sub ${App}-${Stage}-user-subscriptions-stream-arn
             StartingPosition: LATEST
-            MaximumRetryAttempts: 10
+            MaximumRecordAgeInSeconds: 28800
       Tags:
         Stage: !Ref Stage
         Stack: !Ref Stack


### PR DESCRIPTION
We previously limited the retries to stop records retrying for ever in this PR https://github.com/guardian/mobile-purchases/pull/1588

However we recently had an outage due to credential issues, which was resolved but already some records were lost.

In the logs it appeared that there were only 10 retries over the course of a few minutes.

This PR updates it to retry for 8 hours, which should give us time to resolve a simple issue.

There's a good summary of the options available here (assuming it's an asynchronous invocation which I'm not sure about): https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-error-handling.html
