### PR TITLE
correct the implementation of expiresDateMs

### DIFF
--- a/typescript/src/pubsub/apple-common.ts
+++ b/typescript/src/pubsub/apple-common.ts
@@ -413,7 +413,7 @@ function parseNotification(payload: unknown): Result<string, StatusUpdateNotific
 
     const expiresDateMs = (unifiedReceipt: UnifiedReceiptInfo): number => {
         if (unifiedReceipt.latest_receipt_info.length > 0) {
-            return Number(unifiedReceipt.latest_receipt_info[0].purchase_date_ms || '0');
+            return Number(unifiedReceipt.latest_receipt_info[0].expires_date_ms ?? '0');
         }
         return 0;
     };


### PR DESCRIPTION
@paulbrown1982 reported that the implementation of `expiresDateMs` we made two years ago ( https://github.com/guardian/mobile-purchases/pull/1235/files#r2282071052 ) is incorrect as it reads the `purchase_date_ms` instead of the `expires_date_ms`. 