### PR TITLE
Adding an extra key to subscriptions (Part 3: upgrade SubscriptionEvent)

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -457,6 +457,13 @@ Resources:
         Stage: !Ref Stage
         Stack: !Ref Stack
         App: !Ref App
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}/${Stack}/*
+
 
   GoogleLinkUserToSubLambda:
     Type: AWS::Serverless::Function
@@ -673,6 +680,12 @@ Resources:
         Stage: !Ref Stage
         Stack: !Ref Stack
         App: !Ref App
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}/${Stack}/*
 
   GoogleSubscriptionsQueue:
     Type: AWS::SQS::Queue

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,6 +42,10 @@ applepubsub
     - AWS function (s): mobile-purchases-applepubsub-PROD
                       : mobile-purchases-applepubsub-CODE
 
+apple-subscriptions-to-fetch
+    - code: src/update-subs/apple.ts
+    - AWS function (s): mobile-purchases-apple-update-subscriptions-PROD
+
 subscription-events-v2
     - Dynamo table: mobile-purchases-PROD-subscription-events-v2
 

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -121,7 +121,7 @@ const processSQSRecord = async (record: SQSRecord): Promise<void> => {
   );
   const promises = appleValidationResponses.map(
     async (appleValidationResponse) => {
-      const appleSubscription: Subscription = toAppleSubscription(
+      const appleSubscription: Subscription = await toAppleSubscription(
         appleValidationResponse,
       );
       console.log(

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -14,12 +14,17 @@ import type {
   AcquisitionApiPayload,
   AcquisitionApiPayloadQueryParameter,
 } from './common';
-import { appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline } from '../../services/api-storekit';
+import { AppleStoreKitSubscriptionDataDerivationForFeastPipeline, appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline } from '../../services/api-storekit';
 
 const appleSubscriptionToAcquisitionApiPayload = async (
   subscription: Subscription,
 ): Promise<AcquisitionApiPayload> => {
-  const extendedData = await appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline(subscription);
+  const extendedData: AppleStoreKitSubscriptionDataDerivationForFeastPipeline | null = await appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline(subscription);
+
+  if (extendedData === null) {
+    console.log(`[f57be98c] could not extract extendedData for subscription`);
+    throw new Error("[1504e11c] could not extract extendedData for subscription");
+  }
 
   console.log(
     `[12901310] acquisition api payload: ${JSON.stringify(extendedData)}`,

--- a/typescript/src/feast/pubsub/apple.ts
+++ b/typescript/src/feast/pubsub/apple.ts
@@ -12,17 +12,18 @@ import { dynamoMapper, sendToSqs } from '../../utils/aws';
 const defaultLogRequest = (request: APIGatewayProxyEvent): void =>
   console.log(`[34ef7aa3] ${JSON.stringify(request)}`);
 
-const defaultStoreEventInDynamo = (
+const defaultStoreEventInDynamo = async (
   event: StatusUpdateNotification,
 ): Promise<void> => {
   console.log(`[286bdcb5] event: ${JSON.stringify(event)}`);
-  const item = toDynamoEvent(event, true);
+  const item = await toDynamoEvent(event, true);
   console.log(`[22227627] item: ${JSON.stringify(item)}`);
   if (JSON.stringify(item) === '{}') {
     // Temporary measure while investigating permission problem
     return Promise.resolve(undefined);
   }
-  return dynamoMapper.put({ item }).then((_) => undefined);
+  const _ = await dynamoMapper.put({ item });
+  return undefined;
 };
 
 export function buildHandler(

--- a/typescript/src/feast/pubsub/apple.ts
+++ b/typescript/src/feast/pubsub/apple.ts
@@ -15,7 +15,9 @@ const defaultLogRequest = (request: APIGatewayProxyEvent): void =>
 const defaultStoreEventInDynamo = (
   event: StatusUpdateNotification,
 ): Promise<void> => {
+  console.log(`[286bdcb5] event: ${JSON.stringify(event)}`);
   const item = toDynamoEvent(event, true);
+  console.log(`[22227627] item: ${JSON.stringify(item)}`);
   return dynamoMapper.put({ item }).then((_) => undefined);
 };
 

--- a/typescript/src/feast/pubsub/apple.ts
+++ b/typescript/src/feast/pubsub/apple.ts
@@ -18,6 +18,10 @@ const defaultStoreEventInDynamo = (
   console.log(`[286bdcb5] event: ${JSON.stringify(event)}`);
   const item = toDynamoEvent(event, true);
   console.log(`[22227627] item: ${JSON.stringify(item)}`);
+  if (JSON.stringify(item) === '{}') {
+    // Temporary measure while investigating permission problem
+    return Promise.resolve(undefined);
+  }
   return dynamoMapper.put({ item }).then((_) => undefined);
 };
 

--- a/typescript/src/feast/pubsub/apple.ts
+++ b/typescript/src/feast/pubsub/apple.ts
@@ -15,7 +15,7 @@ const defaultLogRequest = (request: APIGatewayProxyEvent): void =>
 const defaultStoreEventInDynamo = (
   event: StatusUpdateNotification,
 ): Promise<void> => {
-  const item = toDynamoEvent(event);
+  const item = toDynamoEvent(event, true);
   return dynamoMapper.put({ item }).then((_) => undefined);
 };
 

--- a/typescript/src/feast/pubsub/google.ts
+++ b/typescript/src/feast/pubsub/google.ts
@@ -60,7 +60,7 @@ export function buildHandler(
         }
 
         const metaData = await fetchMetadata(notification);
-        const dynamoEvent = toDynamoEvent(notification, metaData);
+        const dynamoEvent = await toDynamoEvent(notification, metaData);
 
         await Promise.all([
           sendMessageToSqs(queueUrl, androidSubscriptionReference),

--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -37,17 +37,19 @@ export const defaultFetchSubscriptionsFromApple = async (
     { sandboxRetry: false },
     App.Feast,
   );
-  return responses.map((response) => {
-    const subscription = toAppleSubscription(response);
-    if (response.latestReceiptInfo.appAccountToken) {
-      return withAppAccountToken(
-        subscription,
-        response.latestReceiptInfo.appAccountToken,
-      );
-    } else {
-      return subscription;
-    }
-  });
+  return Promise.all(
+    responses.map(async (response) => {
+      const subscription = await toAppleSubscription(response);
+      if (response.latestReceiptInfo.appAccountToken) {
+        return withAppAccountToken(
+          subscription,
+          response.latestReceiptInfo.appAccountToken,
+        );
+      } else {
+        return subscription;
+      }
+    }),
+  );
 };
 
 const defaultStoreSubscriptionInDynamo = (

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -1,6 +1,7 @@
 import { DynamoDbTable } from '@aws/dynamodb-data-mapper';
 import { attribute, hashKey } from '@aws/dynamodb-data-mapper-annotations';
 import { App, Stage } from '../utils/appIdentity';
+import { AppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
 export class Subscription {
   /*
@@ -49,6 +50,9 @@ export class Subscription {
   @attribute()
   ttl?: number;
 
+  @attribute()
+  extra: string | undefined;
+
   tableName: string;
 
   constructor(
@@ -65,6 +69,7 @@ export class Subscription {
     receipt?: string,
     applePayload?: any,
     ttl?: number,
+    extra?: string | undefined,
     tableName = 'subscriptions',
   ) {
     this.subscriptionId = subscriptionId;
@@ -80,6 +85,7 @@ export class Subscription {
     this.receipt = receipt;
     this.applePayload = applePayload;
     this.ttl = ttl;
+    this.extra = extra;
     this.tableName = tableName;
   }
 
@@ -97,7 +103,23 @@ export class Subscription {
 
 export class SubscriptionEmpty extends Subscription {
   constructor() {
-    super('', '', '', undefined, false, '', undefined, undefined, undefined);
+    super(
+        '', // subscriptionId
+        '', // startTimestamp
+        '', // endTimestamp
+        undefined, // cancellationTimestamp
+        false, // autoRenewing
+        '', // productId
+        undefined, // platform
+        undefined, // freeTrial
+        undefined, // billingPeriod
+        undefined, // googlePayload
+        undefined, // receipt
+        undefined, // applePayload
+        undefined, // ttl
+        undefined, // extra
+        '' , // tableName
+      );
   }
 
   setSubscriptionId(subscriptionId: string): SubscriptionEmpty {

--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -41,7 +41,7 @@ export class SubscriptionEvent {
   @attribute()
   expires_date_ms: number;
   @attribute()
-  extra: AppleStoreKitSubscriptionDataDerivationForExtra | null;
+  extra: string | null;
 
   constructor(
     subscriptionId: string,
@@ -60,7 +60,7 @@ export class SubscriptionEvent {
     product_id: any,
     purchase_date_ms: any,
     expires_date_ms: any,
-    extra: AppleStoreKitSubscriptionDataDerivationForExtra | null,
+    extra: string| null,
   ) {
     this.subscriptionId = subscriptionId;
     this.timestampAndType = timestampAndType;

--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -60,7 +60,7 @@ export class SubscriptionEvent {
     product_id: any,
     purchase_date_ms: any,
     expires_date_ms: any,
-    extra: string| null,
+    extra: string | null,
   ) {
     this.subscriptionId = subscriptionId;
     this.timestampAndType = timestampAndType;

--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -5,6 +5,7 @@ import {
   rangeKey,
 } from '@aws/dynamodb-data-mapper-annotations';
 import { App, Stage } from '../utils/appIdentity';
+import { AppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
 export class SubscriptionEvent {
   @hashKey()
@@ -39,6 +40,8 @@ export class SubscriptionEvent {
   purchase_date_ms: number;
   @attribute()
   expires_date_ms: number;
+  @attribute()
+  extra: AppleStoreKitSubscriptionDataDerivationForExtra | null;
 
   constructor(
     subscriptionId: string,
@@ -57,6 +60,7 @@ export class SubscriptionEvent {
     product_id: any,
     purchase_date_ms: any,
     expires_date_ms: any,
+    extra: AppleStoreKitSubscriptionDataDerivationForExtra | null,
   ) {
     this.subscriptionId = subscriptionId;
     this.timestampAndType = timestampAndType;
@@ -74,6 +78,7 @@ export class SubscriptionEvent {
     this.product_id = product_id;
     this.purchase_date_ms = purchase_date_ms;
     this.expires_date_ms = expires_date_ms;
+    this.extra = extra;
   }
 
   get [DynamoDbTable]() {
@@ -83,6 +88,24 @@ export class SubscriptionEvent {
 
 export class SubscriptionEventEmpty extends SubscriptionEvent {
   constructor() {
-    super('', '', '', '', '', '', '', undefined, {}, {}, 0, '', '', '', 0, 0);
+    super(
+      '', // subscriptionId
+      '', // timestampAndType
+      '', // date
+      '', // timestamp
+      '', // eventType
+      '', // platform
+      '', // appId
+      undefined, // freeTrial
+      {}, // googlePayload
+      {}, // applePayload
+      0, // ttl
+      '', // promotional_offer_id
+      '', // promotional_offer_name
+      '', // product_id
+      0, // purchase_date_ms
+      0, // expires_date_ms
+      null // extra
+    );
   }
 }

--- a/typescript/src/pubsub/apple-common.ts
+++ b/typescript/src/pubsub/apple-common.ts
@@ -39,7 +39,7 @@ export interface UnifiedReceiptInfo {
 
 export interface StatusUpdateNotification {
   environment: string;
-  bid: string;
+  bid: string; // bundle Id
   bvrs: string;
   notification_type: string;
   password?: string;

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -68,9 +68,11 @@ export async function toDynamoEvent(
   }
   
   const appBundleId = notification.bid;
+  console.log(`[9b648812] appBundleId: ${appBundleId}`);
   const extra1: AppleStoreKitSubscriptionDataDerivationForExtra | null = await conditionallyBuildExtra(appBundleId, original_transaction_id, shouldBuildExtra);
+  console.log(`[5d661829] extra1: ${extra1}`);
   const extra2 = JSON.stringify(extra1);
-  console.log(`[0165ec6d] extra: ${extra2}`);
+  console.log(`[0165ec6d] extra2: ${extra2}`);
 
   const subscriptionEvent = new SubscriptionEvent(
     original_transaction_id,

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -67,7 +67,7 @@ export async function toDynamoEvent(
     }
   }
   
-  const extra1 = await conditionallyBuildExtra(original_transaction_id, shouldBuildExtra);
+  const extra1: AppleStoreKitSubscriptionDataDerivationForExtra | null = await conditionallyBuildExtra(original_transaction_id, shouldBuildExtra);
   const extra2 = JSON.stringify(extra1);
   console.log(`[0165ec6d] extra: ${extra2}`);
 

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -59,15 +59,16 @@ export async function toDynamoEvent(
 
   const original_transaction_id = receiptsInOrder[0].original_transaction_id;
 
-  const conditionallyBuildExtra = async (original_transaction_id: string, shouldBuildExtra: boolean): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
+  const conditionallyBuildExtra = async (appBundleId: string, original_transaction_id: string, shouldBuildExtra: boolean): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
     if (shouldBuildExtra) {
-      return await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(original_transaction_id);
+      return await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(appBundleId, original_transaction_id);
     } else {
       return Promise.resolve(null);
     }
   }
   
-  const extra1: AppleStoreKitSubscriptionDataDerivationForExtra | null = await conditionallyBuildExtra(original_transaction_id, shouldBuildExtra);
+  const appBundleId = notification.bid;
+  const extra1: AppleStoreKitSubscriptionDataDerivationForExtra | null = await conditionallyBuildExtra(appBundleId, original_transaction_id, shouldBuildExtra);
   const extra2 = JSON.stringify(extra1);
   console.log(`[0165ec6d] extra: ${extra2}`);
 

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -8,7 +8,7 @@ import { dateToSecondTimestamp, thirtyMonths } from '../utils/dates';
 import type { StatusUpdateNotification } from './apple-common';
 import { parsePayload } from './apple-common';
 import { parseStoreAndSend } from './pubsub';
-import { AppleStoreKitSubscriptionDataDerivationForExtra, transactionIdToAppleStoreKitSubscriptionDataDerivation2 } from '../services/api-storekit';
+import { AppleStoreKitSubscriptionDataDerivationForExtra, transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
 export async function toDynamoEvent(
   notification: StatusUpdateNotification,
@@ -61,7 +61,7 @@ export async function toDynamoEvent(
 
   const conditionallyBuildExtra = async (original_transaction_id: string, shouldBuildExtra: boolean): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
     if (shouldBuildExtra) {
-      return await transactionIdToAppleStoreKitSubscriptionDataDerivation2(original_transaction_id);
+      return await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(original_transaction_id);
     } else {
       return Promise.resolve(null);
     }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -10,6 +10,15 @@ import { parsePayload } from './apple-common';
 import { parseStoreAndSend } from './pubsub';
 import { AppleStoreKitSubscriptionDataDerivationForExtra, transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
+const conditionallyBuildExtra = async (appBundleId: string, original_transaction_id: string, shouldBuildExtra: boolean): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
+  console.log(`[fd84c952] appBundleId: ${appBundleId}, original_transaction_id: ${original_transaction_id}, shouldBuildExtra: ${shouldBuildExtra}`);
+  if (shouldBuildExtra) {
+    return await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(appBundleId, original_transaction_id);
+  } else {
+    return Promise.resolve(null);
+  }
+}
+
 export async function toDynamoEvent(
   notification: StatusUpdateNotification,
   shouldBuildExtra: boolean,
@@ -58,15 +67,6 @@ export async function toDynamoEvent(
   }
 
   const original_transaction_id = receiptsInOrder[0].original_transaction_id;
-
-  const conditionallyBuildExtra = async (appBundleId: string, original_transaction_id: string, shouldBuildExtra: boolean): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
-    console.log(`[fd84c952] appBundleId: ${appBundleId}, original_transaction_id: ${original_transaction_id}, shouldBuildExtra: ${shouldBuildExtra}`);
-    if (shouldBuildExtra) {
-      return await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(appBundleId, original_transaction_id);
-    } else {
-      return Promise.resolve(null);
-    }
-  }
   
   const appBundleId = notification.bid;
   console.log(`[9b648812] appBundleId: ${appBundleId}`);

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -60,6 +60,7 @@ export async function toDynamoEvent(
   const original_transaction_id = receiptsInOrder[0].original_transaction_id;
 
   const conditionallyBuildExtra = async (appBundleId: string, original_transaction_id: string, shouldBuildExtra: boolean): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
+    console.log(`[fd84c952] appBundleId: ${appBundleId}, original_transaction_id: ${original_transaction_id}, shouldBuildExtra: ${shouldBuildExtra}`);
     if (shouldBuildExtra) {
       return await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(appBundleId, original_transaction_id);
     } else {

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -67,7 +67,9 @@ export async function toDynamoEvent(
     }
   }
   
-  const extra = await conditionallyBuildExtra(original_transaction_id, shouldBuildExtra);
+  const extra1 = await conditionallyBuildExtra(original_transaction_id, shouldBuildExtra);
+  const extra2 = JSON.stringify(extra1);
+  console.log(`[0165ec6d] extra: ${extra2}`);
 
   const subscriptionEvent = new SubscriptionEvent(
     original_transaction_id,
@@ -86,7 +88,7 @@ export async function toDynamoEvent(
     notification.product_id, // SubscriptionEvent.product_id
     notification.purchase_date_ms, // SubscriptionEvent.purchase_date_ms
     notification.expires_date_ms, // SubscriptionEvent.expires_date_ms
-    extra,
+    extra2,
   );
 
   return Promise.resolve(subscriptionEvent);

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -147,10 +147,10 @@ export async function fetchMetadata(
   }
 }
 
-export function toDynamoEvent(
+export async function toDynamoEvent(
   notification: SubscriptionNotification,
   metaData?: GoogleSubscriptionMetaData,
-): SubscriptionEvent {
+): Promise<SubscriptionEvent> {
   const eventTime = optionalMsToDate(notification.eventTimeMillis);
   if (!eventTime) {
     // this is tested while parsing the payload in order to return HTTP 400 early.
@@ -186,6 +186,7 @@ export function toDynamoEvent(
     undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
     undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
     undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
+    null,
   );
 }
 

--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -31,7 +31,7 @@ function storeInDynamoImpl(
 export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
   request: APIGatewayProxyEvent,
   parsePayload: (body: Option<string>) => Payload | Ignorable | Error,
-  toDynamoEvent: (payload: Payload, metaData?: MetaData) => SubscriptionEvent,
+  toDynamoEvent: (payload: Payload, metaData?: MetaData) => Promise<SubscriptionEvent>,
   toSqsEvent: (payload: Payload) => SqsEvent,
   fetchMetadata: (payload: Payload) => Promise<MetaData | undefined>,
   storeInDynamo: (
@@ -65,7 +65,7 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
       }
 
       const metaData = await fetchMetadata(notification);
-      const dynamoEvent = toDynamoEvent(notification, metaData);
+      const dynamoEvent = await toDynamoEvent(notification, metaData);
       const dynamoPromise = storeInDynamo(dynamoEvent);
       const sqsEvent = toSqsEvent(notification);
       const sqsPromise = sendToSqsFunction(queueUrl, sqsEvent);

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -61,13 +61,12 @@ interface AppleLatestReceiptInfoItem {
 type AppleLatestReceiptInfo = AppleLatestReceiptInfoItem[];
 
 export const transactionIdToAppleStoreKitSubscriptionData = async (appBundleId: string, transactionId: string): Promise<AppleStoreKitSubscriptionData | null> => {
-  console.log(`[116fa7d4] transactionId: ${transactionId}`);
+  console.log(`[116fa7d4] appBundleId: ${appBundleId}, transactionId: ${transactionId}`);
 
   const url = `https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/${transactionId}`;
   console.log(`[5330931d] url: ${url}`);
 
   const token = await forgeStoreKitBearerToken(appBundleId);
-
   console.log(`[f1335718] ${token}`);
 
   const params = {

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -32,7 +32,7 @@ export interface AppleStoreKitSubscriptionData {
   offerDiscountType: string
 }
 
-// AppleStoreKitSubscriptionDataDerivation1 is derived from AppleStoreKitSubscriptionData
+// AppleStoreKitSubscriptionDataDerivationForFeastPipeline is derived from AppleStoreKitSubscriptionData
 export interface AppleStoreKitSubscriptionDataDerivationForFeastPipeline {
   transactionId: string;
   country: string; // country as two letter code
@@ -46,7 +46,7 @@ export interface AppleStoreKitSubscriptionDataDerivationForFeastPipeline {
   // "ANNUALLY"
 }
 
-// AppleStoreKitSubscriptionDataDerivation1 is derived from AppleStoreKitSubscriptionData
+// AppleStoreKitSubscriptionDataDerivationForExtra is derived from AppleStoreKitSubscriptionData
 // Was originally introduced as part of adding an extra key to SubscriptionEvent and AppleSubscription
 // That are sent to the Lake.
 // The only difference with AppleStoreKitSubscriptionData is that for safety and forward compatibility
@@ -230,7 +230,7 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
           "offerDiscountType": "FREE_TRIAL"
       }
 
-      Sample of AppleStoreKitSubscriptionDataDerivation1 
+      Sample of AppleStoreKitSubscriptionDataDerivationForExtra
       {
           "transactionId": "2200001105",
           "productId": "uk.co.guardian.Feast.monthly",
@@ -249,7 +249,7 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
 
 export const transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra = async (transactionId: string): Promise<AppleStoreKitSubscriptionDataDerivationForExtra> => {
   // This function builds a AppleStoreKitSubscriptionData, and just adds the guVersion key to make it a 
-  // AppleStoreKitSubscriptionDataDerivation2
+  // AppleStoreKitSubscriptionDataDerivationForExtra
   const data1: AppleStoreKitSubscriptionData = await transactionIdToAppleStoreKitSubscriptionData(transactionId);
   const data2: AppleStoreKitSubscriptionDataDerivationForExtra = {
     guType: "apple-extra-2025-04-29",

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -258,11 +258,10 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
   };
 };
 
-export const transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra = async (transactionId: string): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
+export const transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra = async (appBundleId: string, transactionId: string): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
   // This function builds a AppleStoreKitSubscriptionData, and just adds the guType key to make it a 
   // AppleStoreKitSubscriptionDataDerivationForExtra
 
-  const appBundleId = "uk.co.guardian.iphone2";
   const data1: AppleStoreKitSubscriptionData | null = await transactionIdToAppleStoreKitSubscriptionData(appBundleId, transactionId);
   if (data1 === null) {
     return Promise.resolve(null);

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -46,6 +46,38 @@ export interface AppleStoreKitSubscriptionDataDerivationForFeastPipeline {
   // "ANNUALLY"
 }
 
+// AppleStoreKitSubscriptionDataDerivation1 is derived from AppleStoreKitSubscriptionData
+// Was originally introduced as part of adding an extra key to SubscriptionEvent and AppleSubscription
+// That are sent to the Lake.
+// The only difference with AppleStoreKitSubscriptionData is that for safety and forward compatibility
+// we introduce a guVersion, which is going to be incremented if there is any non backward compatible 
+// change in that structure. 
+export interface AppleStoreKitSubscriptionDataDerivationForExtra {
+  guVersion: "2025-04-29", // Doesn't matter what the value is as long as it's unambiguous, doesn't change, and if changing it increases.
+  transactionId: string,
+  originalTransactionId: string,
+  webOrderLineItemId: string,
+  bundleId: string,
+  productId: string,
+  subscriptionGroupIdentifier: string,
+  purchaseDate: number,
+  originalPurchaseDate: number,
+  expiresDate: number,
+  quantity: number,
+  type: string,
+  appAccountToken: string,
+  inAppOwnershipType: string,
+  signedDate: number,
+  offerType: number,
+  environment: string,
+  transactionReason: string,
+  storefront: string,
+  storefrontId: string,
+  price: number,
+  currency: string,
+  offerDiscountType: string
+}
+
 interface AppleLatestReceiptInfoItem {
   transaction_id: string;
 }
@@ -238,3 +270,14 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
     paymentFrequency,
   };
 };
+
+export const transactionIdToAppleStoreKitSubscriptionDataDerivation2 = async (transactionId: string): Promise<AppleStoreKitSubscriptionDataDerivationForExtra> => {
+  // This function builds a AppleStoreKitSubscriptionData, and just adds the guVersion key to make it a 
+  // AppleStoreKitSubscriptionDataDerivation2
+  const data1: AppleStoreKitSubscriptionData = await transactionIdToAppleStoreKitSubscriptionData(transactionId);
+  const data2: AppleStoreKitSubscriptionDataDerivationForExtra = {
+    guVersion: "2025-04-29",
+    ...data1
+  }
+  return Promise.resolve(data2)
+}

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -52,31 +52,7 @@ export interface AppleStoreKitSubscriptionDataDerivationForFeastPipeline {
 // The only difference with AppleStoreKitSubscriptionData is that for safety and forward compatibility
 // we introduce a guVersion, which is going to be incremented if there is any non backward compatible 
 // change in that structure. 
-export interface AppleStoreKitSubscriptionDataDerivationForExtra {
-  guType: "apple-extra-2025-04-29",
-  transactionId: string,
-  originalTransactionId: string,
-  webOrderLineItemId: string,
-  bundleId: string,
-  productId: string,
-  subscriptionGroupIdentifier: string,
-  purchaseDate: number,
-  originalPurchaseDate: number,
-  expiresDate: number,
-  quantity: number,
-  type: string,
-  appAccountToken: string,
-  inAppOwnershipType: string,
-  signedDate: number,
-  offerType: number,
-  environment: string,
-  transactionReason: string,
-  storefront: string,
-  storefrontId: string,
-  price: number,
-  currency: string,
-  offerDiscountType: string
-}
+export type AppleStoreKitSubscriptionDataDerivationForExtra = AppleStoreKitSubscriptionData & {  guType: "apple-extra-2025-04-29" }
 
 interface AppleLatestReceiptInfoItem {
   transaction_id: string;
@@ -271,7 +247,7 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
   };
 };
 
-export const transactionIdToAppleStoreKitSubscriptionDataDerivation2 = async (transactionId: string): Promise<AppleStoreKitSubscriptionDataDerivationForExtra> => {
+export const transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra = async (transactionId: string): Promise<AppleStoreKitSubscriptionDataDerivationForExtra> => {
   // This function builds a AppleStoreKitSubscriptionData, and just adds the guVersion key to make it a 
   // AppleStoreKitSubscriptionDataDerivation2
   const data1: AppleStoreKitSubscriptionData = await transactionIdToAppleStoreKitSubscriptionData(transactionId);

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -202,6 +202,8 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
     'feastAppleStoreKitConfigAppBunbleId',
   );
 
+  console.log(`[52c0e2ef] appBundleId: ${appBundleId}, transactionId: ${transactionId}`);
+
   const appleStoreKitSubscriptionData: AppleStoreKitSubscriptionData | null = await transactionIdToAppleStoreKitSubscriptionData(appBundleId, transactionId);
 
   if (appleStoreKitSubscriptionData === null) {
@@ -261,6 +263,8 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
 export const transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra = async (appBundleId: string, transactionId: string): Promise<AppleStoreKitSubscriptionDataDerivationForExtra | null> => {
   // This function builds a AppleStoreKitSubscriptionData, and just adds the guType key to make it a 
   // AppleStoreKitSubscriptionDataDerivationForExtra
+
+  console.log(`[e2b0930d] appBundleId: ${appBundleId}, transactionId: ${transactionId}`);
 
   const data1: AppleStoreKitSubscriptionData | null = await transactionIdToAppleStoreKitSubscriptionData(appBundleId, transactionId);
   if (data1 === null) {

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -53,7 +53,7 @@ export interface AppleStoreKitSubscriptionDataDerivationForFeastPipeline {
 // we introduce a guVersion, which is going to be incremented if there is any non backward compatible 
 // change in that structure. 
 export interface AppleStoreKitSubscriptionDataDerivationForExtra {
-  guVersion: "2025-04-29", // Doesn't matter what the value is as long as it's unambiguous, doesn't change, and if changing it increases.
+  guType: "apple-extra-2025-04-29",
   transactionId: string,
   originalTransactionId: string,
   webOrderLineItemId: string,
@@ -276,7 +276,7 @@ export const transactionIdToAppleStoreKitSubscriptionDataDerivation2 = async (tr
   // AppleStoreKitSubscriptionDataDerivation2
   const data1: AppleStoreKitSubscriptionData = await transactionIdToAppleStoreKitSubscriptionData(transactionId);
   const data2: AppleStoreKitSubscriptionDataDerivationForExtra = {
-    guVersion: "2025-04-29",
+    guType: "apple-extra-2025-04-29",
     ...data1
   }
   return Promise.resolve(data2)

--- a/typescript/src/services/apple-json-web-tokens.ts
+++ b/typescript/src/services/apple-json-web-tokens.ts
@@ -9,6 +9,8 @@ export const forgeStoreKitBearerToken = async (appBundleId: string): Promise<str
   // Generating the JWT token
   // https://developer.apple.com/documentation/appstoreserverapi/generating-json-web-tokens-for-api-requests
 
+  console.log(`[77bb28f7] collecting data from Parameter Store`);
+
   const issuerId = await getConfigValue<string>(
     'feastAppleStoreKitConfigIssuerId',
   );

--- a/typescript/src/services/apple-json-web-tokens.ts
+++ b/typescript/src/services/apple-json-web-tokens.ts
@@ -12,10 +12,15 @@ export const forgeStoreKitBearerToken = async (appBundleId: string): Promise<str
   const issuerId = await getConfigValue<string>(
     'feastAppleStoreKitConfigIssuerId',
   );
+  console.log(`[32ff1faa] issuerId: ${issuerId}`);
+
   const keyId = await getConfigValue<string>('feastAppleStoreKitConfigKeyId');
+  console.log(`[85c9b1e7] keyId: ${keyId}`);
+
   const audience = await getConfigValue<string>(
     'feastAppleStoreKitConfigAudience',
   );
+  console.log(`[8b3ae72e] audience: ${audience}`);
 
   const privateKey1 = await getConfigValue<string>(
     'feastAppleStoreKitConfigPrivateKey1',

--- a/typescript/src/services/apple-json-web-tokens.ts
+++ b/typescript/src/services/apple-json-web-tokens.ts
@@ -1,7 +1,7 @@
 import { getConfigValue } from '../utils/ssmConfig';
 const jwt = require('jsonwebtoken');
 
-export const forgeStoreKitBearerToken = async (): Promise<string> => {
+export const forgeStoreKitBearerToken = async (appBundleId: string): Promise<string> => {
   // ------------------------------------------------------------------------
   // This process is described in storekit-signatures.md in the docs folder. |
   // ------------------------------------------------------------------------
@@ -16,9 +16,7 @@ export const forgeStoreKitBearerToken = async (): Promise<string> => {
   const audience = await getConfigValue<string>(
     'feastAppleStoreKitConfigAudience',
   );
-  const appBundleId = await getConfigValue<string>(
-    'feastAppleStoreKitConfigAppBunbleId',
-  );
+
   const privateKey1 = await getConfigValue<string>(
     'feastAppleStoreKitConfigPrivateKey1',
   );

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -190,6 +190,7 @@ async function updateParallelTestTable(
       undefined,
       null,
       dateToSecondTimestamp(thirtyMonths(googleSubscription.expiryTime)),
+      undefined,
       'subscriptions-parallel-test',
     );
 

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -32,8 +32,9 @@ export async function toAppleSubscription(
     );
   }
 
+  const appBundleId = response.latestReceiptInfo.bundleId || "uk.co.guardian.iphone2";
   const originalTransactionId = latestReceiptInfo.originalTransactionId;
-  const extra1: AppleStoreKitSubscriptionDataDerivationForExtra | null = await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(originalTransactionId);
+  const extra1: AppleStoreKitSubscriptionDataDerivationForExtra | null = await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(appBundleId, originalTransactionId);
   const extra2 = JSON.stringify(extra1);
   console.log(`[bae41983] extra: ${extra2}`);
 

--- a/typescript/tests/feast/pubsub/google.test.ts
+++ b/typescript/tests/feast/pubsub/google.test.ts
@@ -151,6 +151,7 @@ describe('The Feast Google pubsub', () => {
         undefined,
         undefined,
         undefined,
+        null,
       );
 
     expect(result).toStrictEqual(HTTPResponses.OK);

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -105,6 +105,7 @@ describe('The google pubsub', () => {
         undefined,
         undefined,
         undefined,
+        null,
       );
 
     const expectedSubscriptionReferenceInSqs = {
@@ -264,7 +265,9 @@ describe('The google pubsub', () => {
 });
 
 describe('The apple pubsub', () => {
+
   test('Should return HTTP 200 and store the correct data in dynamo', () => {
+
     process.env['Secret'] = 'MYSECRET';
     process.env['QueueUrl'] = '';
 
@@ -417,7 +420,7 @@ describe('The apple pubsub', () => {
     return parseStoreAndSend(
       input,
       parseApplePayload,
-      applePayloadToDynamo,
+      (notification) => applePayloadToDynamo(notification, false),
       toAppleSqsEvent,
       mockFetchMetadataFunction,
       mockStoreFunction,


### PR DESCRIPTION
Previous step: https://github.com/guardian/mobile-purchases/pull/1821

In this step we introduce `AppleStoreKitSubscriptionDataDerivationForExtra` the official type of the data we are sending to the Lake as additional key to SubscriptionEvent. Each data version is clearly indicated, in this case `apple-extra-2025-04-29`, this will the object to be forward compatible in storage in case DataDesign asks for non backward compatible changes, but also will allow the difference between the apple and google extra data.

And note the decision to update the signature of `toDynamoEvent` in the apple case. This is to preserve testability.  

