### PR TITLE
[extra field project; iOS] Part 6: update google-subscription-extra.ts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,8 +19,8 @@ Data enters the system via pubsub endpoints which are called by the Apple App St
                                                                                                                                                                 |
  ------------------------      HTTP via API Gateway        ----------------                         ------------                                         -----------------------------                        ----------------------------------
 | App Store & Play Store | --------------------------->   | Pubsub Lambdas |      ---------------> | SQS Queues | --------------------------------------| Update subscription Lambdas | -------------------> | Dynamo Table: subscriptions [08] |
- ------------------------                                  ----------------                         ------------                                         -----------------------------                        ----------------------------------
-                                                          ( applepubsub [09] )                     ( apple-subscriptions-to-fetch )                     ( apple-update-subscriptions [03] )
+ ------------------------                                  ----------------                         ------------                                         -----------------------------                       |               [extra]            |
+                                                          ( applepubsub [09] )                     ( apple-subscriptions-to-fetch )                     ( apple-update-subscriptions [03] )                   ----------------------------------
                                                           ( googlepubsub [10] )                    ( google-subscriptions-to-fetch [06] )               ( google-update-subscriptions [02] )
                                                           ( feastapplepubsub )                     ( feast-apple-subscriptions-to-fetch [05] )          ( feast-apple-subscriptions-to-fetch [11] )
                                                           ( feastgooglepubsub )                    ( feast-google-subscriptions-to-fetch [04] )         ( feast-google-subscriptions-to-fetch [01] )
@@ -34,8 +34,9 @@ Data enters the system via pubsub endpoints which are called by the Apple App St
                                                                 v                                                                                               |                   ------------
                                                  -------------------------------------------                                                                     ----------------> | SQS Queues |
                                                 | Dynamo Table: subscription-events-v2 [07] |                                                                      (feast only)     ------------
-                                                 -------------------------------------------                                                                                       ( apple-historical-subscriptions )
-                                                                                                                                                                                   ( google-historical-subscriptions )
+                                                |               [extra]                     |                                                                                  ( apple-historical-subscriptions )
+                                                 -------------------------------------------                                                                                   ( google-historical-subscriptions )
+                                                                                                                                                                                   
 
 [09] lambda : applepubsub
      code: src/pubsub/apple.ts
@@ -44,7 +45,7 @@ Data enters the system via pubsub endpoints which are called by the Apple App St
 
 [10] lambda : googlepubsub
      code: src/pubsub/google.ts
-     AWS function (s): mobile-purchases-googlepubsub-PROD
+     AWS function (s): mobile-purchases-googlepubsub-PROD (generate extra for table [07])
                      : mobile-purchases-googlepubsub-CODE
 
 [06] queue : google-subscriptions-to-fetch
@@ -74,10 +75,10 @@ Data enters the system via pubsub endpoints which are called by the Apple App St
      AWS function: mobile-purchases-feast-apple-update-subscriptions-PROD
 
 [07] table : subscription-events-v2
-     Dynamo table: mobile-purchases-PROD-subscription-events-v2
+     Dynamo table: mobile-purchases-PROD-subscription-events-v2 [extra]
 
 [08] table : subscriptions
