### PR TITLE
upgrade Subscription with a new key: extra

### DIFF
--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -8,7 +8,7 @@ import type {
   ValidationOptions,
 } from '../../services/appleValidateReceipts';
 import { validateReceipt } from '../../services/appleValidateReceipts';
-import { toAppleSubscription } from '../../update-subs/apple';
+import { toAppleSubscription_v2 } from '../../update-subs/apple';
 import { postPayloadToAcquisitionAPI } from './common';
 import type {
   AcquisitionApiPayload,
@@ -116,7 +116,7 @@ const processSQSRecord = async (record: SQSRecord): Promise<void> => {
   );
   const promises = appleValidationResponses.map(
     async (appleValidationResponse) => {
-      const appleSubscription: Subscription = toAppleSubscription(
+      const appleSubscription: Subscription = await toAppleSubscription_v2(
         appleValidationResponse,
       );
       console.log(

--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -8,7 +8,7 @@ import type {
   ValidationOptions,
 } from '../../services/appleValidateReceipts';
 import { validateReceipt } from '../../services/appleValidateReceipts';
-import { toAppleSubscription_v2 } from '../../update-subs/apple';
+import { toAppleSubscription_async } from '../../update-subs/apple';
 import { postPayloadToAcquisitionAPI } from './common';
 import type {
   AcquisitionApiPayload,
@@ -116,7 +116,7 @@ const processSQSRecord = async (record: SQSRecord): Promise<void> => {
   );
   const promises = appleValidationResponses.map(
     async (appleValidationResponse) => {
-      const appleSubscription: Subscription = await toAppleSubscription_v2(
+      const appleSubscription: Subscription = await toAppleSubscription_async(
         appleValidationResponse,
       );
       console.log(

--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -6,7 +6,7 @@ import type { AppleSubscriptionReference } from '../../models/subscriptionRefere
 import { UserSubscription } from '../../models/userSubscription';
 import { validateReceipt } from '../../services/appleValidateReceipts';
 import { getIdentityIdFromBraze, IdentityIdFromBraze } from '../../services/braze';
-import { toAppleSubscription_v2 } from '../../update-subs/apple';
+import { toAppleSubscription_async } from '../../update-subs/apple';
 import { dynamoMapper, putMetric } from '../../utils/aws';
 import {
   queueHistoricalSubscription as defaultSendSubscriptionToHistoricalQueue,
@@ -39,7 +39,7 @@ export const defaultFetchSubscriptionsFromApple = async (
   );
   return Promise.all(
     responses.map(async (response) => {
-      const subscription = await toAppleSubscription_v2(response);
+      const subscription = await toAppleSubscription_async(response);
       if (response.latestReceiptInfo.appAccountToken) {
         return withAppAccountToken(
           subscription,

--- a/typescript/src/feast/update-subs/apple.ts
+++ b/typescript/src/feast/update-subs/apple.ts
@@ -6,7 +6,7 @@ import type { AppleSubscriptionReference } from '../../models/subscriptionRefere
 import { UserSubscription } from '../../models/userSubscription';
 import { validateReceipt } from '../../services/appleValidateReceipts';
 import { getIdentityIdFromBraze, IdentityIdFromBraze } from '../../services/braze';
-import { toAppleSubscription } from '../../update-subs/apple';
+import { toAppleSubscription_v2 } from '../../update-subs/apple';
 import { dynamoMapper, putMetric } from '../../utils/aws';
 import {
   queueHistoricalSubscription as defaultSendSubscriptionToHistoricalQueue,
@@ -37,17 +37,19 @@ export const defaultFetchSubscriptionsFromApple = async (
     { sandboxRetry: false },
     App.Feast,
   );
-  return responses.map((response) => {
-    const subscription = toAppleSubscription(response);
-    if (response.latestReceiptInfo.appAccountToken) {
-      return withAppAccountToken(
-        subscription,
-        response.latestReceiptInfo.appAccountToken,
-      );
-    } else {
-      return subscription;
-    }
-  });
+  return Promise.all(
+    responses.map(async (response) => {
+      const subscription = await toAppleSubscription_v2(response);
+      if (response.latestReceiptInfo.appAccountToken) {
+        return withAppAccountToken(
+          subscription,
+          response.latestReceiptInfo.appAccountToken,
+        );
+      } else {
+        return subscription;
+      }
+    }),
+  );
 };
 
 const defaultStoreSubscriptionInDynamo = (

--- a/typescript/src/models/subscription.ts
+++ b/typescript/src/models/subscription.ts
@@ -49,6 +49,9 @@ export class Subscription {
   @attribute()
   ttl?: number;
 
+  @attribute()
+  extra?: string;
+
   tableName: string;
 
   constructor(
@@ -65,6 +68,7 @@ export class Subscription {
     receipt?: string,
     applePayload?: any,
     ttl?: number,
+    extra?: string,
     tableName = 'subscriptions',
   ) {
     this.subscriptionId = subscriptionId;
@@ -80,6 +84,7 @@ export class Subscription {
     this.receipt = receipt;
     this.applePayload = applePayload;
     this.ttl = ttl;
+    this.extra = extra;
     this.tableName = tableName;
   }
 
@@ -97,7 +102,17 @@ export class Subscription {
 
 export class SubscriptionEmpty extends Subscription {
   constructor() {
-    super('', '', '', undefined, false, '', undefined, undefined, undefined);
+    super(
+      '', // subscriptionId
+      '', // startTimestamp
+      '', // endTimestamp
+      undefined, // cancellationTimestamp
+      false, // autoRenewing
+      '', // productId
+      undefined, // platform
+      undefined, // freeTrial
+      undefined // billingPeriod
+    );
   }
 
   setSubscriptionId(subscriptionId: string): SubscriptionEmpty {

--- a/typescript/src/update-subs/apple.ts
+++ b/typescript/src/update-subs/apple.ts
@@ -10,7 +10,7 @@ import { dateToSecondTimestamp, thirtyMonths } from '../utils/dates';
 import { parseAndStoreSubscriptionUpdate } from './updatesub';
 import { transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 
-export async function toAppleSubscription_v2(
+export async function toAppleSubscription_async(
   response: AppleValidationResponse,
 ): Promise<Subscription> {
   const latestReceiptInfo = response.latestReceiptInfo;
@@ -70,7 +70,7 @@ function sqsRecordToAppleSubscription(
   // sandboxRetry is set to false such that in production we don't store any sandbox receipt that would have snuck all the way here
   // In CODE or locally the default endpoint will be sanbox therefore no retry is necessary
   return validateReceipt(subRef.receipt, { sandboxRetry: false }).then(async (subs) =>
-    Promise.all(subs.map(toAppleSubscription_v2)),
+    Promise.all(subs.map(toAppleSubscription_async)),
   ); // `subs` here is a AppleValidationResponse[]
 }
 


### PR DESCRIPTION
Here we perform for `Subscription` the same operation we did for `SubscriptionEvent` ( https://github.com/guardian/mobile-purchases/pull/1830#issue-3035300883 )

1. Adding an `extra` key 
2. Modify the synchronicity of the corresponding function to enable awaiting for the API answer

