### PR TITLE
Remove `android-price-rise` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "test": "jest",
     "test-lambda": "yarn build:dev && node ./tsc-target/test-launcher.js",
     "lint": "eslint ./typescript --ext .ts",
-    "lint-fix": "eslint ./typescript --ext .ts --fix",
-    "android-price-rise": "AWS_PROFILE=mobile ts-node ./typescript/src/scripts/android-price-rise/runPriceRise.ts"
+    "lint-fix": "eslint ./typescript --ext .ts --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove `android-price-rise` from package.json. The functionality has been moved to the price migration engine source code ( https://github.com/guardian/price-migration-engine/tree/1bdf7a08db2f4caf4d9c0972b4c054f548220582/android-price-rise )