### PR TITLE
Add currency code for Trinidad & Tobago

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -122,6 +122,7 @@ const countryToCurrencyMap = {
     CL: 'CLP', // Chile - Chilean Peso
     CO: 'COP', // Colombia - Colombian Peso
     PE: 'PEN', // Peru - Peruvian Sol
+    TT: 'TTD', // Trinidad & Tobago
 
     // Oceania
     FJ: 'FJD', // Fiji - Fijian Dollar


### PR DESCRIPTION
Will prevent
"Error: [acba643d] Country TT is not supported"