### PR TITLE
Add BHD to google currency mapping

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -136,6 +136,7 @@ const countryToCurrencyMap = {
     KG: 'KGS', // Kyrgyzstan - Kyrgystani Som
     MU: 'MUR', // Republic of Mauritius - Mauritian rupee
     NP: 'NPR', // Nepal - Nepalese Rupee
+    BH: 'BHD', // Bahrain - Bahraini Dinar
 };
 
 const countryToCurrency = (country: string): string => {


### PR DESCRIPTION
Prevent: [acba643d] Country BH is not supported