### PR TITLE
Make getGoogleSubResponse asynchronous

### DIFF
--- a/typescript/src/feast/update-subs/google.ts
+++ b/typescript/src/feast/update-subs/google.ts
@@ -77,7 +77,7 @@ export const buildHandler =
                     subRef.purchaseToken,
                     subRef.packageName,
                 );
-                const subscriptionV1 = googleResponseBodyToSubscription(
+                const subscriptionV1 = await googleResponseBodyToSubscription(
                     subRef.purchaseToken,
                     subRef.packageName,
                     subRef.subscriptionId,


### PR DESCRIPTION
This is the second prelude for https://github.com/guardian/mobile-purchases/pull/1995 . Previous prelude: https://github.com/guardian/mobile-purchases/pull/1996

Here we upgrade the signature of googleResponseBodyToSubscription to become an asynchronous function.