### PR TITLE
fix(adjust-fivetran): Implement 3-day attribution delay to avoid discrepancy

### DIFF
--- a/adjust_report_etl/connector.py
+++ b/adjust_report_etl/connector.py
@@ -15,7 +15,7 @@ fivetran deploy --api-key xxx --destination GNM --connection adjust_premium --co
 import csv
 import json
 from io import StringIO
-
+from datetime import datetime, timedelta
 import requests
 from fivetran_connector_sdk import Connector
 from fivetran_connector_sdk import Logging as log
@@ -141,7 +141,8 @@ def schema(configuration: dict):
 def update(configuration: dict, state: dict):
     ADJUST_API_URL = "https://automate.adjust.com/reports-service/csv_report"
     AD_SPEND_MODE = "network"
-    DATE_PERIOD = "2023-04-01:-0d"
+    end_date = datetime.now() - timedelta(days=3)
+    DATE_PERIOD = f"2023-04-01:{end_date.strftime('%Y-%m-%d')}"
     API_KEY = configuration["API_KEY"]
     APP_TOKEN = configuration["APP_TOKEN"]
 


### PR DESCRIPTION
…stion of incomplete Adjust data

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

During our recent analysis, we discovered that Adjust install data retrieved on the same day is often incomplete due to delayed attributions (e.g., view-through and cross-device installs), especially from Apple. These discrepancies were leading to mismatches between Adjust and BigQuery data.

✅ What this PR changes

We now exclude the last 3 days of data from the date_period used when querying Adjust. This is implemented directly in code (hardcoded to 3 days) to avoid ingesting incomplete or unstable install data. This discrepancies between Adjust and BigQuery data are exclusively caused by Apple Search Ads, due to delayed attribution windows, where Apple finalizes install attributions after a delay—resulting in incomplete data when retrieved too early via direct API calls.

This allows:
	•	More accurate and stable ingestion
	•	Automatic retroactive corrections via full history sync (already part of the connector logic)
	•	No config file changes needed (simplified for now)

## How to test

deploy on fivetran

## How can we measure success?

looking at tableau report in the near future

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
