### PR TITLE
pass correct values to build_extra_string

### DIFF
--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -149,8 +149,19 @@ export async function toDynamoEvent_google_async(
     console.log(`[8753e006] google pubsub, shouldBuildExtra: ${shouldBuildExtra}`);
     if (shouldBuildExtra) {
         const purchaseToken = notification.subscriptionNotification.purchaseToken;
-        extra = await build_extra_string(Stage, purchaseToken);
+        const productId = notification.subscriptionNotification.subscriptionId; // [1]
+        extra = await build_extra_string(Stage, purchaseToken, productId);
         console.log(`[a7beb002] ${extra}`);
+
+        // [1]
+        // What is called `subscriptionId` in the notification is actually a productId.
+        // An example of notification is
+        // {
+        //     "packageName": "uk.co.guardian.feast",
+        //     "purchaseToken": "Example-kokmikjooafaEUsuLAO3RKjfwtmyQ",
+        //     "subscriptionId": "uk.co.guardian.feast.access"
+        //}
+        // See docs/google-identifiers.md for details
     }
 
     const subscription = new SubscriptionEvent(

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -148,7 +148,8 @@ export async function toDynamoEvent_google_async(
     let extra = '';
     console.log(`[8753e006] google pubsub, shouldBuildExtra: ${shouldBuildExtra}`);
     if (shouldBuildExtra) {
-        extra = await build_extra_string(Stage);
+        const purchaseToken = notification.subscriptionNotification.purchaseToken;
+        extra = await build_extra_string(Stage, purchaseToken);
         console.log(`[a7beb002] ${extra}`);
     }
 

--- a/typescript/src/services/google-subscription-extra.ts
+++ b/typescript/src/services/google-subscription-extra.ts
@@ -232,12 +232,15 @@ const extractGoogleSubscription = async (
 
 const extractGoogleSubscriptionProduct = async (
     accessToken: AccessToken,
+    productId: string,
 ): Promise<E1GoogleSubscriptionProduct | undefined> => {
     console.log(`[f779539] query google api for subscription product`);
 
+    // Example of productId: 'guardian.subscription.month.meteredoffer'
+    // See docs/google-identifiers.md for details
+
     // Sample data for the moment
     const packageName = 'com.guardian';
-    const productId = 'guardian.subscription.month.meteredoffer';
 
     const url = `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${packageName}/subscriptions/${productId}`;
     console.log(`[643eb5b5] url: ${url}`);
@@ -284,13 +287,17 @@ const extractOfferTagsFromSubscriptionProduct = (
     return [];
 };
 
-const buildExtraObject = async (accessToken: AccessToken, purchaseToken: string): Promise<E1Android | undefined> => {
+const buildExtraObject = async (
+    accessToken: AccessToken,
+    purchaseToken: string,
+    productId: string,
+): Promise<E1Android | undefined> => {
     const subscription = await extractGoogleSubscription(accessToken, purchaseToken);
     if (subscription === undefined) {
         return Promise.resolve(undefined);
     }
     console.log(`[26b172df] subscription: ${JSON.stringify(subscription)}`);
-    const subscriptionProduct = await extractGoogleSubscriptionProduct(accessToken);
+    const subscriptionProduct = await extractGoogleSubscriptionProduct(accessToken, productId);
     console.log(`[d9d390c4] subscription product: ${JSON.stringify(subscriptionProduct)}`);
     const offerTags = extractOfferTagsFromSubscriptionProduct(subscriptionProduct);
     console.log(`[68041474] offer tags: ${JSON.stringify(offerTags)}`);
@@ -302,9 +309,13 @@ const buildExtraObject = async (accessToken: AccessToken, purchaseToken: string)
     return Promise.resolve(extraObject);
 };
 
-export async function build_extra_string(stage: string, purchaseToken: string): Promise<string> {
+export async function build_extra_string(
+    stage: string,
+    purchaseToken: string,
+    productId: string,
+): Promise<string> {
     const accessToken: AccessToken = await getAccessToken(stage);
-    const extraObject = await buildExtraObject(accessToken, purchaseToken);
+    const extraObject = await buildExtraObject(accessToken, purchaseToken, productId);
     console.log(`[6734a9c1] extra object: ${JSON.stringify(extraObject)}`);
     const extra = `(work in progress)`;
     return Promise.resolve(extra);

--- a/typescript/src/services/google-subscription-extra.ts
+++ b/typescript/src/services/google-subscription-extra.ts
@@ -192,13 +192,12 @@ interface E1GoogleSubscriptionProduct {
 
 const extractGoogleSubscription = async (
     accessToken: AccessToken,
+    purchaseToken: string,
 ): Promise<E1GoogleSubscription | undefined> => {
     console.log(`[e0b04200] query google api for subscription`);
 
     // Sample data for the moment
     const packageName = 'com.guardian';
-    const purchaseToken =
-        'kadmieppmanincgeejahkkbp.AO-J1OywsudKktRZAd2tqgY9rTw-FXFujNuNHTokG7bia7jqZEox_xAj7Jb0Y8b3uSoW2ewDhT6FMla_ExAtQObAmHo53tmIjw';
 
     const url = `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${packageName}/purchases/subscriptionsv2/tokens/${purchaseToken}`;
     console.log(`[26b172df] url: ${url}`);
@@ -285,8 +284,8 @@ const extractOfferTagsFromSubscriptionProduct = (
     return [];
 };
 
-const buildExtraObject = async (accessToken: AccessToken): Promise<E1Android | undefined> => {
-    const subscription = await extractGoogleSubscription(accessToken);
+const buildExtraObject = async (accessToken: AccessToken, purchaseToken: string): Promise<E1Android | undefined> => {
+    const subscription = await extractGoogleSubscription(accessToken, purchaseToken);
     if (subscription === undefined) {
         return Promise.resolve(undefined);
     }
@@ -303,9 +302,9 @@ const buildExtraObject = async (accessToken: AccessToken): Promise<E1Android | u
     return Promise.resolve(extraObject);
 };
 
-export async function build_extra_string(stage: string): Promise<string> {
+export async function build_extra_string(stage: string, purchaseToken: string): Promise<string> {
     const accessToken: AccessToken = await getAccessToken(stage);
-    const extraObject = await buildExtraObject(accessToken);
+    const extraObject = await buildExtraObject(accessToken, purchaseToken);
     console.log(`[6734a9c1] extra object: ${JSON.stringify(extraObject)}`);
     const extra = `(work in progress)`;
     return Promise.resolve(extra);


### PR DESCRIPTION
Previously, in extra data for Google subscriptions:
- Part 5: https://github.com/guardian/mobile-purchases/pull/1939

Here we pass correct values to `build_extra_string`:
- The purchase token (which identify a subscription) will be passed to `extractGoogleSubscription`.
- The product id (which identify a subscription product) will be passed to `extractGoogleSubscriptionProduct`