### PR TITLE
expand storekit look up functions to accept a appBundleId

### DIFF
--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -1,4 +1,5 @@
 import type { Subscription } from '../models/subscription';
+import { getConfigValue } from '../utils/ssmConfig';
 import { forgeStoreKitBearerToken } from './apple-json-web-tokens';
 import { productIdToPaymentFrequency, storefrontToCountry } from './apple-mappings';
 const jwt = require('jsonwebtoken');
@@ -51,13 +52,13 @@ interface AppleLatestReceiptInfoItem {
 }
 type AppleLatestReceiptInfo = AppleLatestReceiptInfoItem[];
 
-export const transactionIdToAppleStoreKitSubscriptionData = async (transactionId: string): Promise<AppleStoreKitSubscriptionData> => {
+export const transactionIdToAppleStoreKitSubscriptionData = async (appBundleId: string, transactionId: string): Promise<AppleStoreKitSubscriptionData> => {
   console.log(`[116fa7d4] transactionId: ${transactionId}`);
 
   const url = `https://api.storekit.itunes.apple.com/inApps/v1/subscriptions/${transactionId}`;
   console.log(`[5330931d] url: ${url}`);
-
-  const token = await forgeStoreKitBearerToken();
+  
+  const token = await forgeStoreKitBearerToken(appBundleId);
 
   console.log(`[f1335718] ${token}`);
 
@@ -187,7 +188,13 @@ export const appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastP
 
   const transactionId = appleSubscriptionToOriginalTransactionId(subscription);
 
-  const appleStoreKitSubscriptionData: AppleStoreKitSubscriptionData = await transactionIdToAppleStoreKitSubscriptionData(transactionId);
+  const appBundleId = await getConfigValue<string>(
+    'feastAppleStoreKitConfigAppBunbleId',
+  );
+
+  console.log(`[52c0e2ef] appBundleId: ${appBundleId}, transactionId: ${transactionId}`);
+
+  const appleStoreKitSubscriptionData: AppleStoreKitSubscriptionData = await transactionIdToAppleStoreKitSubscriptionData(appBundleId, transactionId);
 
   console.log(`[7f53de39] appleStoreKitSubscriptionData: ${JSON.stringify(appleStoreKitSubscriptionData)}`);
 

--- a/typescript/src/services/apple-json-web-tokens.ts
+++ b/typescript/src/services/apple-json-web-tokens.ts
@@ -1,7 +1,7 @@
 import { getConfigValue } from '../utils/ssmConfig';
 const jwt = require('jsonwebtoken');
 
-export const forgeStoreKitBearerToken = async (): Promise<string> => {
+export const forgeStoreKitBearerToken = async (appBundleId: string): Promise<string> => {
   // ------------------------------------------------------------------------
   // This process is described in storekit-signatures.md in the docs folder. |
   // ------------------------------------------------------------------------
@@ -15,9 +15,6 @@ export const forgeStoreKitBearerToken = async (): Promise<string> => {
   const keyId = await getConfigValue<string>('feastAppleStoreKitConfigKeyId');
   const audience = await getConfigValue<string>(
     'feastAppleStoreKitConfigAudience',
-  );
-  const appBundleId = await getConfigValue<string>(
-    'feastAppleStoreKitConfigAppBunbleId',
   );
   const privateKey1 = await getConfigValue<string>(
     'feastAppleStoreKitConfigPrivateKey1',


### PR DESCRIPTION
This is the follow up of: https://github.com/guardian/mobile-purchases/pull/1824

When I implemented the storekit API look up the first time, it was in the context of the Feast acquisition pipeline and there was only one possible appBundleId, that of the feast app. But now we want to be able to make the same look up for other apps and in particular the mobile apps. 

Interestingly the encryption key (which is GU wide) doesn't need to change, neither does the Audience.

Here we pass the value of appBundleId to both `forgeStoreKitBearerToken` and `transactionIdToAppleStoreKitSubscriptionData`