### PR TITLE
Adding an extra key to subscriptions (Part 2: more refactoring)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,6 +42,12 @@ applepubsub
     - AWS function (s): mobile-purchases-applepubsub-PROD
                       : mobile-purchases-applepubsub-CODE
 
+subscription-events-v2
+    - Dynamo table: mobile-purchases-PROD-subscription-events-v2
+
+subscriptions
+    - Dynamo table: mobile-purchases-PROD-subscriptions
+
 ```
 
 This pattern is repeated for the Apple and Google live apps, as well as Feast apps.
@@ -105,6 +111,9 @@ Deletions from the subscriptions table (triggered by the TTL being reached) trig
  ----------------------------------                                         ----------------------------------                         -------------------
                                                                                                                                       (membership account)
 
+subscriptions
+    - Dynamo table: mobile-purchases-PROD-subscriptions
+
 ```
 
 
@@ -159,6 +168,12 @@ The update-subscriptions lambdas push onto an SQS queue for each change and this
  ----------------------------------                      -------------------------------------------            ----                ------------------------------------
 | Dynamo Table: user-subscriptions | -----------------> | Lambda: export-user-subscription-table-v2 | ---------| S3 |------------> | datalake.mobile_user_subscriptions |
  ----------------------------------                      -------------------------------------------            ----                ------------------------------------
