### PR TITLE
add extra key to SubscriptionEvent

### DIFF
--- a/typescript/src/feast/pubsub/apple.ts
+++ b/typescript/src/feast/pubsub/apple.ts
@@ -4,7 +4,7 @@ import type Sqs from 'aws-sdk/clients/sqs';
 import type { PromiseResult } from 'aws-sdk/lib/request';
 import { HTTPResponses } from '../../models/apiGatewayHttp';
 import type { AppleSubscriptionReference } from '../../models/subscriptionReference';
-import { toDynamoEvent_v4_apple, toSqsSubReference } from '../../pubsub/apple';
+import { toDynamoEvent_apple_async, toSqsSubReference } from '../../pubsub/apple';
 import type { StatusUpdateNotification } from '../../pubsub/apple-common';
 import { parsePayload } from '../../pubsub/apple-common';
 import { dynamoMapper, sendToSqs } from '../../utils/aws';
@@ -15,7 +15,7 @@ const defaultLogRequest = (request: APIGatewayProxyEvent): void =>
 const defaultStoreEventInDynamo = async (
   event: StatusUpdateNotification,
 ): Promise<void> => {
-  const item = await toDynamoEvent_v4_apple(event, true);
+  const item = await toDynamoEvent_apple_async(event, true);
   return dynamoMapper.put({ item }).then((_) => undefined);
 };
 

--- a/typescript/src/feast/pubsub/apple.ts
+++ b/typescript/src/feast/pubsub/apple.ts
@@ -4,7 +4,7 @@ import type Sqs from 'aws-sdk/clients/sqs';
 import type { PromiseResult } from 'aws-sdk/lib/request';
 import { HTTPResponses } from '../../models/apiGatewayHttp';
 import type { AppleSubscriptionReference } from '../../models/subscriptionReference';
-import { toDynamoEvent_v2, toSqsSubReference } from '../../pubsub/apple';
+import { toDynamoEvent_v4_apple, toSqsSubReference } from '../../pubsub/apple';
 import type { StatusUpdateNotification } from '../../pubsub/apple-common';
 import { parsePayload } from '../../pubsub/apple-common';
 import { dynamoMapper, sendToSqs } from '../../utils/aws';
@@ -15,7 +15,7 @@ const defaultLogRequest = (request: APIGatewayProxyEvent): void =>
 const defaultStoreEventInDynamo = async (
   event: StatusUpdateNotification,
 ): Promise<void> => {
-  const item = await toDynamoEvent_v2(event);
+  const item = await toDynamoEvent_v4_apple(event, true);
   return dynamoMapper.put({ item }).then((_) => undefined);
 };
 

--- a/typescript/src/feast/pubsub/apple.ts
+++ b/typescript/src/feast/pubsub/apple.ts
@@ -4,7 +4,7 @@ import type Sqs from 'aws-sdk/clients/sqs';
 import type { PromiseResult } from 'aws-sdk/lib/request';
 import { HTTPResponses } from '../../models/apiGatewayHttp';
 import type { AppleSubscriptionReference } from '../../models/subscriptionReference';
-import { toDynamoEvent, toSqsSubReference } from '../../pubsub/apple';
+import { toDynamoEvent_v2, toSqsSubReference } from '../../pubsub/apple';
 import type { StatusUpdateNotification } from '../../pubsub/apple-common';
 import { parsePayload } from '../../pubsub/apple-common';
 import { dynamoMapper, sendToSqs } from '../../utils/aws';
@@ -12,10 +12,10 @@ import { dynamoMapper, sendToSqs } from '../../utils/aws';
 const defaultLogRequest = (request: APIGatewayProxyEvent): void =>
   console.log(`[34ef7aa3] ${JSON.stringify(request)}`);
 
