### PR TITLE
[TBC] Enabling streams for the DynamoDB subscription-events-v2 tables

### DIFF
--- a/dynamo.cloudformation.yaml
+++ b/dynamo.cloudformation.yaml
@@ -48,6 +48,8 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       SSESpecification:
         SSEEnabled: true
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
       TimeToLiveSpecification:
         Enabled: true
         AttributeName: ttl


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Enabling streams for the DynamoDB subscription-events-v2 tables that will get extracted via Fivetran to BigQuery.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- [ ] Streaming enabled on `mobile-purchases-CODE-subscription-events-v2` after deploying to CODE

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Fivetran can extract 

- [ ] CODE table is extractable via Fivetran

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

- This is replacing an existing ETL process so is not a new use or deposit of personal data.
