### PR TITLE
Add ZW to google countryToCurrency code (2)

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -115,7 +115,11 @@ const countryToCurrencyMap = {
     EG: 'EGP', // Egypt - Egyptian Pound
     KE: 'KES', // Kenya - Kenyan Shilling
     ET: 'ETB', // Ethiopia - Ethiopian Birr
-    ZW: 'ZWG', // Zimbabwe, ZWG: The Zimbabwe Gold (ZiG; code: ZWG) is the official currency of Zimbabwe since 8 April 2024
+    ZW: 'ZWL', // Zimbabwe, Zimbabwe Dollar ( https://en.wikipedia.org/wiki/Zimbabwean_dollar )
+    // Although The Zimbabwe Gold (ZiG; code: ZWG) ( https://en.wikipedia.org/wiki/Zimbabwean_ZiG )
+    // is the official currency of Zimbabwe since 8 April 2024,
+    // the bigquery-acquisitions-publisher, expect the old currency Zimbabwe Dollar
+    // https://github.com/guardian/support-frontend/blob/7bb6458a3cda69b70f8d3e46ac6b95814891216d/support-lambdas/bigquery-acquisitions-publisher/typescript/currencySchema.ts#L163
 
     // Americas
     MX: 'MXN', // Mexico - Mexican Peso


### PR DESCRIPTION
Follow up of https://github.com/guardian/mobile-purchases/pull/1943

Although The Zimbabwe Gold (ZiG; code: ZWG) ( https://en.wikipedia.org/wiki/Zimbabwean_ZiG ) is the official currency of Zimbabwe since 8 April 2024, the bigquery-acquisitions-publisher, expect the old currency Zimbabwe Dollar: https://github.com/guardian/support-frontend/blob/7bb6458a3cda69b70f8d3e46ac6b95814891216d/support-lambdas/bigquery-acquisitions-publisher/typescript/currencySchema.ts#L163
