### PR TITLE
feast: add MU/MUR to google country to currency mapping

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -134,6 +134,7 @@ const countryToCurrencyMap = {
     BZ: 'BZD', // Belize - Belize Dollar
     IL: 'ILS', // Israel - Israeli Shekel
     KG: 'KGS', // Kyrgyzstan - Kyrgystani Som
+    MU: 'MUR', // Republic of Mauritius  - Mauritian rupee
 };
 
 const countryToCurrency = (country: string): string => {


### PR DESCRIPTION
feast: add MU/MUR to google country to currency mapping, to prevent: "[acba643d] Country MU is not supported"