### PR TITLE
PRODUCT_BILLING_PERIOD

### DIFF
--- a/typescript/src/services/productBillingPeriod.ts
+++ b/typescript/src/services/productBillingPeriod.ts
@@ -5,6 +5,7 @@ export const PRODUCT_BILLING_PERIOD: Record<string, string> = {
     'com.guardian.subscription.6monthly.12': 'P6M',
     'com.guardian.subscription.6monthly.13.freetrial': 'P6M',
     'com.guardian.subscription.monthly.10': 'P1M',
+    'com.guardian.subscription.monthly.10.freetrial': 'P1M',
     'com.guardian.subscription.monthly.11.freetrial': 'P1M',
     'com.guardian.subscription.annual.13': 'P1Y',
     'com.guardian.subscription.annual.14.freetrial': 'P1Y',


### PR DESCRIPTION
Prevent:
WARN [593d026a] Unable to get the billing period, unknown google subscription ID com.guardian.subscription.monthly.10.freetrial
