### PR TITLE
documentation update

### DIFF
--- a/docs/calling-apple-and-google.md
+++ b/docs/calling-apple-and-google.md
@@ -1,0 +1,32 @@
+
+In this file I am going to document the calls to Apple (through api-storekit.ts) and the two currently used versions of the Google API (through google-play.ts and googleplay-v2.ts).
+
+This is written in June 2025, as part of preparing the code for doing for the google subscriptions the work we did for the apple ones. 
+
+
+```
+                                              --------------------------------- /src/update-subs/apple.ts
+                                             |       -------------------------- /src/update-subs/google.ts
+ ----------------                            |      |
+| api-storekit.ts|                           |      |
+ ----------------                            |---<- | -<----------------------- /src/pubsub/apple.ts
+                                             |      |-------------------------- /src/pubsub/google-common.ts
+ - apple(...)FeastPipeline     <~~~~~~~~~~~~ | ~~~~ | ~~~~~~~~~~~~
+                                             |      |            |
+ - transactingId(...)ForExtra  <-------------       |             ~~~~~~~~~~~~~ /src/feast/acquisation-events/apple.ts
+                                                    |               ----------- /src/feast/acquisation-events/google.ts
+                                                    |              |
+ ----------------                                   |              |
+| google-play.ts |                                  |-----------<- | -<-----------
+ ----------------                                   v              |              |
+                                                    |               ------------/src/subscription-status/googleSubStatus.ts
+- fetchGoogleSubscription      <--------------------               |
+                                                                   |
+                                                                   |
+ ------------------                                                |
+| googleplay-v2.ts |                                               |
+ ------------------                                                |
+                                                                   |
+- fetchGoogleSubscriptionV2    <-----------------------------------
+
+```

--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -63,7 +63,7 @@ interface AppleLatestReceiptInfoItem {
 }
 type AppleLatestReceiptInfo = AppleLatestReceiptInfoItem[];
 
-export const transactionIdToAppleStoreKitSubscriptionData = async (
+const transactionIdToAppleStoreKitSubscriptionData = async (
     appBundleId: string,
     transactionId: string,
 ): Promise<AppleStoreKitSubscriptionData> => {


### PR DESCRIPTION
This add a piece of documentation to map the use of the apple and google api visually (prelude to extending google Dynamo records with extra data). 

We also remove one unnecessary `export`.