### PR TITLE
upgrade AWS Lambda runtime from Node.js 14 to 20.x

### DIFF
--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -104,7 +104,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: export-subscription-tables.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-subscription-tables/export-subscription-tables.zip
@@ -134,7 +134,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: export-subscription-tables.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-subscription-tables/export-subscription-tables.zip
@@ -164,7 +164,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: export-subscription-table-v2.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-subscription-table-v2/export-subscription-table-v2.zip
@@ -196,7 +196,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: export-subscription-table-v2.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-subscription-table-v2/export-subscription-table-v2.zip
@@ -228,7 +228,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: export-subscription-events-table.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-subscription-events-table/export-subscription-events-table.zip
@@ -317,7 +317,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: export-historical-data.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-historical-data/export-historical-data.zip
@@ -347,7 +347,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: export-historical-data.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-export-historical-data/export-historical-data.zip


### PR DESCRIPTION
- Update all Lambda functions across CloudFormation templates to use nodejs20.x runtime
- Ensures compatibility with supported Node.js LTS version
- Resolves security and performance issues with deprecated Node.js 14

Files updated:
- exports-cloudformation.yaml (7 Lambda functions)  