### PR TITLE
update pubsub.test.ts

### DIFF
--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -20,7 +20,24 @@ import { parseStoreAndSend_async } from '../../src/pubsub/pubsub';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { SendMessageResult } from 'aws-sdk/clients/sqs';
 import { PromiseResult } from 'aws-sdk/lib/request';
-import type { AWSError } from 'aws-sdk';
+
+type GooglePayload = {
+	version: string;
+	packageName: string;
+	eventTimeMillis: string;
+	subscriptionNotification?: {
+		version: string;
+		notificationType: number;
+		purchaseToken: string;
+		subscriptionId: string;
+	};
+	voidedPurchaseNotification?: {
+		purchaseToken: string;
+		orderId: string;
+		productType: number;
+		refundType: number;
+	};
+};
 
 describe('The google pubsub', () => {
 	test('Should return HTTP 200 and store the correct data in dynamo (1)', () => {
@@ -41,7 +58,7 @@ describe('The google pubsub', () => {
 				),
 		);
 
-		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+		const mockGoogleFetchMetadataFunction = jest.fn((_event: GooglePayload) =>
 			Promise.resolve({ freeTrial: true }),
 		);
 
@@ -133,7 +150,7 @@ describe('The google pubsub', () => {
 				metaData?: GoogleSubscriptionMetaData,
 			) => googlePayloadToDynamo(notification, false, metaData),
 			toGoogleSqsEvent,
-			mockFetchMetadataFunction,
+			mockGoogleFetchMetadataFunction,
 			mockStoreFunction,
 			mockSqsFunction,
 		).then((result) => {
@@ -146,8 +163,8 @@ describe('The google pubsub', () => {
 			expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual(
 				expectedSubscriptionReferenceInSqs,
 			);
-			expect(mockFetchMetadataFunction.mock.calls.length).toEqual(1);
-			expect(mockFetchMetadataFunction.mock.calls[0][0]).toStrictEqual(
+			expect(mockGoogleFetchMetadataFunction.mock.calls.length).toEqual(1);
+			expect(mockGoogleFetchMetadataFunction.mock.calls[0][0]).toStrictEqual(
 				receivedEvent,
 			);
 		});
@@ -169,7 +186,7 @@ describe('The google pubsub', () => {
 					>,
 				),
 		);
-		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+		const mockGoogleFetchMetadataFunction = jest.fn((_event: GooglePayload) =>
 			Promise.resolve({ freeTrial: true }),
 		);
 
@@ -198,7 +215,7 @@ describe('The google pubsub', () => {
 			path: '',
 			pathParameters: {},
 			multiValueQueryStringParameters: {},
-			// @ts-expect-error
+			// @ts-expect-error // keeping the test fixtures small
 			requestContext: null,
 			resource: '',
 		};
@@ -211,7 +228,7 @@ describe('The google pubsub', () => {
 				metaData?: GoogleSubscriptionMetaData,
 			) => googlePayloadToDynamo(notification, false, metaData),
 			toGoogleSqsEvent,
-			mockFetchMetadataFunction,
+			mockGoogleFetchMetadataFunction,
 			mockStoreFunction,
 			mockSqsFunction,
 		);
@@ -235,7 +252,7 @@ describe('The google pubsub', () => {
 					>,
 				),
 		);
-		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+		const mockGoogleFetchMetadataFunction = jest.fn((_event: GooglePayload) =>
 			Promise.resolve({ freeTrial: true }),
 		);
 
@@ -274,7 +291,7 @@ describe('The google pubsub', () => {
 			path: '',
 			pathParameters: {},
 			multiValueQueryStringParameters: {},
-			// @ts-expect-error
+			// @ts-expect-error // keeping the test fixtures small
 			requestContext: null,
 			resource: '',
 		};
@@ -287,7 +304,7 @@ describe('The google pubsub', () => {
 				metaData?: GoogleSubscriptionMetaData,
 			) => googlePayloadToDynamo(notification, false, metaData),
 			toGoogleSqsEvent,
-			mockFetchMetadataFunction,
+			mockGoogleFetchMetadataFunction,
 			mockStoreFunction,
 			mockSqsFunction,
 		);
@@ -313,8 +330,8 @@ describe('The apple pubsub', () => {
 					>,
 				),
 		);
-		const mockFetchMetadataFunction = jest.fn((_event: any) =>
-			Promise.resolve(undefined),
+		const mockAppleFetchMetadataFunction = jest.fn(
+			(_event: StatusUpdateNotification) => Promise.resolve(undefined),
 		);
 
 		const body: StatusUpdateNotification = {
@@ -389,7 +406,7 @@ describe('The apple pubsub', () => {
 			resource: '',
 		};
 
-		const expectedSubscriptionEventInDynamo: any = {
+		const expectedSubscriptionEventInDynamo: Partial<SubscriptionEvent> = {
 			subscriptionId: 'TEST',
 			eventType: 'INITIAL_BUY',
 			platform: 'ios',
@@ -454,7 +471,7 @@ describe('The apple pubsub', () => {
 			parseApplePayload,
 			(notification) => applePayloadToDynamo(notification, false),
 			toAppleSqsEvent,
-			mockFetchMetadataFunction,
+			mockAppleFetchMetadataFunction,
 			mockStoreFunction,
 			mockSqsFunction,
 		).then((result) => {
@@ -467,7 +484,7 @@ describe('The apple pubsub', () => {
 			expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual(
 				expectedSubscriptionReferenceInSqs,
 			);
-			expect(mockFetchMetadataFunction.mock.calls.length).toEqual(1);
+			expect(mockAppleFetchMetadataFunction.mock.calls.length).toEqual(1);
 		});
 	});
 });

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe, it } from '@jest/globals';
+import { expect, test, describe, it, jest } from '@jest/globals';
 import { HTTPResponses } from '../../src/models/apiGatewayHttp';
 import { SubscriptionEvent } from '../../src/models/subscriptionEvent';
 import {
@@ -18,24 +18,31 @@ import {
 } from '../../src/pubsub/google-common';
 import { parseStoreAndSend_async } from '../../src/pubsub/pubsub';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { SendMessageResult } from 'aws-sdk/clients/sqs';
+import { PromiseResult } from 'aws-sdk/lib/request';
+import type { AWSError } from 'aws-sdk';
 
 describe('The google pubsub', () => {
 	test('Should return HTTP 200 and store the correct data in dynamo (1)', () => {
 		process.env['Secret'] = 'MYSECRET';
 		process.env['QueueUrl'] = '';
 
-		const mockStoreFunction: jest.Mock<
-			Promise<SubscriptionEvent>,
-			[SubscriptionEvent]
-		> = jest.fn((event) => Promise.resolve(event));
+		const mockStoreFunction = jest.fn((event: SubscriptionEvent) =>
+			Promise.resolve(event),
+		);
 
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, { purchaseToken: string }]
-		> = jest.fn((queurl, event) => Promise.resolve({}));
+		const mockSqsFunction = jest.fn(
+			(_queueUrl: string, _event: { purchaseToken: string }) =>
+				Promise.resolve(
+					{} as unknown as PromiseResult<
+						SendMessageResult,
+						import('aws-sdk').AWSError
+					>,
+				),
+		);
 
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+			Promise.resolve({ freeTrial: true }),
 		);
 
 		const receivedEvent = {
@@ -76,7 +83,7 @@ describe('The google pubsub', () => {
 			path: '',
 			pathParameters: {},
 			multiValueQueryStringParameters: {},
-			// @ts-expect-error
+			// @ts-expect-error // keeping test fixtures small
 			requestContext: null,
 			resource: '',
 		};
@@ -149,17 +156,23 @@ describe('The google pubsub', () => {
 	it('returns a 400 response if the payload parsing fails', async () => {
 		process.env['Secret'] = 'MYSECRET';
 		process.env['QueueUrl'] = '';
-		const mockStoreFunction: jest.Mock<
-			Promise<SubscriptionEvent>,
-			[SubscriptionEvent]
-		> = jest.fn((event) => Promise.resolve(event));
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, { purchaseToken: string }]
-		> = jest.fn((queurl, event) => Promise.resolve({}));
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+
+		const mockStoreFunction = jest.fn((event: SubscriptionEvent) =>
+			Promise.resolve(event),
 		);
+		const mockSqsFunction = jest.fn(
+			(_queueUrl: string, _event: { purchaseToken: string }) =>
+				Promise.resolve(
+					{} as unknown as PromiseResult<
+						SendMessageResult,
+						import('aws-sdk').AWSError
+					>,
+				),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+			Promise.resolve({ freeTrial: true }),
+		);
+
 		const receivedEvent = { foo: 'bar' };
 		const encodedEvent = Buffer.from(JSON.stringify(receivedEvent)).toString(
 			'base64',
@@ -209,17 +222,23 @@ describe('The google pubsub', () => {
 	it('returns a 200 response but does not do anything with a voided purchase notification', async () => {
 		process.env['Secret'] = 'MYSECRET';
 		process.env['QueueUrl'] = '';
-		const mockStoreFunction: jest.Mock<
-			Promise<SubscriptionEvent>,
-			[SubscriptionEvent]
-		> = jest.fn((event) => Promise.resolve(event));
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, { purchaseToken: string }]
-		> = jest.fn((queurl, event) => Promise.resolve({}));
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+
+		const mockStoreFunction = jest.fn((event: SubscriptionEvent) =>
+			Promise.resolve(event),
 		);
+		const mockSqsFunction = jest.fn(
+			(_queueUrl: string, _event: { purchaseToken: string }) =>
+				Promise.resolve(
+					{} as unknown as PromiseResult<
+						SendMessageResult,
+						import('aws-sdk').AWSError
+					>,
+				),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+			Promise.resolve({ freeTrial: true }),
+		);
+
 		const receivedEvent = {
 			version: '1.0',
 			packageName: 'com.guardian.debug',
@@ -282,18 +301,20 @@ describe('The apple pubsub', () => {
 		process.env['Secret'] = 'MYSECRET';
 		process.env['QueueUrl'] = '';
 
-		const mockStoreFunction: jest.Mock<
-			Promise<SubscriptionEvent>,
-			[SubscriptionEvent]
-		> = jest.fn((event) => Promise.resolve(event));
-
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, { receipt: string }]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
-
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ undefined }),
+		const mockStoreFunction = jest.fn((event: SubscriptionEvent) =>
+			Promise.resolve(event),
+		);
+		const mockSqsFunction = jest.fn(
+			(_queueUrl: string, _event: { receipt: string }) =>
+				Promise.resolve(
+					{} as unknown as PromiseResult<
+						SendMessageResult,
+						import('aws-sdk').AWSError
+					>,
+				),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+			Promise.resolve(undefined),
 		);
 
 		const body: StatusUpdateNotification = {
@@ -363,7 +384,7 @@ describe('The apple pubsub', () => {
 			path: '',
 			pathParameters: {},
 			multiValueQueryStringParameters: {},
-			// @ts-expect-error
+			// @ts-expect-error // keeping test fixtures small
 			requestContext: null,
 			resource: '',
 		};


### PR DESCRIPTION
Previously: https://github.com/guardian/mobile-purchases/pull/2126

Fourth episode of a series aimed at removing all linting errors from the entire codebase. Here we update pubsub.test.ts. This has moved the number of errors from 168 to 143.