-     Dynamo table: mobile-purchases-PROD-subscriptions
+     Dynamo table: mobile-purchases-PROD-subscriptions [extra]
 
 ```
 
@@ -88,6 +89,8 @@ In addition to writing to the subscriptions Dynamo table, the Feast lambdas also
 **Note:** Apple subscriptions are revalidated on a schedule by the apple-revalidate-receipts lambda. This lambda reads from the subscriptions Dynamo table and pushes items to the subscriptions-to-fetch SQS queues.
 
 **Note:** Tokens for the Play Store are refreshed on a schedule by the mobile-purchases-googleoauth lambda and accessed from an s3 bucket.
+
+**Note:** The [extra] attribute added to some tables is described in [extra.md](extra.md).
 
 ## Linking
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,4 @@ mobile-purchases performs at least two primary functions.
 - [Signing request to api.storekit.itunes.apple.com](storekit-signatures.md)
 - [The Feast Acquisition Pipeline](feast-acqusition-pipeline.md)
 - [Calling Apple and Google APIs](calling-apple-and-google-apis.md)
+- [The extra field](extra.md)

--- a/docs/extra.md
+++ b/docs/extra.md
@@ -1,0 +1,109 @@
+
+### Introducing the extra field
+
+The `extra` field [1], was introduced by Pascal in 2025 as a temporary measure to help Data Design get extra data about subscriptions without and before the project to redesign the entire system.
+
+The two tables that have received an extra field are
+
+- mobile-purchases-PROD-subscription-events-v2
+- mobile-purchases-PROD-subscriptions
+
+The extra field add data to both Apple and Android subscriptions, both using the `extra` field but the object being added is different between the two platforms.
+
+[1] Ok, ok, by now I can see it might now have been the absolute best name.
+
+### The Apple extra field
+
+The apple extra object is retreived from Apple using the [api-storekit.ts](https://github.com/guardian/mobile-purchases/blob/a67a7d2246342bb16d635ace4f407c66ea7d0b28/typescript/src/services/api-storekit.ts)
+
+Example (anonymised)
+
+```
+{
+    "guType": "apple-extra-2025-04-29",
+    "transactionId": "180002815908204",
+    "originalTransactionId": "180001049822339",
+    "webOrderLineItemId": "180001274909722",
+    "bundleId": "uk.co.guardian.iphone2",
+    "productId": "uk.co.guardian.gla.1month.2018May.withFreeTrial",
+    "subscriptionGroupIdentifier": "20450880",
+    "purchaseDate": 1755362890000,
+    "originalPurchaseDate": 1630236283000,
+    "expiresDate": 1758041290000,
+    "quantity": 1,
+    "type": "Auto-Renewable Subscription",
+    "inAppOwnershipType": "PURCHASED",
+    "signedDate": 1755334128921,
+    "environment": "Production",
+    "transactionReason": "RENEWAL",
+    "storefront": "AUS",
+    "storefrontId": "143460",
+    "price": 14990,
+    "currency": "AUD",
+    "appTransactionId": "704334945917031057"
+}
+```
+
+The data we get from the Apple API is the above object without the `guType` attribute. That attribute is added to the object we get from Apple to indicate that the object is companion of Apple subscription. The value is always "apple-extra-2025-04-29".
+
+
+### The Google/Android extra field
+
+The extra object for Android is constructed in [google-subscription-extra.ts](https://github.com/guardian/mobile-purchases/blob/a67a7d2246342bb16d635ace4f407c66ea7d0b28/typescript/src/services/google-subscription-extra.ts)
+
+Unlike the extra object for Apple where we just call the API once and add the `guType` attribute to the object, for Google, it take more hoops.
+
+First we start with a purchase `purchaseToken` and a `productId`. And example is 
+
+- purchaseToken: "Example-kokmikjooafaEUsuLAO3RKjfwtmyQ",
+- productId: "uk.co.guardian.feast.access"
+
+We also need an access token that is retrieved from S3. There is a process which generates the access token and drops it to S3.
+
+Using the `purchaseToken` we retrieve a subscription (first call to the Google API). Using the subscription we retrieve a `subscriptionProduct` (second call to the Google API). Using the subscription product we determine the offer tags.
+
+The resulting extra object has the form 
+
+```
+{
+    guType: "google-extra-2025-06-26",
+    subscription,
+    offerTags,
+}
+```
+
+Alike the Apple extra object, the Google/Android extra object has a an extra attribute called `guType` and value "google-extra-2025-06-26".
+
+```
+{
+    "guType": "google-extra-2025-06-26",
+    "subscription": {
+        "kind": "androidpublisher#subscriptionPurchaseV2",
+        "startTime": "2020-10-17T11:29:43.457Z",
+        "regionCode": "DE",
+        "subscriptionState": "SUBSCRIPTION_STATE_ACTIVE",
+        "latestOrderId": "GPA.3331-7311-8633-87504..58",
+        "acknowledgementState": "ACKNOWLEDGEMENT_STATE_ACKNOWLEDGED",
+        "lineItems": [
+            {
+                "productId": "com.guardian.subscription.monthly.10",
+                "expiryTime": "2025-09-24T13:29:26.306Z",
+                "autoRenewingPlan": {
+                    "autoRenewEnabled": true,
+                    "recurringPrice": {
+                        "currencyCode": "EUR",
+                        "units": "6",
+                        "nanos": 990000000
+                    }
+                },
+                "offerDetails": {
+                    "basePlanId": "p1m",
+                    "offerId": "freetrial"
+                },
+                "latestSuccessfulOrderId": "GPA.3331-7311-8633-87504..58"
+            }
+        ]
+    },
+    "offerTags": []
+}
+```

--- a/typescript/src/services/google-subscription-extra.ts
+++ b/typescript/src/services/google-subscription-extra.ts
@@ -43,36 +43,6 @@ interface E1CommonPrice {
     nanos: number;
 }
 
-/*
-line item example:
-    {
-        "productId": "guardian.subscription.month.meteredoffer",
-        "expiryTime": "2025-08-26T15:10:44.400Z",
-        "autoRenewingPlan": {
-            "autoRenewEnabled": true,
-            "recurringPrice": {
-                "currencyCode": "GBP",
-                "units": "11",
-                "nanos": 990000000
-            },
-            "priceChangeDetails": {
-                "newPrice": {
-                    "currencyCode": "GBP",
-                    "units": "11",
-                    "nanos": 990000000
-                },
-                "priceChangeMode": "OPT_OUT_PRICE_INCREASE",
-                "priceChangeState": "APPLIED"
-            }
-        },
-        "offerDetails": {
-            "basePlanId": "p1m",
-            "offerId": "offer1month"
-        },
-        "latestSuccessfulOrderId": "GPA.3386-9869-8781-40466..21"
-    }
-*/
-
 interface E1GoogleSubscriptionLineItemAutoRenewingPlan {
     autoRenewEnabled: boolean;
     recurringPrice: E1CommonPrice;
@@ -101,74 +71,6 @@ interface E1GoogleSubscription {
     acknowledgementState: string;
     lineItems: E1GoogleSubscriptionLineItem[];
 }
-
-/*
-E1GoogleSubscriptionProduct example
-
-{
-  "packageName": "com.guardian",
-  "productId": "guardian.subscription.month.meteredoffer",
-  "basePlans": [
-    {
-      "basePlanId": "p1m",
-      "regionalConfigs": [
-        {
-          "regionCode": "AE",
-          "newSubscriberAvailability": true,
-          "price": {
-            "currencyCode": "AED",
-            "units": "47",
-            "nanos": 710000000
-          }
-        },
-        {
-          "regionCode": "AT",
-          "newSubscriberAvailability": true,
-          "price": {
-            "currencyCode": "EUR",
-            "units": "9",
-            "nanos": 990000000
-          }
-        },
-        (...)
-      ],
-      "state": "ACTIVE",
-      "autoRenewingBasePlanType": {
-        "billingPeriodDuration": "P1M",
-        "gracePeriodDuration": "P30D",
-        "resubscribeState": "RESUBSCRIBE_STATE_ACTIVE",
-        "prorationMode": "SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE",
-        "legacyCompatible": true,
-        "legacyCompatibleSubscriptionOfferId": "offer1month",
-        "accountHoldDuration": "P30D"
-      },
-      "otherRegionsConfig": {
-        "usdPrice": {
-          "currencyCode": "USD",
-          "units": "9",
-          "nanos": 940000000
-        },
-        "eurPrice": {
-          "currencyCode": "EUR",
-          "units": "9",
-          "nanos": 320000000
-        },
-        "newSubscriberAvailability": true
-      }
-    }
-  ],
-  "listings": [
-    {
-      "title": "£9.99/1-month (with offer)",
-      "languageCode": "en-GB"
-    }
-  ],
-  "taxAndComplianceSettings": {
-    "eeaWithdrawalRightType": "WITHDRAWAL_RIGHT_SERVICE"
-  }
-}
-*/
-
 interface E1GoogleSubscriptionProductBasePlanRegionalConfig {
     regionCode: string;
     newSubscriberAvailability: boolean;
@@ -179,14 +81,14 @@ interface E1GoogleSubscriptionProductBasePlan {
     regionalConfigs: E1GoogleSubscriptionProductBasePlanRegionalConfig[];
     state: string;
     // autoRenewingBasePlanType // not modelled for the moment
-    // otherRegionsConfig // not modelled for the moment
+    // otherRegionsConfig       // not modelled for the moment
 }
 
 interface E1GoogleSubscriptionProduct {
     packageName: string;
     productId: string;
     basePlans: E1GoogleSubscriptionProductBasePlan[];
-    // listings // not modelled for the moment
+    // listings                 // not modelled for the moment
     // taxAndComplianceSettings // not modelled for the moment
 }
 
@@ -239,7 +141,6 @@ const extractGoogleSubscriptionProduct = async (
     // Example of productId: 'guardian.subscription.month.meteredoffer'
     // See docs/google-identifiers.md for details
 
-    // Sample data for the moment
     const packageName = 'com.guardian';
 
     const url = `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${packageName}/subscriptions/${productId}`;
@@ -297,8 +198,120 @@ const buildExtraObject = async (
         return Promise.resolve(undefined);
     }
     console.log(`[26b172df] subscription: ${JSON.stringify(subscription)}`);
+    /*
+        {
+            "guType": "google-extra-2025-06-26",
+            "subscription": {
+                "kind": "androidpublisher#subscriptionPurchaseV2",
+                "startTime": "2020-10-17T11:29:43.457Z",
+                "regionCode": "DE",
+                "subscriptionState": "SUBSCRIPTION_STATE_ACTIVE",
+                "latestOrderId": "GPA.3331-7311-8633-87504..58",
+                "acknowledgementState": "ACKNOWLEDGEMENT_STATE_ACKNOWLEDGED",
+                "lineItems": [
+                    {
+                        "productId": "com.guardian.subscription.monthly.10",
+                        "expiryTime": "2025-09-24T13:29:26.306Z",
+                        "autoRenewingPlan": {
+                            "autoRenewEnabled": true,
+                            "recurringPrice": {
+                                "currencyCode": "EUR",
+                                "units": "6",
+                                "nanos": 990000000
+                            }
+                        },
+                        "offerDetails": {
+                            "basePlanId": "p1m",
+                            "offerId": "freetrial"
+                        },
+                        "latestSuccessfulOrderId": "GPA.3331-7311-8633-87504..58"
+                    }
+                ]
+            },
+            "offerTags": []
+        }
+    */
     const subscriptionProduct = await extractGoogleSubscriptionProduct(accessToken, productId);
     console.log(`[d9d390c4] subscription product: ${JSON.stringify(subscriptionProduct)}`);
+    /*
+        {
+            "packageName": "com.guardian",
+            "productId": "uk.co.guardian.subscription.3",
+            "basePlans": [
+                {
+                    "basePlanId": "p1m",
+                    "regionalConfigs": [
+                        {
+                            "regionCode": "AE",
+                            "newSubscriberAvailability": true,
+                            "price": {
+                                "currencyCode": "AED",
+                                "units": "22",
+                                "nanos": 930000000
+                            }
+                        },
+                        (...) # many instances
+                        {
+                            "regionCode": "ZM",
+                            "newSubscriberAvailability": true,
+                            "price": {
+                                "currencyCode": "USD",
+                                "units": "4",
+                                "nanos": 660000000
+                            }
+                        },
+                        {
+                            "regionCode": "ZW",
+                            "newSubscriberAvailability": true,
+                            "price": {
+                                "currencyCode": "USD",
+                                "units": "4",
+                                "nanos": 660000000
+                            }
+                        }
+                    ],
+                    "state": "ACTIVE",
+                    "autoRenewingBasePlanType": {
+                        "billingPeriodDuration": "P1M",
+                        "gracePeriodDuration": "P30D",
+                        "resubscribeState": "RESUBSCRIBE_STATE_ACTIVE",
+                        "prorationMode": "SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE",
+                        "legacyCompatible": true,
+                        "legacyCompatibleSubscriptionOfferId": "freetrial",
+                        "accountHoldDuration": "P30D"
+                    },
+                    "otherRegionsConfig": {
+                        "usdPrice": {
+                            "currencyCode": "USD",
+                            "units": "3",
+                            "nanos": 130000000
+                        },
+                        "eurPrice": {
+                            "currencyCode": "EUR",
+                            "units": "2",
+                            "nanos": 950000000
+                        },
+                        "newSubscriberAvailability": true
+                    }
+                }
+            ],
+            "listings": [
+                {
+                    "title": "Premium Tier Subscription",
+                    "languageCode": "en-GB",
+                    "description": "Premium Tier Subscription"
+                },
+                {
+                    "title": "Premium Tier Subscription",
+                    "languageCode": "en-US",
+                    "description": "Premium Tier Subscription"
+                }
+            ],
+            "taxAndComplianceSettings": {
+                "eeaWithdrawalRightType": "WITHDRAWAL_RIGHT_SERVICE"
+            }
+        }
+    */
     const offerTags = extractOfferTagsFromSubscriptionProduct(subscriptionProduct);
     console.log(`[68041474] offer tags: ${JSON.stringify(offerTags)}`);
     const extraObject: E1Android = {


### PR DESCRIPTION
Previously in "Generate Dynamo table `extra` field for android subscriptions"...
- Part 1: https://github.com/guardian/mobile-purchases/pull/1921 
- Part 2: https://github.com/guardian/mobile-purchases/pull/1931
- Part 3: https://github.com/guardian/mobile-purchases/pull/1932
- Part 4: https://github.com/guardian/mobile-purchases/pull/1937
- Part 5: https://github.com/guardian/mobile-purchases/pull/1939

In this Part 6, we update introduce the documentation notes for `extra` (both for Apple/iOS and Google/Android). And update some comments in google-subscription-extra.ts