### PR TITLE
add an extra key to SubscriptionEvent

### DIFF
--- a/typescript/src/models/subscriptionEvent.ts
+++ b/typescript/src/models/subscriptionEvent.ts
@@ -39,6 +39,8 @@ export class SubscriptionEvent {
   purchase_date_ms: number;
   @attribute()
   expires_date_ms: number;
+  @attribute()
+  extra: string;
 
   constructor(
     subscriptionId: string,
@@ -57,6 +59,7 @@ export class SubscriptionEvent {
     product_id: any,
     purchase_date_ms: any,
     expires_date_ms: any,
+    extra: string,
   ) {
     this.subscriptionId = subscriptionId;
     this.timestampAndType = timestampAndType;
@@ -74,6 +77,7 @@ export class SubscriptionEvent {
     this.product_id = product_id;
     this.purchase_date_ms = purchase_date_ms;
     this.expires_date_ms = expires_date_ms;
+    this.extra = extra;
   }
 
   get [DynamoDbTable]() {
@@ -83,6 +87,24 @@ export class SubscriptionEvent {
 
 export class SubscriptionEventEmpty extends SubscriptionEvent {
   constructor() {
-    super('', '', '', '', '', '', '', undefined, {}, {}, 0, '', '', '', 0, 0);
+    super(
+      '', // subscriptionId
+      '', // timestampAndType
+      '', // date
+      '', // timestamp
+      '', // eventType
+      '', // platform
+      '', // appId
+      undefined, // freeTrial
+      {}, // googlePayload
+      {}, // applePayload
+      0, // ttl
+      '', // promotional_offer_id
+      '', // promotional_offer_name
+      '', // product_id
+      0, // purchase_date_ms
+      0, // expires_date_ms
+      '' // extra
+    );
   }
 }

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -72,6 +72,7 @@ export function toDynamoEvent(
     notification.product_id, // SubscriptionEvent.product_id
     notification.purchase_date_ms, // SubscriptionEvent.purchase_date_ms
     notification.expires_date_ms, // SubscriptionEvent.expires_date_ms
+    '',
   );
 }
 

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -186,6 +186,7 @@ export function toDynamoEvent(
     undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
     undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
     undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
+    '', // extra
   );
 }
 

--- a/typescript/tests/feast/pubsub/google.test.ts
+++ b/typescript/tests/feast/pubsub/google.test.ts
@@ -151,6 +151,7 @@ describe('The Feast Google pubsub', () => {
         undefined,
         undefined,
         undefined,
+        '',
       );
 
     expect(result).toStrictEqual(HTTPResponses.OK);

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -105,6 +105,7 @@ describe('The google pubsub', () => {
         undefined,
         undefined,
         undefined,
+        '',
       );
 
     const expectedSubscriptionReferenceInSqs = {


### PR DESCRIPTION
This is a small preliminary to PR3 ( https://github.com/guardian/mobile-purchases/pull/1822 ) (which as it stands is breaking), where we just introduce a new ket to SubscriptionEvent.

At the moment it remains as an empty string, this change only purpose is to extend the schema.

