### PR TITLE
fix(adjust): fix final fix adjust discrepancy

### DIFF
--- a/adjust_report_etl/connector.py
+++ b/adjust_report_etl/connector.py
@@ -141,8 +141,9 @@ def schema(configuration: dict):
 def update(configuration: dict, state: dict):
     ADJUST_API_URL = "https://automate.adjust.com/reports-service/csv_report"
     AD_SPEND_MODE = "network"
-    end_date = datetime.now() - timedelta(days=3)
-    DATE_PERIOD = f"2023-04-01:{end_date.strftime('%Y-%m-%d')}"
+    end_date = datetime.now()
+    start_date = datetime.now() - timedelta(days=4)
+    DATE_PERIOD = f"{start_date.strftime('%Y-%m-%d')}:{end_date.strftime('%Y-%m-%d')}"
     API_KEY = configuration["API_KEY"]
     APP_TOKEN = configuration["APP_TOKEN"]
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This change updates the Adjust connector’s sync configuration to:
	•	Only sync the last 4 days of data instead of the full history.
	•	Run more frequent syncs to ensure fresher and more up-to-date data in BigQuery.

This change is based on the assumption that Adjust data becomes immutable after 3 days, especially for Apple Search Ads campaigns where late-arriving events can cause fluctuations. By syncing only the relevant window (last 4 days), we reduce unnecessary load while still capturing any delayed data updates.

## How to test

go in tableau

## How can we measure success?

go in tableau

## Have we considered potential risks?

no risks

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