-const defaultStoreEventInDynamo = (
+const defaultStoreEventInDynamo = async (
   event: StatusUpdateNotification,
 ): Promise<void> => {
-  const item = toDynamoEvent(event);
+  const item = await toDynamoEvent_v2(event);
   return dynamoMapper.put({ item }).then((_) => undefined);
 };
 

--- a/typescript/src/feast/pubsub/google.ts
+++ b/typescript/src/feast/pubsub/google.ts
@@ -12,7 +12,7 @@ import type {
 import {
   fetchMetadata as defaultFetchMetadata,
   parsePayload,
-  toDynamoEvent,
+  toDynamoEvent_v2,
   toSqsSubReference,
 } from '../../pubsub/google-common';
 import { Ignorable } from '../../pubsub/ignorable';
@@ -60,7 +60,7 @@ export function buildHandler(
         }
 
         const metaData = await fetchMetadata(notification);
-        const dynamoEvent = toDynamoEvent(notification, metaData);
+        const dynamoEvent = await toDynamoEvent_v2(notification, metaData);
 
         await Promise.all([
           sendMessageToSqs(queueUrl, androidSubscriptionReference),

--- a/typescript/src/feast/pubsub/google.ts
+++ b/typescript/src/feast/pubsub/google.ts
@@ -12,7 +12,7 @@ import type {
 import {
   fetchMetadata as defaultFetchMetadata,
   parsePayload,
-  toDynamoEvent_v2,
+  toDynamoEvent_google_async,
   toSqsSubReference,
 } from '../../pubsub/google-common';
 import { Ignorable } from '../../pubsub/ignorable';
@@ -60,7 +60,7 @@ export function buildHandler(
         }
 
         const metaData = await fetchMetadata(notification);
-        const dynamoEvent = await toDynamoEvent_v2(notification, metaData);
+        const dynamoEvent = await toDynamoEvent_google_async(notification, metaData);
 
         await Promise.all([
           sendMessageToSqs(queueUrl, androidSubscriptionReference),

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -7,7 +7,7 @@ import { Stage } from '../utils/appIdentity';
 import { dateToSecondTimestamp, thirtyMonths } from '../utils/dates';
 import type { StatusUpdateNotification } from './apple-common';
 import { parsePayload } from './apple-common';
-import { parseStoreAndSend } from './pubsub';
+import { parseStoreAndSend_v2 } from './pubsub';
 import { AppleStoreKitSubscriptionDataDerivationForExtra, transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
 export function toDynamoEvent(
@@ -107,10 +107,10 @@ export async function handler(
   request: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> {
   console.log(`[23ad7cb3] ${JSON.stringify(request)}`);
-  return parseStoreAndSend(
+  return parseStoreAndSend_v2(
     request,
     parsePayload,
-    toDynamoEvent,
+    async (notification: StatusUpdateNotification) => toDynamoEvent(notification),
     toSqsSubReference,
     () => Promise.resolve(undefined),
   );

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -7,7 +7,7 @@ import { Stage } from '../utils/appIdentity';
 import { dateToSecondTimestamp, thirtyMonths } from '../utils/dates';
 import type { StatusUpdateNotification } from './apple-common';
 import { parsePayload } from './apple-common';
-import { parseStoreAndSend_v2 } from './pubsub';
+import { parseStoreAndSend_async } from './pubsub';
 import { AppleStoreKitSubscriptionDataDerivationForExtra, transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
 export async function toDynamoEvent_v4_apple(
@@ -115,7 +115,7 @@ export async function handler(
   request: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> {
   console.log(`[23ad7cb3] ${JSON.stringify(request)}`);
-  return parseStoreAndSend_v2(
+  return parseStoreAndSend_async(
     request,
     parsePayload,
     (notification: StatusUpdateNotification) => toDynamoEvent_v4_apple(notification, true),

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -10,7 +10,7 @@ import { parsePayload } from './apple-common';
 import { parseStoreAndSend_async } from './pubsub';
 import { AppleStoreKitSubscriptionDataDerivationForExtra, transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
-export async function toDynamoEvent_v4_apple(
+export async function toDynamoEvent_apple_async(
   notification: StatusUpdateNotification,
   useStoreKitForExtra: boolean
 ): Promise<SubscriptionEvent> {
@@ -118,7 +118,7 @@ export async function handler(
   return parseStoreAndSend_async(
     request,
     parsePayload,
-    (notification: StatusUpdateNotification) => toDynamoEvent_v4_apple(notification, true),
+    (notification: StatusUpdateNotification) => toDynamoEvent_apple_async(notification, true),
     toSqsSubReference,
     () => Promise.resolve(undefined),
   );

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -147,10 +147,10 @@ export async function fetchMetadata(
   }
 }
 
-export function toDynamoEvent(
+export async function toDynamoEvent_v2(
   notification: SubscriptionNotification,
   metaData?: GoogleSubscriptionMetaData,
-): SubscriptionEvent {
+): Promise<SubscriptionEvent> {
   const eventTime = optionalMsToDate(notification.eventTimeMillis);
   if (!eventTime) {
     // this is tested while parsing the payload in order to return HTTP 400 early.
@@ -169,7 +169,7 @@ export function toDynamoEvent(
     console.warn(`Unknown package name ${notification.packageName}`);
   }
 
-  return new SubscriptionEvent(
+  const subscription = new SubscriptionEvent(
     notification.subscriptionNotification.purchaseToken,
     eventTimestamp + '|' + eventTypeString,
     date,
@@ -188,6 +188,8 @@ export function toDynamoEvent(
     undefined, // any ; Introduced during the Apple extension of SubscriptionEvent [2023-11-03]
     '', // extra
   );
+
+  return Promise.resolve(subscription);
 }
 
 export function toSqsSubReference(

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -147,7 +147,7 @@ export async function fetchMetadata(
   }
 }
 
-export async function toDynamoEvent_v2(
+export async function toDynamoEvent_google_async(
   notification: SubscriptionNotification,
   metaData?: GoogleSubscriptionMetaData,
 ): Promise<SubscriptionEvent> {

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -3,18 +3,18 @@ import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import {
   fetchMetadata,
   parsePayload,
-  toDynamoEvent,
+  toDynamoEvent_v2,
   toSqsSubReference,
 } from './google-common';
-import { parseStoreAndSend } from './pubsub';
+import { parseStoreAndSend_v2 } from './pubsub';
 
 export async function handler(
   request: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> {
-  return parseStoreAndSend(
+  return parseStoreAndSend_v2(
     request,
     parsePayload,
-    toDynamoEvent,
+    toDynamoEvent_v2,
     toSqsSubReference,
     fetchMetadata,
   );

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -6,12 +6,12 @@ import {
   toDynamoEvent_v2,
   toSqsSubReference,
 } from './google-common';
-import { parseStoreAndSend_v2 } from './pubsub';
+import { parseStoreAndSend_async } from './pubsub';
 
 export async function handler(
   request: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> {
-  return parseStoreAndSend_v2(
+  return parseStoreAndSend_async(
     request,
     parsePayload,
     toDynamoEvent_v2,

--- a/typescript/src/pubsub/google.ts
+++ b/typescript/src/pubsub/google.ts
@@ -3,7 +3,7 @@ import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import {
   fetchMetadata,
   parsePayload,
-  toDynamoEvent_v2,
+  toDynamoEvent_google_async,
   toSqsSubReference,
 } from './google-common';
 import { parseStoreAndSend_async } from './pubsub';
@@ -14,7 +14,7 @@ export async function handler(
   return parseStoreAndSend_async(
     request,
     parsePayload,
-    toDynamoEvent_v2,
+    toDynamoEvent_google_async,
     toSqsSubReference,
     fetchMetadata,
   );

--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -28,7 +28,7 @@ function storeInDynamoImpl(
   return dynamoMapper.put({ item: event }).then((result) => result.item);
 }
 
-export async function parseStoreAndSend_v2<Payload, SqsEvent, MetaData>(
+export async function parseStoreAndSend_async<Payload, SqsEvent, MetaData>(
   request: APIGatewayProxyEvent,
   parsePayload: (body: Option<string>) => Payload | Ignorable | Error,
   toDynamoEvent: (payload: Payload, metaData?: MetaData) => Promise<SubscriptionEvent>,

--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -28,10 +28,10 @@ function storeInDynamoImpl(
   return dynamoMapper.put({ item: event }).then((result) => result.item);
 }
 
-export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
+export async function parseStoreAndSend_v2<Payload, SqsEvent, MetaData>(
   request: APIGatewayProxyEvent,
   parsePayload: (body: Option<string>) => Payload | Ignorable | Error,
-  toDynamoEvent: (payload: Payload, metaData?: MetaData) => SubscriptionEvent,
+  toDynamoEvent: (payload: Payload, metaData?: MetaData) => Promise<SubscriptionEvent>,
   toSqsEvent: (payload: Payload) => SqsEvent,
   fetchMetadata: (payload: Payload) => Promise<MetaData | undefined>,
   storeInDynamo: (
@@ -65,7 +65,7 @@ export async function parseStoreAndSend<Payload, SqsEvent, MetaData>(
       }
 
       const metaData = await fetchMetadata(notification);
-      const dynamoEvent = toDynamoEvent(notification, metaData);
+      const dynamoEvent = await toDynamoEvent(notification, metaData);
       const dynamoPromise = storeInDynamo(dynamoEvent);
       const sqsEvent = toSqsEvent(notification);
       const sqsPromise = sendToSqsFunction(queueUrl, sqsEvent);

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -11,7 +11,7 @@ import {
   parsePayload as parseGooglePayload,
   toSqsSubReference as toGoogleSqsEvent,
 } from '../../src/pubsub/google-common';
-import { parseStoreAndSend_v2 } from '../../src/pubsub/pubsub';
+import { parseStoreAndSend_async } from '../../src/pubsub/pubsub';
 import Mock = jest.Mock;
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 
@@ -114,7 +114,7 @@ describe('The google pubsub', () => {
       subscriptionId: 'my.sku',
     };
 
-    return parseStoreAndSend_v2(
+    return parseStoreAndSend_async(
       input,
       parseGooglePayload,
       googlePayloadToDynamo,
@@ -183,7 +183,7 @@ describe('The google pubsub', () => {
       resource: '',
     };
 
-    const result = await parseStoreAndSend_v2(
+    const result = await parseStoreAndSend_async(
       input,
       parseGooglePayload,
       googlePayloadToDynamo,
@@ -250,7 +250,7 @@ describe('The google pubsub', () => {
       resource: '',
     };
 
-    const result = await parseStoreAndSend_v2(
+    const result = await parseStoreAndSend_async(
       input,
       parseGooglePayload,
       googlePayloadToDynamo,
@@ -415,7 +415,7 @@ describe('The apple pubsub', () => {
 
     const expectedSubscriptionReferenceInSqs = { receipt: 'TEST' };
 
-    return parseStoreAndSend_v2(
+    return parseStoreAndSend_async(
       input,
       parseApplePayload,
       (notification) => applePayloadToDynamo(notification, false),

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -1,7 +1,7 @@
 import { HTTPResponses } from '../../src/models/apiGatewayHttp';
 import { SubscriptionEvent } from '../../src/models/subscriptionEvent';
 import {
-  toDynamoEvent as applePayloadToDynamo,
+  toDynamoEvent_v2 as applePayloadToDynamo,
   toSqsSubReference as toAppleSqsEvent,
 } from '../../src/pubsub/apple';
 import type { StatusUpdateNotification } from '../../src/pubsub/apple-common';
@@ -418,7 +418,7 @@ describe('The apple pubsub', () => {
     return parseStoreAndSend_v2(
       input,
       parseApplePayload,
-      async (notification) => applePayloadToDynamo(notification),
+      (notification) => applePayloadToDynamo(notification),
       toAppleSqsEvent,
       mockFetchMetadataFunction,
       mockStoreFunction,

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -1,7 +1,7 @@
 import { HTTPResponses } from '../../src/models/apiGatewayHttp';
 import { SubscriptionEvent } from '../../src/models/subscriptionEvent';
 import {
-  toDynamoEvent_v4_apple as applePayloadToDynamo,
+  toDynamoEvent_apple_async as applePayloadToDynamo,
   toSqsSubReference as toAppleSqsEvent,
 } from '../../src/pubsub/apple';
 import type { StatusUpdateNotification } from '../../src/pubsub/apple-common';

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -7,7 +7,7 @@ import {
 import type { StatusUpdateNotification } from '../../src/pubsub/apple-common';
 import { parsePayload as parseApplePayload } from '../../src/pubsub/apple-common';
 import {
-  toDynamoEvent_v2 as googlePayloadToDynamo,
+  toDynamoEvent_google_async as googlePayloadToDynamo,
   parsePayload as parseGooglePayload,
   toSqsSubReference as toGoogleSqsEvent,
 } from '../../src/pubsub/google-common';

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -1,7 +1,7 @@
 import { HTTPResponses } from '../../src/models/apiGatewayHttp';
 import { SubscriptionEvent } from '../../src/models/subscriptionEvent';
 import {
-  toDynamoEvent_v2 as applePayloadToDynamo,
+  toDynamoEvent_v4_apple as applePayloadToDynamo,
   toSqsSubReference as toAppleSqsEvent,
 } from '../../src/pubsub/apple';
 import type { StatusUpdateNotification } from '../../src/pubsub/apple-common';
@@ -418,7 +418,7 @@ describe('The apple pubsub', () => {
     return parseStoreAndSend_v2(
       input,
       parseApplePayload,
-      (notification) => applePayloadToDynamo(notification),
+      (notification) => applePayloadToDynamo(notification, false),
       toAppleSqsEvent,
       mockFetchMetadataFunction,
       mockStoreFunction,

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -7,11 +7,11 @@ import {
 import type { StatusUpdateNotification } from '../../src/pubsub/apple-common';
 import { parsePayload as parseApplePayload } from '../../src/pubsub/apple-common';
 import {
-  toDynamoEvent as googlePayloadToDynamo,
+  toDynamoEvent_v2 as googlePayloadToDynamo,
   parsePayload as parseGooglePayload,
   toSqsSubReference as toGoogleSqsEvent,
 } from '../../src/pubsub/google-common';
-import { parseStoreAndSend } from '../../src/pubsub/pubsub';
+import { parseStoreAndSend_v2 } from '../../src/pubsub/pubsub';
 import Mock = jest.Mock;
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 
@@ -114,7 +114,7 @@ describe('The google pubsub', () => {
       subscriptionId: 'my.sku',
     };
 
-    return parseStoreAndSend(
+    return parseStoreAndSend_v2(
       input,
       parseGooglePayload,
       googlePayloadToDynamo,
@@ -183,7 +183,7 @@ describe('The google pubsub', () => {
       resource: '',
     };
 
-    const result = await parseStoreAndSend(
+    const result = await parseStoreAndSend_v2(
       input,
       parseGooglePayload,
       googlePayloadToDynamo,
@@ -250,7 +250,7 @@ describe('The google pubsub', () => {
       resource: '',
     };
 
-    const result = await parseStoreAndSend(
+    const result = await parseStoreAndSend_v2(
       input,
       parseGooglePayload,
       googlePayloadToDynamo,
@@ -415,10 +415,10 @@ describe('The apple pubsub', () => {
 
     const expectedSubscriptionReferenceInSqs = { receipt: 'TEST' };
 
-    return parseStoreAndSend(
+    return parseStoreAndSend_v2(
       input,
       parseApplePayload,
-      applePayloadToDynamo,
+      async (notification) => applePayloadToDynamo(notification),
       toAppleSqsEvent,
       mockFetchMetadataFunction,
       mockStoreFunction,


### PR DESCRIPTION
Previous step: https://github.com/guardian/mobile-purchases/pull/1826

In this change we essentially update the signature of `toDynamoEvent`, to be able to perform an `await` inside it. 

Here one has to be careful. There is an apple `toDynamoEvent` which has been renamed `toDynamoEvent_v4_apple` and a google `toDynamoEvent`, which also needed to have its signature upgraded an is now named `toDynamoEvent_v2`.

Note that the signature of `parseStoreAndSend` has been updated and renamed `parseStoreAndSend_v2`.

ps: `parseStoreAndSend_v2` and google's `toDynamoEvent_v2` are just the asynchronous versions of their synchronous pre-existence. Function `toDynamoEvent_v4_apple` is not only async but also has acquired an extra parameter that control the API calls and ensures that the tests continue to function. 