### PR TITLE
Add Côte d'Ivoire to the apple storefront mapping

### DIFF
--- a/typescript/src/services/apple-mappings.ts
+++ b/typescript/src/services/apple-mappings.ts
@@ -93,6 +93,7 @@ const storefrontToCountryMap = {
     PAK: 'PK', // Pakistan
     BHR: 'BH', // Bahrain
     NPL: 'NP', // Nepal
+    CIV: 'CI', // Côte d'Ivoire
 };
 
 export const storefrontToCountry = (storefront: string): string => {


### PR DESCRIPTION
Prevent: "[898812c2] storefront CIV is not supported"