### PR TITLE
Handle 500 return codes from api.storekit

### DIFF
--- a/typescript/src/services/api-storekit.ts
+++ b/typescript/src/services/api-storekit.ts
@@ -93,6 +93,7 @@ const transactionIdToAppleStoreKitSubscriptionData = async (
             json = await response.json();
         } else {
             console.error(`[661fe1aa] error: fetch failed: ${response.status}`);
+            return Promise.resolve(undefined);
         }
     } catch (error) {
         if (error instanceof Error) {


### PR DESCRIPTION
Here we address this event in the logs (which caused an alarm)

```
[
        "TypeError: Cannot read properties of undefined (reading 'data')",
        "    at s (/var/task/apple-pubsub.js:2:83499)",
        "    at processTicksAndRejections (node:internal/process/task_queues:95:5)",
        "    at t.transactionIdToAppleStoreKitSubscriptionDataDerivationForExtra (/var/task/apple-pubsub.js:2:85043)",
        "    at l (/var/task/apple-pubsub.js:2:1029656)",
        "    at /var/task/apple-pubsub.js:2:964353"
]
```

The key was 

```
[55ca8e2c] undefined
```

which was caused by 

```
[661fe1aa] error: fetch failed: 500
```

The original code didn't correctly handle a non 200 code from the Apple API. 