### PR TITLE
google extra (introduction)

### DIFF
--- a/typescript/src/feast/pubsub/google.ts
+++ b/typescript/src/feast/pubsub/google.ts
@@ -58,7 +58,7 @@ export function buildHandler(
                 }
 
                 const metaData = await fetchMetadata(notification);
-                const dynamoEvent = await toDynamoEvent_google_async(notification, metaData);
+                const dynamoEvent = await toDynamoEvent_google_async(notification, false, metaData);
 
                 await Promise.all([
                     sendMessageToSqs(queueUrl, androidSubscriptionReference),

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { SubscriptionEvent } from '../models/subscriptionEvent';
 import type { GoogleSubscriptionReference } from '../models/subscriptionReference';
 import { googlePackageNameToPlatform } from '../services/appToPlatform';
+import { build_extra_string } from '../services/google-subscription-extra';
+import { Stage } from '../utils/appIdentity';
 import { fetchGoogleSubscription, GOOGLE_PAYMENT_STATE } from '../services/google-play';
 import { dateToSecondTimestamp, optionalMsToDate, thirtyMonths } from '../utils/dates';
 import type { Option } from '../utils/option';
@@ -125,6 +127,7 @@ export async function fetchMetadata(
 
 export async function toDynamoEvent_google_async(
     notification: SubscriptionNotification,
+    shouldBuildExtra: boolean,
     metaData?: GoogleSubscriptionMetaData,
 ): Promise<SubscriptionEvent> {
     const eventTime = optionalMsToDate(notification.eventTimeMillis);
@@ -140,6 +143,13 @@ export async function toDynamoEvent_google_async(
     const platform = googlePackageNameToPlatform(notification.packageName)?.toString();
     if (!platform) {
         console.warn(`Unknown package name ${notification.packageName}`);
+    }
+
+    let extra = '';
+    console.log(`[8753e006] google pubsub, shouldBuildExtra: ${shouldBuildExtra}`);
+    if (shouldBuildExtra) {
+        extra = await build_extra_string(Stage);
+        console.log(`[a7beb002] ${extra}`);
     }
 
     const subscription = new SubscriptionEvent(

--- a/typescript/src/pubsub/pubsub.ts
+++ b/typescript/src/pubsub/pubsub.ts
@@ -29,7 +29,11 @@ function storeInDynamoImpl(event: SubscriptionEvent): Promise<SubscriptionEvent>
 export async function parseStoreAndSend_async<Payload, SqsEvent, MetaData>(
     request: APIGatewayProxyEvent,
     parsePayload: (body: Option<string>) => Payload | Ignorable | Error,
-    toDynamoEvent: (payload: Payload, metaData?: MetaData) => Promise<SubscriptionEvent>,
+    toDynamoEvent: (
+        payload: Payload,
+        shouldBuildExtra: boolean,
+        metaData?: MetaData,
+    ) => Promise<SubscriptionEvent>,
     toSqsEvent: (payload: Payload) => SqsEvent,
     fetchMetadata: (payload: Payload) => Promise<MetaData | undefined>,
     storeInDynamo: (event: SubscriptionEvent) => Promise<SubscriptionEvent> = storeInDynamoImpl,
@@ -61,7 +65,7 @@ export async function parseStoreAndSend_async<Payload, SqsEvent, MetaData>(
             }
 
             const metaData = await fetchMetadata(notification);
-            const dynamoEvent = await toDynamoEvent(notification, metaData);
+            const dynamoEvent = await toDynamoEvent(notification, false, metaData);
             const dynamoPromise = storeInDynamo(dynamoEvent);
             const sqsEvent = toSqsEvent(notification);
             const sqsPromise = sendToSqsFunction(queueUrl, sqsEvent);

--- a/typescript/src/services/google-subscription-extra.ts
+++ b/typescript/src/services/google-subscription-extra.ts
@@ -1,0 +1,12 @@
+// Author: Pascal
+// This file was introduced in July 2025 to implement the service that queries the Google API
+// to retrieve subscription and subscription product metadata in order to populate
+// the `extra` field for android records.
+
+// -----------------------------------------------
+
+export async function build_extra_string(stage: string): Promise<string> {
+    // stage is going to be used to retrieve the token from S3
+    const extra = `(work in progress)`;
+    return Promise.resolve(extra);
+}


### PR DESCRIPTION
This is the first of a series of changes to build the google version of the subscription data upgrade work we have recently done for the iOS records. 

This PR is left small on purpose and only introduce the minimum among of code to give birth to the `google-subscription-extra` service which is going to implement the new metadata.