### PR TITLE
Include platform for user subscriptions

### DIFF
--- a/typescript/src/user/user.ts
+++ b/typescript/src/user/user.ts
@@ -10,6 +10,7 @@ import type { UserIdResolution } from '../utils/guIdentityApi';
 import { getAuthToken, getUserId } from '../utils/guIdentityApi';
 import { mapPlatformToSoftOptInProductName } from '../utils/softOptIns';
 import { getConfigValue } from '../utils/ssmConfig';
+import { Platform } from '../models/platform';
 
 interface SubscriptionStatus {
     subscriptionId: string;
@@ -21,6 +22,7 @@ interface SubscriptionStatus {
     autoRenewing: boolean;
     productId: string;
     softOptInProductName: string;
+    platform?: Platform;
 }
 
 interface SubscriptionStatusResponse {
@@ -83,6 +85,7 @@ async function getSubscriptions(subscriptionIds: string[]): Promise<Subscription
             autoRenewing: sub.autoRenewing,
             productId: sub.productId,
             softOptInProductName: mapPlatformToSoftOptInProductName(sub.platform),
+            platform: sub.platform as Platform,
         };
     });
 

--- a/typescript/tests/user/user.test.ts
+++ b/typescript/tests/user/user.test.ts
@@ -1,4 +1,5 @@
 import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { Platform } from '../../src/models/platform';
 import { SubscriptionEmpty } from '../../src/models/subscription';
 import { handler } from '../../src/user/user';
 import { plusDays } from '../../src/utils/dates';
@@ -56,7 +57,7 @@ describe('The user subscriptions lambda', () => {
         });
         const sub = new SubscriptionEmpty();
         sub.subscriptionId = subscriptionId;
-        sub.platform = 'ios-feast';
+        sub.platform = Platform.IosFeast;
         sub.productId = 'product-id';
         sub.startTimestamp = new Date().toISOString();
         sub.endTimestamp = plusDays(new Date(), 35).toISOString();
@@ -75,6 +76,7 @@ describe('The user subscriptions lambda', () => {
         expect(data.subscriptions[0].subscriptionId).toEqual(subscriptionId);
         expect(data.subscriptions[0].valid).toEqual(true);
         expect(data.subscriptions[0].softOptInProductName).toEqual('FeastInAppPurchase');
+        expect(data.subscriptions[0].platform).toEqual(Platform.IosFeast);
     });
 });
 


### PR DESCRIPTION
This pull request enhances the subscription handling by introducing the `Platform` type to the subscription status. The changes also update the related test suite to use the new `Platform` enum, ensuring consistency across the codebase.


**Context:**

We are doing this change in the context of the [this](https://github.com/guardian/members-data-api/pull/1142#issuecomment-3228421737) comment on [this](https://github.com/guardian/members-data-api/pull/1142) pull request. TL:DR we found out that we are not showing Support messaging to Feast app subscribers, which is not expected. To be able to solve this, we have to somehow be able to differentiate Live App subs from other App subs. After looking at data, mainly `productId` there were too many variants. So we decide to use the `platform` property and consider Live App subs the ones with `platform` as `android` or `ios` (excluding the others like `ios-feast`, etc).
The change on `members-data-api` is described [here](https://github.com/guardian/members-data-api/pull/1144).

**Subscription model improvements:**

* Added an optional `platform` property of type `Platform` to the `SubscriptionStatus` interface in `user.ts`, and ensured the property is set when mapping subscription data. [[1]](diffhunk://#diff-e3dc4f56534c44edc5f964b4cdad95a976fc597691b0b5ca104a8922d3008a86R25) [[2]](diffhunk://#diff-e3dc4f56534c44edc5f964b4cdad95a976fc597691b0b5ca104a8922d3008a86R88)
* Imported the `Platform` enum from `models/platform` and used it in relevant locations within `user.ts`.

**Test updates:**

* Updated tests in `user.test.ts` to use the `Platform` enum instead of string literals for the `platform` property, and added an assertion to verify the `platform` value in the response. [[1]](diffhunk://#diff-f3906bc1d59409d2987b30e32da11f953270a832d982a83b55e2751165e08888R2) [[2]](diffhunk://#diff-f3906bc1d59409d2987b30e32da11f953270a832d982a83b55e2751165e08888L59-R60) [[3]](diffhunk://#diff-f3906bc1d59409d2987b30e32da11f953270a832d982a83b55e2751165e08888R79)