### PR TITLE
let membership alarms handler describe alarms

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1706,7 +1706,11 @@ Resources:
         - PolicyName: cloudwatch-list-tags
           PolicyDocument:
             Statement:
-              Effect: Allow
-              Action:
-                - cloudwatch:ListTagsForResource
-              Resource: "*"
+              - Effect: Allow
+                Action:
+                  - cloudwatch:ListTagsForResource
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - cloudwatch:DescribeAlarms
+                Resource: "*"


### PR DESCRIPTION
needed for https://github.com/guardian/support-service-lambdas/pull/2844

we need to be able to enumerate all alarms in ALARM state so that we can send a daily summary.

This PR adds the DescribeAlarms permission to the cross account role that the handler uses.

Tested in CODE.