+
+subscription-events-v2
+    - Dynamo table: mobile-purchases-PROD-subscription-events-v2
+
+subscriptions
+    - Dynamo table: mobile-purchases-PROD-subscriptions
 
 ```
 

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -14,12 +14,12 @@ import type {
   AcquisitionApiPayload,
   AcquisitionApiPayloadQueryParameter,
 } from './common';
-import { appleSubscriptionToAppleStoreKitSubscriptionDataDerivation1 } from '../../services/api-storekit';
+import { appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline } from '../../services/api-storekit';
 
 const appleSubscriptionToAcquisitionApiPayload = async (
   subscription: Subscription,
 ): Promise<AcquisitionApiPayload> => {
-  const extendedData = await appleSubscriptionToAppleStoreKitSubscriptionDataDerivation1(subscription);
+  const extendedData = await appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline(subscription);
 
   console.log(
     `[12901310] acquisition api payload: ${JSON.stringify(extendedData)}`,

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -14,12 +14,12 @@ import type {
   AcquisitionApiPayload,
   AcquisitionApiPayloadQueryParameter,
 } from './common';
-import { appleSubscriptionToExtendedData } from '../../services/api-storekit';
+import { appleSubscriptionToAppleStoreKitSubscriptionDataDerivation1 } from '../../services/api-storekit';
 
 const appleSubscriptionToAcquisitionApiPayload = async (
   subscription: Subscription,
 ): Promise<AcquisitionApiPayload> => {
-  const extendedData = await appleSubscriptionToExtendedData(subscription);
+  const extendedData = await appleSubscriptionToAppleStoreKitSubscriptionDataDerivation1(subscription);
 
   console.log(
     `[12901310] acquisition api payload: ${JSON.stringify(extendedData)}`,

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -33,7 +33,7 @@ export interface AppleStoreKitSubscriptionData {
 }
 
 // AppleStoreKitSubscriptionDataDerivation1 is derived from AppleStoreKitSubscriptionData
-export interface AppleStoreKitSubscriptionDataDerivation1 {
+export interface AppleStoreKitSubscriptionDataDerivationForFeastPipeline {
   transactionId: string;
   country: string; // country as two letter code
   currency: string; // currency as three letter code
@@ -174,9 +174,9 @@ const appleSubscriptionToOriginalTransactionId = (subscription: Subscription): s
   return transactionId;
 } 
 
-export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivation1 = async (
+export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline = async (
     subscription: Subscription,
-): Promise<AppleStoreKitSubscriptionDataDerivation1> => {
+): Promise<AppleStoreKitSubscriptionDataDerivationForFeastPipeline> => {
   /*
       This function takes a Subscription and returns a derivation of 
       the data that is retrieved from the Apple API

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -3,10 +3,37 @@ import { forgeStoreKitBearerToken } from './apple-json-web-tokens';
 import { productIdToPaymentFrequency, storefrontToCountry } from './apple-mappings';
 const jwt = require('jsonwebtoken');
 
-// AppleExtendedData is built from the answer from
+// AppleSubscriptionData is built from the answer from
 // https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/{transactionId}
 // and contains information that are required to build an AcquisitionApiPayload
-export interface AppleExtendedData {
+
+export interface AppleStoreKitSubscriptionData {
+  transactionId: string,
+  originalTransactionId: string,
+  webOrderLineItemId: string,
+  bundleId: string,
+  productId: string,
+  subscriptionGroupIdentifier: string,
+  purchaseDate: number,
+  originalPurchaseDate: number,
+  expiresDate: number,
+  quantity: number,
+  type: string,
+  appAccountToken: string,
+  inAppOwnershipType: string,
+  signedDate: number,
+  offerType: number,
+  environment: string,
+  transactionReason: string,
+  storefront: string,
+  storefrontId: string,
+  price: number,
+  currency: string,
+  offerDiscountType: string
+}
+
+// AppleStoreKitSubscriptionDataDerivation1 is derived from AppleStoreKitSubscriptionData
+export interface AppleStoreKitSubscriptionDataDerivation1 {
   transactionId: string;
   country: string; // country as two letter code
   currency: string; // currency as three letter code
@@ -24,30 +51,7 @@ interface AppleLatestReceiptInfoItem {
 }
 type AppleLatestReceiptInfo = AppleLatestReceiptInfoItem[];
 
-interface AppleTransactionQueryResponse {
-  transactionId: string;
-  productId: string; // from which we are going to derive the paymentFrequency
-  storefront: string; // storefront seems to be the country as three letter code
-  currency: string; // currency as three letter code
-}
-
-export const appleSubscriptionToExtendedData = async (
-    subscription: Subscription,
-): Promise<AppleExtendedData> => {
-  /*
-        This function takes a Subscription and return the extra data that is retrieved from the Apple API
-        at https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/{transactionId}
-    */
-
-  console.log(`[940dc079] ${new Date()}`);
-
-  // This extraction will be abstracted in a function in a coming refactoring
-  const latest_receipt_info = subscription.applePayload?.latest_receipt_info as AppleLatestReceiptInfo;
-  if (latest_receipt_info.length === 0) {
-    throw new Error('[3b5a2b0d] latest_receipt_info is empty');
-  }
-  const transactionId = latest_receipt_info[0].transaction_id;
-
+export const transactionIdToAppleStoreKitSubscriptionData = async (transactionId: string): Promise<AppleStoreKitSubscriptionData> => {
   console.log(`[116fa7d4] transactionId: ${transactionId}`);
 
   const url = `https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/${transactionId}`;
@@ -128,55 +132,105 @@ export const appleSubscriptionToExtendedData = async (
 
   console.log(`[c5dabbcc] ${signedTransactionInfo}`);
 
-  const data1 = jwt.decode(signedTransactionInfo);
+  const data1 = jwt.decode(signedTransactionInfo) as AppleStoreKitSubscriptionData;
 
-  console.log(`[7f53de39] data1: ${JSON.stringify(data1)}`);
+  /* 
+  sanitized version:
+  {
+    "transactionId": "220002344001105",
+    "originalTransactionId": "220002344001105",
+    "webOrderLineItemId": "220001000009784",
+    "bundleId": "uk.co.guardian.Feast",
+    "productId": "uk.co.guardian.Feast.monthly",
+    "subscriptionGroupIdentifier": "21396030",
+    "purchaseDate": 1732526628000,
+    "originalPurchaseDate": 1732526630000,
+    "expiresDate": 1733736228000,
+    "quantity": 1,
+    "type": "Auto-Renewable Subscription",
+    "appAccountToken": "51f7092f-8b2d-0000-86b5-60352eb62d8e",
+    "inAppOwnershipType": "PURCHASED",
+    "signedDate": 1735899829949,
+    "offerType": 1,
+    "environment": "Production",
+    "transactionReason": "PURCHASE",
+    "storefront": "GBR",
+    "storefrontId": "143444",
+    "price": 0,
+    "currency": "GBP",
+    "offerDiscountType": "FREE_TRIAL"
+  }
+  */
 
-  // At this point we need to transform the signedTransactionInfo into a JSON object: a AppleTransactionQueryResponse
+  return Promise.resolve(data1);
+}
+
+const appleSubscriptionToOriginalTransactionId = (subscription: Subscription): string => {
+  const latest_receipt_info = subscription.applePayload?.latest_receipt_info as AppleLatestReceiptInfo;
+  if (latest_receipt_info.length === 0) {
+    throw new Error('[3b5a2b0d] latest_receipt_info is empty');
+  }
+  const transactionId = latest_receipt_info[0].transaction_id;
+  return transactionId;
+} 
+
+export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivation1 = async (
+    subscription: Subscription,
+): Promise<AppleStoreKitSubscriptionDataDerivation1> => {
+  /*
+      This function takes a Subscription and returns a derivation of 
+      the data that is retrieved from the Apple API
+      at https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/{transactionId}
+  */
+
+  console.log(`[940dc079] ${new Date()}`);
+
+  const transactionId = appleSubscriptionToOriginalTransactionId(subscription);
+
+  const appleStoreKitSubscriptionData: AppleStoreKitSubscriptionData = await transactionIdToAppleStoreKitSubscriptionData(transactionId);
+
+  console.log(`[7f53de39] appleStoreKitSubscriptionData: ${JSON.stringify(appleStoreKitSubscriptionData)}`);
+
+  const country = storefrontToCountry(appleStoreKitSubscriptionData.storefront);
+  const currency = appleStoreKitSubscriptionData.currency;
+  const paymentFrequency = productIdToPaymentFrequency(appleStoreKitSubscriptionData.productId);
 
   /*
-        payload (anonymized) from the answer
+      appleSubscriptionData (anonymized)
+      {
+          "transactionId": "2200001105",
+          "originalTransactionId": "2200001105",
+          "webOrderLineItemId": "22048309784",
+          "bundleId": "uk.co.guardian.Feast",
+          "productId": "uk.co.guardian.Feast.monthly",
+          "subscriptionGroupIdentifier": "21396030",
+          "purchaseDate": 1732526628000,
+          "originalPurchaseDate": 1732526630000,
+          "expiresDate": 1733736228000,
+          "quantity": 1,
+          "type": "Auto-Renewable Subscription",
+          "appAccountToken": "3b70e18e-de6c-46a8-83b5-3e317d6c7b84",
+          "inAppOwnershipType": "PURCHASED",
+          "signedDate": 1735899829949,
+          "offerType": 1,
+          "environment": "Production",
+          "transactionReason": "PURCHASE",
+          "storefront": "GBR",
+          "storefrontId": "143444",
+          "price": 0,
+          "currency": "GBP",
+          "offerDiscountType": "FREE_TRIAL"
+      }
 
-        {
-            "transactionId": "2200001105",
-            "originalTransactionId": "2200001105",
-            "webOrderLineItemId": "22048309784",
-            "bundleId": "uk.co.guardian.Feast",
-            "productId": "uk.co.guardian.Feast.monthly",
-            "subscriptionGroupIdentifier": "21396030",
-            "purchaseDate": 1732526628000,
-            "originalPurchaseDate": 1732526630000,
-            "expiresDate": 1733736228000,
-            "quantity": 1,
-            "type": "Auto-Renewable Subscription",
-            "appAccountToken": "3b70e18e-de6c-46a8-83b5-3e317d6c7b84",
-            "inAppOwnershipType": "PURCHASED",
-            "signedDate": 1735899829949,
-            "offerType": 1,
-            "environment": "Production",
-            "transactionReason": "PURCHASE",
-            "storefront": "GBR",
-            "storefrontId": "143444",
-            "price": 0,
-            "currency": "GBP",
-            "offerDiscountType": "FREE_TRIAL"
-        }
+      Sample of AppleStoreKitSubscriptionDataDerivation1 
+      {
+          "transactionId": "2200001105",
+          "productId": "uk.co.guardian.Feast.monthly",
+          "storefront": "GBR",
+          "currency": "GBP",
+      }
+  */
 
-        Sample of AppleTransactionQueryResponse {
-            "transactionId": "2200001105",
-            "productId": "uk.co.guardian.Feast.monthly",
-            "storefront": "GBR",
-            "currency": "GBP",
-        }
-
-    */
-
-  const appleResponse: AppleTransactionQueryResponse =
-    data1 as AppleTransactionQueryResponse;
-
-  const country = storefrontToCountry(appleResponse.storefront);
-  const currency = appleResponse.currency;
-  const paymentFrequency = productIdToPaymentFrequency(appleResponse.productId);
   return {
     transactionId,
     country,

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -3,7 +3,7 @@ import { forgeStoreKitBearerToken } from './apple-json-web-tokens';
 import { productIdToPaymentFrequency, storefrontToCountry } from './apple-mappings';
 const jwt = require('jsonwebtoken');
 
-// AppleSubscriptionData is built from the answer from
+// AppleStoreKitSubscriptionData is built from the answer from
 // https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/{transactionId}
 // and contains information that are required to build an AcquisitionApiPayload
 
@@ -32,7 +32,7 @@ export interface AppleStoreKitSubscriptionData {
   offerDiscountType: string
 }
 
-// AppleStoreKitSubscriptionDataDerivation1 is derived from AppleStoreKitSubscriptionData
+// AppleStoreKitSubscriptionDataDerivationForFeastPipeline is derived from AppleStoreKitSubscriptionData
 export interface AppleStoreKitSubscriptionDataDerivationForFeastPipeline {
   transactionId: string;
   country: string; // country as two letter code
@@ -222,7 +222,7 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
           "offerDiscountType": "FREE_TRIAL"
       }
 
-      Sample of AppleStoreKitSubscriptionDataDerivation1 
+      Sample of AppleStoreKitSubscriptionDataDerivationForFeastPipeline
       {
           "transactionId": "2200001105",
           "productId": "uk.co.guardian.Feast.monthly",


### PR DESCRIPTION
Previous step: https://github.com/guardian/mobile-purchases/pull/1820

In this step: 
- We rename `AppleExtendedData` to the more accurately descriptive `AppleStoreKitSubscriptionDataDerivationForFeastPipeline`
- We introduce `AppleStoreKitSubscriptionData` to represent the data we get from StoreKit.
- We split functions into their basic components and in particular it is now clearly visible that `AppleStoreKitSubscriptionDataDerivationForFeastPipeline` is derived from a `AppleStoreKitSubscriptionData`.
- The function `transactionIdToAppleStoreKitSubscriptionData` is now the center of action as it just takes a `transactionId` and returns a StoreKit data, which is the signature we need for the next step. 

