### PR TITLE
handle apple storekit errors

### DIFF
--- a/typescript/src/feast/acquisition-events/apple.ts
+++ b/typescript/src/feast/acquisition-events/apple.ts
@@ -2,6 +2,8 @@ import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import fetch from 'node-fetch';
 import { App } from '../../models/app';
 import type { Subscription } from '../../models/subscription';
+import type { AppleStoreKitSubscriptionDataDerivationForFeastPipeline } from '../../services/api-storekit';
+import { appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline } from '../../services/api-storekit';
 import type {
     AppleValidationResponse,
     ValidationOptions,
@@ -10,15 +12,23 @@ import { validateReceipt } from '../../services/appleValidateReceipts';
 import { toAppleSubscription_async } from '../../update-subs/apple';
 import { postPayloadToAcquisitionAPI } from './common';
 import type { AcquisitionApiPayload, AcquisitionApiPayloadQueryParameter } from './common';
-import { appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline } from '../../services/api-storekit';
 
 const appleSubscriptionToAcquisitionApiPayload = async (
     subscription: Subscription,
 ): Promise<AcquisitionApiPayload> => {
-    const extendedData =
+    const extendedData: AppleStoreKitSubscriptionDataDerivationForFeastPipeline | undefined =
         await appleSubscriptionToAppleStoreKitSubscriptionDataDerivationForFeastPipeline(
             subscription,
         );
+
+    if (extendedData === undefined) {
+        console.error(
+            `[e88e8329] there was a problem while acquiring subscription data from Apple`,
+        );
+        throw new Error(
+            '[ae7b14ba] there was a problem while acquiring subscription data from Apple',
+        );
+    }
 
     console.log(`[12901310] acquisition api payload: ${JSON.stringify(extendedData)}`);
 

--- a/typescript/src/pubsub/apple.ts
+++ b/typescript/src/pubsub/apple.ts
@@ -2,6 +2,7 @@ import 'source-map-support/register';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { SubscriptionEvent } from '../models/subscriptionEvent';
 import type { AppleSubscriptionReference } from '../models/subscriptionReference';
+import type { AppleStoreKitSubscriptionData } from '../services/api-storekit';
 import { transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra } from '../services/api-storekit';
 import { appleBundleToPlatform } from '../services/appToPlatform';
 import { Stage } from '../utils/appIdentity';
@@ -55,14 +56,17 @@ export async function toDynamoEvent_apple_async(
         // Defining the two variables we need to call for the extra data
         const original_transaction_id = receiptsInOrder[0].original_transaction_id;
         const appBundleId = notification.bid;
-        const extra_object = await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(
-            appBundleId,
-            original_transaction_id,
-        );
-        extra = JSON.stringify(extra_object);
-        console.log(`[8250388c] original_transaction_id: ${original_transaction_id}`);
-        console.log(`[6081748f] appBundleId: ${appBundleId}`);
-        console.log(`[ffa2b2a7] extra: ${extra}`);
+        const extra_object: AppleStoreKitSubscriptionData | undefined =
+            await transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra(
+                appBundleId,
+                original_transaction_id,
+            );
+        if (extra_object !== undefined) {
+            extra = JSON.stringify(extra_object);
+            console.log(`[8250388c] original_transaction_id: ${original_transaction_id}`);
+            console.log(`[6081748f] appBundleId: ${appBundleId}`);
+            console.log(`[ffa2b2a7] extra: ${extra}`);
+        }
     }
 
     const subscription = new SubscriptionEvent(


### PR DESCRIPTION
We address a problem by which the apple storekit fails to return the extra data for a subscription, and cause data errors. Here we

1. Update the signature of the functions involved
2. If the operation was optional (for instance building the `extra` data for subscription), we do not error (A separate piece of work will address those case)
3. If the operation was mandatory (for instance during the processing of Feast subscriptions), then we carry on erroring. (We might come up with a way in the future to not error, but for the moment we maintain the current behavior)

