### PR TITLE
Adding an extra key to subscriptions (Part 4: Subscriptions)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,6 +42,10 @@ applepubsub
     - AWS function (s): mobile-purchases-applepubsub-PROD
                       : mobile-purchases-applepubsub-CODE
 
+apple-subscriptions-to-fetch
+    - code: src/update-subs/apple.ts
+    - AWS function (s): mobile-purchases-apple-update-subscriptions-PROD
+
 subscription-events-v2
     - Dynamo table: mobile-purchases-PROD-subscription-events-v2
 

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -121,7 +121,7 @@ const processSQSRecord = async (record: SQSRecord): Promise<void> => {
   );
   const promises = appleValidationResponses.map(
     async (appleValidationResponse) => {
-      const appleSubscription: Subscription = toAppleSubscription(
+      const appleSubscription: Subscription = await toAppleSubscription(
         appleValidationResponse,
       );
       console.log(

--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -37,17 +37,19 @@ export const defaultFetchSubscriptionsFromApple = async (
     { sandboxRetry: false },
     App.Feast,
   );
-  return responses.map((response) => {
-    const subscription = toAppleSubscription(response);
-    if (response.latestReceiptInfo.appAccountToken) {
-      return withAppAccountToken(
-        subscription,
-        response.latestReceiptInfo.appAccountToken,
-      );
-    } else {
-      return subscription;
-    }
-  });
+  return Promise.all(
+    responses.map(async (response) => {
+      const subscription = await toAppleSubscription(response);
+      if (response.latestReceiptInfo.appAccountToken) {
+        return withAppAccountToken(
+          subscription,
+          response.latestReceiptInfo.appAccountToken,
+        );
+      } else {
+        return subscription;
+      }
+    }),
+  );
 };
 
 const defaultStoreSubscriptionInDynamo = (

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -1,6 +1,7 @@
 import { DynamoDbTable } from '@aws/dynamodb-data-mapper';
 import { attribute, hashKey } from '@aws/dynamodb-data-mapper-annotations';
 import { App, Stage } from '../utils/appIdentity';
+import { AppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
 export class Subscription {
   /*
@@ -49,6 +50,9 @@ export class Subscription {
   @attribute()
   ttl?: number;
 
+  @attribute()
+  extra: string | undefined;
+
   tableName: string;
 
   constructor(
@@ -65,6 +69,7 @@ export class Subscription {
     receipt?: string,
     applePayload?: any,
     ttl?: number,
+    extra?: string | undefined,
     tableName = 'subscriptions',
   ) {
     this.subscriptionId = subscriptionId;
@@ -80,6 +85,7 @@ export class Subscription {
     this.receipt = receipt;
     this.applePayload = applePayload;
     this.ttl = ttl;
+    this.extra = extra;
     this.tableName = tableName;
   }
 
@@ -97,7 +103,23 @@ export class Subscription {
 
 export class SubscriptionEmpty extends Subscription {
   constructor() {
-    super('', '', '', undefined, false, '', undefined, undefined, undefined);
+    super(
+        '', // subscriptionId
+        '', // startTimestamp
+        '', // endTimestamp
+        undefined, // cancellationTimestamp
+        false, // autoRenewing
+        '', // productId
+        undefined, // platform
+        undefined, // freeTrial
+        undefined, // billingPeriod
+        undefined, // googlePayload
+        undefined, // receipt
+        undefined, // applePayload
+        undefined, // ttl
+        undefined, // extra
+        '' , // tableName
+      );
   }
 
   setSubscriptionId(subscriptionId: string): SubscriptionEmpty {

--- a/typescript/src/subscription-status/googleSubStatus.ts
+++ b/typescript/src/subscription-status/googleSubStatus.ts
@@ -190,6 +190,7 @@ async function updateParallelTestTable(
       undefined,
       null,
       dateToSecondTimestamp(thirtyMonths(googleSubscription.expiryTime)),
+      undefined,
       'subscriptions-parallel-test',
     );
 


### PR DESCRIPTION
Previous step: https://github.com/guardian/mobile-purchases/pull/1822

In this step we perform for a Subscription the work we did for a SubscriptionEvent of adding the `extra` attribute that carries a ` AppleStoreKitSubscriptionDataDerivationForExtra`.


