### PR TITLE
Prepare googleResponseBodyToSubscription for extra metadata (Part 1)

### DIFF
--- a/docs/extra.md
+++ b/docs/extra.md
@@ -4,16 +4,16 @@ The `extra` field [1], was introduced by Pascal in 2025 as a temporary measure t
 
 The two tables that have received an extra field are
 
-- mobile-purchases-PROD-subscription-events-v2
 - mobile-purchases-PROD-subscriptions
+- mobile-purchases-PROD-subscription-events-v2
 
 The extra field add data to both Apple and Android subscriptions, both using the `extra` field but the object being added is different between the two platforms.
 
 [1] Ok, ok, by now I can see it might now have been the absolute best name.
 
-### The Apple extra field
+### The Apple/iOS extra field
 
-The apple extra object is retreived from Apple using the [api-storekit.ts](https://github.com/guardian/mobile-purchases/blob/a67a7d2246342bb16d635ace4f407c66ea7d0b28/typescript/src/services/api-storekit.ts)
+The apple extra object is retrieved from Apple using the [api-storekit.ts](https://github.com/guardian/mobile-purchases/blob/a67a7d2246342bb16d635ace4f407c66ea7d0b28/typescript/src/services/api-storekit.ts)
 
 Example (anonymised)
 

--- a/typescript/src/feast/update-subs/google.ts
+++ b/typescript/src/feast/update-subs/google.ts
@@ -53,6 +53,7 @@ export const buildHandler =
         sendSubscriptionToHistoricalQueue: (subscription: Subscription) => Promise<void>,
         exchangeExternalIdForIdentityId: (externalId: string) => Promise<IdentityIdFromBraze>,
         storeUserSubInDynamo: (userSub: UserSubscription) => Promise<void>,
+        shouldBuildExtra: boolean = false,
     ) =>
     async (event: SQSEvent) => {
         const promises = event.Records.map(async (sqsRecord: SQSRecord) => {
@@ -81,6 +82,7 @@ export const buildHandler =
                     subRef.packageName,
                     subRef.subscriptionId,
                     subscriptionFromGoogle.billingPeriodDuration,
+                    shouldBuildExtra,
                     googleResponseV1,
                 );
                 await sendSubscriptionToHistoricalQueue(subscriptionV1);
@@ -146,4 +148,5 @@ export const handler = buildHandler(
     queueHistoricalSubscription,
     getIdentityIdFromBraze,
     storeUserSubscriptionInDynamo,
+    true,
 );


### PR DESCRIPTION
This is the first of two prelude PRs in preparation for https://github.com/guardian/mobile-purchases/pull/1995 .

Here we update googleResponseBodyToSubscription with the template to call the library function to build the `extra` attribute for the `mobile-purchases-PROD-subscriptions` table. Note that we expanded the signature of the function to control whether the metadata string is constructed or not. This is to prevent it from doing so from the test suite.