### PR TITLE
Update the retention period to 14 days for all the dead letter queues

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -694,6 +694,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-${Stage}-google-subscriptions-to-fetch-dlq
+      MessageRetentionPeriod: 1209600 # 14 days
       KmsMasterKeyId: alias/aws/sqs
       Tags:
         - Key: Stage
@@ -723,6 +724,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-${Stage}-apple-subscriptions-to-fetch-dlq
+      MessageRetentionPeriod: 1209600 # 14 days
       KmsMasterKeyId: alias/aws/sqs
       Tags:
         - Key: Stage
@@ -752,6 +754,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-${Stage}-feast-apple-subscriptions-to-fetch-dlq
+      MessageRetentionPeriod: 1209600 # 14 days
       KmsMasterKeyId: alias/aws/sqs
       Tags:
         - Key: Stage
@@ -781,6 +784,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-${Stage}-feast-google-subscriptions-to-fetch-dlq
+      MessageRetentionPeriod: 1209600 # 14 days
       KmsMasterKeyId: alias/aws/sqs
       Tags:
         - Key: Stage
@@ -1453,6 +1457,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-soft-opt-in-acquisitions-DLQ-${Stage}
+      MessageRetentionPeriod: 1209600 # 14 days
 
   SoftOptInAcquisitionsLambda:
     Type: AWS::Serverless::Function

--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -273,6 +273,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-${Stage}-google-historical-subscriptions-dlq
+      MessageRetentionPeriod: 1209600 # 14 days
       KmsMasterKeyId: alias/aws/sqs
       Tags:
         - Key: Stage
@@ -302,6 +303,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-${Stage}-apple-historical-subscriptions-dlq
+      MessageRetentionPeriod: 1209600 # 14 days
       KmsMasterKeyId: alias/aws/sqs
       Tags:
         - Key: Stage

--- a/feast-acquisition-events.cloudformation.yaml
+++ b/feast-acquisition-events.cloudformation.yaml
@@ -61,6 +61,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-${Stage}-feast-apple-acquisition-events-dlq
+      MessageRetentionPeriod: 1209600 # 14 days
       Tags:
         - Key: gu:repo
           Value: guardian/mobile-purchases
@@ -120,6 +121,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${App}-${Stage}-feast-google-acquisition-events-dlq
+      MessageRetentionPeriod: 1209600 # 14 days
       Tags:
         - Key: gu:repo
           Value: guardian/mobile-purchases


### PR DESCRIPTION
## What does this change?

Extend the retention period on mobile purchase SQS


[Trello card](https://trello.com/c/Nyxb3bZ1/1174-extend-the-retention-period-on-mobile-purchase-sqs)

We have encountered several instances where the Mobile Purchase Dead Letter Queue (SQS) alarm is triggered, but upon investigation, the letters in the queue have already disappeared. Additionally, there is no evidence of a purging or triggering of the retry mechanism. This issue occurs because the retention period for letters in the queue is set to 4 days by default.

So we need to update the retention policy for all Mobile Purchase Dead Letter Queues to 14 days to ensure sufficient time for investigation and resolution of issues before letters are removed.

## How to test

Tested in CODE 