### PR TITLE
update deleteLink.test.ts

### DIFF
--- a/typescript/tests/link/deleteLink.test.ts
+++ b/typescript/tests/link/deleteLink.test.ts
@@ -1,32 +1,59 @@
 import type { DynamoDBRecord, DynamoDBStreamEvent } from 'aws-lambda';
 import { handler } from '../../src/link/deleteLink';
 import { UserSubscriptionEmpty } from '../../src/models/userSubscription';
+import * as dynamodbMapper from '@aws/dynamodb-data-mapper';
+import * as sqsModule from 'aws-sdk/clients/sqs';
+import {
+	expect,
+	describe,
+	it,
+	beforeEach,
+	afterEach,
+	jest,
+} from '@jest/globals';
 
-import { expect, describe, it, beforeEach, afterEach } from '@jest/globals';
+const mockedDynamoDBMapper = dynamodbMapper as unknown as {
+	DataMapper: new () => {
+		put: jest.Mock;
+		delete: jest.Mock;
+		query: jest.Mock;
+	};
+	setMockQuery: (
+		fn: (params: {
+			keyCondition: unknown;
+			indexName: unknown;
+		}) => AsyncIterable<unknown>,
+	) => void;
+};
+
+const mockedSQS = sqsModule as unknown as {
+	default: new () => {
+		sendMessage: jest.Mock;
+	};
+};
 
 jest.mock('@aws/dynamodb-data-mapper', () => {
 	const actualDataMapper = jest.requireActual('@aws/dynamodb-data-mapper');
 
 	const queryFn = jest.fn();
-	const putFn = jest.fn().mockResolvedValue(true);
-	const deleteFn = jest.fn().mockResolvedValue(true);
+	const putFn = jest.fn().mockResolvedValue(true as never);
+	const deleteFn = jest.fn().mockResolvedValue(true as never);
 
-	return {
-		...actualDataMapper,
+	return Object.assign({}, actualDataMapper, {
 		DataMapper: jest.fn().mockImplementation(() => ({
 			put: putFn,
 			delete: deleteFn,
 			query: queryFn,
 		})),
-		setMockQuery: (mockImplementation: (arg0: any) => any) => {
+		setMockQuery: (mockImplementation: (arg0: unknown) => unknown) => {
 			queryFn.mockImplementation(async function* (params) {
 				const iterator = mockImplementation(params);
-				for await (const item of iterator) {
+				for await (const item of iterator as AsyncIterable<unknown>) {
 					yield item;
 				}
 			});
 		},
-	};
+	});
 });
 
 jest.mock('util', () => jest.fn());
@@ -36,11 +63,14 @@ jest.mock('aws-sdk/clients/sqs', () => {
 		sendMessage: jest.fn().mockReturnValue({ promise: jest.fn() }),
 	};
 
-	return jest.fn(() => mockSQS);
+	return {
+		__esModule: true,
+		default: jest.fn(() => mockSQS),
+	};
 });
+
 jest.mock('../../src/utils/guIdentityApi');
 
-// mock so imports don't use real client which throws an error as credentials are needed
 jest.mock('aws-sdk/clients/dynamodb', () => jest.fn());
 jest.mock('aws-sdk/clients/s3', () => jest.fn());
 jest.mock('aws-sdk/clients/ssm', () => jest.fn());
@@ -51,16 +81,17 @@ jest.mock('aws-sdk/clients/cloudwatch', () => jest.fn());
 jest.mock('aws-sdk/clients/sts', () => {
 	const mockSTS = {
 		assumeRole: jest.fn().mockReturnValue({
-			promise: jest.fn().mockResolvedValue({
-				Credentials: {
-					AccessKeyId: 'mockAccessKeyId',
-					SecretAccessKey: 'mockSecretAccessKey',
-					SessionToken: 'mockSessionToken',
-				},
-			}),
+			promise: jest.fn().mockImplementation(() =>
+				Promise.resolve({
+					Credentials: {
+						AccessKeyId: 'mockAccessKeyId',
+						SecretAccessKey: 'mockSecretAccessKey',
+						SessionToken: 'mockSessionToken',
+					},
+				}),
+			),
 		}),
 	};
-
 	return jest.fn(() => mockSTS);
 });
 
@@ -75,15 +106,11 @@ jest.mock('aws-sdk/lib/core', () => {
 	};
 });
 
-const setMockQuery = require('@aws/dynamodb-data-mapper').setMockQuery;
-
 describe('handler', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
-
-		// Set the current time to a fixed date (2023-03-14)
 		jest.useFakeTimers();
-		jest.setSystemTime(new Date('2023-03-14').getTime()); // or 1678780800000
+		jest.setSystemTime(new Date('2023-03-14').getTime());
 	});
 
 	afterEach(() => {
@@ -93,13 +120,12 @@ describe('handler', () => {
 
 	it('should process removed records, put messages on queue', async () => {
 		// get the mock instances
-		const mockDataMapper =
-			new (require('@aws/dynamodb-data-mapper').DataMapper)();
-		const mockSQS = new (require('aws-sdk/clients/sqs'))();
+		const mockDataMapper = new mockedDynamoDBMapper.DataMapper();
+		const mockSQS = new mockedSQS.default();
 
-		setMockQuery(async function* (params: {
-			keyCondition: any;
-			indexName: any;
+		mockedDynamoDBMapper.setMockQuery(async function* (_params: {
+			keyCondition: unknown;
+			indexName: unknown;
 		}) {
 			yield {
 				subscriptionId: '1',
@@ -150,14 +176,14 @@ describe('handler', () => {
 
 	it('puts Feast deletions on the SOI SQS queue with the product name FeastInAppPurchase', async () => {
 		// get the mock instances
-		const mockSQS = new (require('aws-sdk/clients/sqs'))();
+		const mockSQS = new mockedSQS.default();
 
 		const subscriptionId = '1';
 		const userId = '123';
 
-		setMockQuery(async function* (params: {
-			keyCondition: any;
-			indexName: any;
+		mockedDynamoDBMapper.setMockQuery(async function* (_params: {
+			keyCondition: unknown;
+			indexName: unknown;
 		}) {
 			yield {
 				subscriptionId,
@@ -195,9 +221,8 @@ describe('handler', () => {
 
 	it('should not process modified records', async () => {
 		// get the mock instances
-		const mockDataMapper =
-			new (require('@aws/dynamodb-data-mapper').DataMapper)();
-		const mockSQS = new (require('aws-sdk/clients/sqs'))();
+		const mockDataMapper = new mockedDynamoDBMapper.DataMapper();
+		const mockSQS = new mockedSQS.default();
 
 		const event: DynamoDBStreamEvent = {
 			Records: [modifyDynamoRecord],

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -20,7 +20,24 @@ import { parseStoreAndSend_async } from '../../src/pubsub/pubsub';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { SendMessageResult } from 'aws-sdk/clients/sqs';
 import { PromiseResult } from 'aws-sdk/lib/request';
-import type { AWSError } from 'aws-sdk';
+
+type GooglePayload = {
+	version: string;
+	packageName: string;
+	eventTimeMillis: string;
+	subscriptionNotification?: {
+		version: string;
+		notificationType: number;
+		purchaseToken: string;
+		subscriptionId: string;
+	};
+	voidedPurchaseNotification?: {
+		purchaseToken: string;
+		orderId: string;
+		productType: number;
+		refundType: number;
+	};
+};
 
 describe('The google pubsub', () => {
 	test('Should return HTTP 200 and store the correct data in dynamo (1)', () => {
@@ -41,7 +58,7 @@ describe('The google pubsub', () => {
 				),
 		);
 
-		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+		const mockGoogleFetchMetadataFunction = jest.fn((_event: GooglePayload) =>
 			Promise.resolve({ freeTrial: true }),
 		);
 
@@ -133,7 +150,7 @@ describe('The google pubsub', () => {
 				metaData?: GoogleSubscriptionMetaData,
 			) => googlePayloadToDynamo(notification, false, metaData),
 			toGoogleSqsEvent,
-			mockFetchMetadataFunction,
+			mockGoogleFetchMetadataFunction,
 			mockStoreFunction,
 			mockSqsFunction,
 		).then((result) => {
@@ -146,8 +163,8 @@ describe('The google pubsub', () => {
 			expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual(
 				expectedSubscriptionReferenceInSqs,
 			);
-			expect(mockFetchMetadataFunction.mock.calls.length).toEqual(1);
-			expect(mockFetchMetadataFunction.mock.calls[0][0]).toStrictEqual(
+			expect(mockGoogleFetchMetadataFunction.mock.calls.length).toEqual(1);
+			expect(mockGoogleFetchMetadataFunction.mock.calls[0][0]).toStrictEqual(
 				receivedEvent,
 			);
 		});
@@ -169,7 +186,7 @@ describe('The google pubsub', () => {
 					>,
 				),
 		);
-		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+		const mockGoogleFetchMetadataFunction = jest.fn((_event: GooglePayload) =>
 			Promise.resolve({ freeTrial: true }),
 		);
 
@@ -198,7 +215,7 @@ describe('The google pubsub', () => {
 			path: '',
 			pathParameters: {},
 			multiValueQueryStringParameters: {},
-			// @ts-expect-error
+			// @ts-expect-error // keeping the test fixtures small
 			requestContext: null,
 			resource: '',
 		};
@@ -211,7 +228,7 @@ describe('The google pubsub', () => {
 				metaData?: GoogleSubscriptionMetaData,
 			) => googlePayloadToDynamo(notification, false, metaData),
 			toGoogleSqsEvent,
-			mockFetchMetadataFunction,
+			mockGoogleFetchMetadataFunction,
 			mockStoreFunction,
 			mockSqsFunction,
 		);
@@ -235,7 +252,7 @@ describe('The google pubsub', () => {
 					>,
 				),
 		);
-		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+		const mockGoogleFetchMetadataFunction = jest.fn((_event: GooglePayload) =>
 			Promise.resolve({ freeTrial: true }),
 		);
 
@@ -274,7 +291,7 @@ describe('The google pubsub', () => {
 			path: '',
 			pathParameters: {},
 			multiValueQueryStringParameters: {},
-			// @ts-expect-error
+			// @ts-expect-error // keeping the test fixtures small
 			requestContext: null,
 			resource: '',
 		};
@@ -287,7 +304,7 @@ describe('The google pubsub', () => {
 				metaData?: GoogleSubscriptionMetaData,
 			) => googlePayloadToDynamo(notification, false, metaData),
 			toGoogleSqsEvent,
-			mockFetchMetadataFunction,
+			mockGoogleFetchMetadataFunction,
 			mockStoreFunction,
 			mockSqsFunction,
 		);
@@ -313,8 +330,8 @@ describe('The apple pubsub', () => {
 					>,
 				),
 		);
-		const mockFetchMetadataFunction = jest.fn((_event: any) =>
-			Promise.resolve(undefined),
+		const mockAppleFetchMetadataFunction = jest.fn(
+			(_event: StatusUpdateNotification) => Promise.resolve(undefined),
 		);
 
 		const body: StatusUpdateNotification = {
@@ -389,7 +406,7 @@ describe('The apple pubsub', () => {
 			resource: '',
 		};
 
-		const expectedSubscriptionEventInDynamo: any = {
+		const expectedSubscriptionEventInDynamo: Partial<SubscriptionEvent> = {
 			subscriptionId: 'TEST',
 			eventType: 'INITIAL_BUY',
 			platform: 'ios',
@@ -454,7 +471,7 @@ describe('The apple pubsub', () => {
 			parseApplePayload,
 			(notification) => applePayloadToDynamo(notification, false),
 			toAppleSqsEvent,
-			mockFetchMetadataFunction,
+			mockAppleFetchMetadataFunction,
 			mockStoreFunction,
 			mockSqsFunction,
 		).then((result) => {
@@ -467,7 +484,7 @@ describe('The apple pubsub', () => {
 			expect(mockSqsFunction.mock.calls[0][1]).toStrictEqual(
 				expectedSubscriptionReferenceInSqs,
 			);
-			expect(mockFetchMetadataFunction.mock.calls.length).toEqual(1);
+			expect(mockAppleFetchMetadataFunction.mock.calls.length).toEqual(1);
 		});
 	});
 });

--- a/typescript/tests/pubsub/pubsub.test.ts
+++ b/typescript/tests/pubsub/pubsub.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe, it } from '@jest/globals';
+import { expect, test, describe, it, jest } from '@jest/globals';
 import { HTTPResponses } from '../../src/models/apiGatewayHttp';
 import { SubscriptionEvent } from '../../src/models/subscriptionEvent';
 import {
@@ -18,24 +18,31 @@ import {
 } from '../../src/pubsub/google-common';
 import { parseStoreAndSend_async } from '../../src/pubsub/pubsub';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { SendMessageResult } from 'aws-sdk/clients/sqs';
+import { PromiseResult } from 'aws-sdk/lib/request';
+import type { AWSError } from 'aws-sdk';
 
 describe('The google pubsub', () => {
 	test('Should return HTTP 200 and store the correct data in dynamo (1)', () => {
 		process.env['Secret'] = 'MYSECRET';
 		process.env['QueueUrl'] = '';
 
-		const mockStoreFunction: jest.Mock<
-			Promise<SubscriptionEvent>,
-			[SubscriptionEvent]
-		> = jest.fn((event) => Promise.resolve(event));
+		const mockStoreFunction = jest.fn((event: SubscriptionEvent) =>
+			Promise.resolve(event),
+		);
 
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, { purchaseToken: string }]
-		> = jest.fn((queurl, event) => Promise.resolve({}));
+		const mockSqsFunction = jest.fn(
+			(_queueUrl: string, _event: { purchaseToken: string }) =>
+				Promise.resolve(
+					{} as unknown as PromiseResult<
+						SendMessageResult,
+						import('aws-sdk').AWSError
+					>,
+				),
+		);
 
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+			Promise.resolve({ freeTrial: true }),
 		);
 
 		const receivedEvent = {
@@ -76,7 +83,7 @@ describe('The google pubsub', () => {
 			path: '',
 			pathParameters: {},
 			multiValueQueryStringParameters: {},
-			// @ts-expect-error
+			// @ts-expect-error // keeping test fixtures small
 			requestContext: null,
 			resource: '',
 		};
@@ -149,17 +156,23 @@ describe('The google pubsub', () => {
 	it('returns a 400 response if the payload parsing fails', async () => {
 		process.env['Secret'] = 'MYSECRET';
 		process.env['QueueUrl'] = '';
-		const mockStoreFunction: jest.Mock<
-			Promise<SubscriptionEvent>,
-			[SubscriptionEvent]
-		> = jest.fn((event) => Promise.resolve(event));
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, { purchaseToken: string }]
-		> = jest.fn((queurl, event) => Promise.resolve({}));
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+
+		const mockStoreFunction = jest.fn((event: SubscriptionEvent) =>
+			Promise.resolve(event),
 		);
+		const mockSqsFunction = jest.fn(
+			(_queueUrl: string, _event: { purchaseToken: string }) =>
+				Promise.resolve(
+					{} as unknown as PromiseResult<
+						SendMessageResult,
+						import('aws-sdk').AWSError
+					>,
+				),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+			Promise.resolve({ freeTrial: true }),
+		);
+
 		const receivedEvent = { foo: 'bar' };
 		const encodedEvent = Buffer.from(JSON.stringify(receivedEvent)).toString(
 			'base64',
@@ -209,17 +222,23 @@ describe('The google pubsub', () => {
 	it('returns a 200 response but does not do anything with a voided purchase notification', async () => {
 		process.env['Secret'] = 'MYSECRET';
 		process.env['QueueUrl'] = '';
-		const mockStoreFunction: jest.Mock<
-			Promise<SubscriptionEvent>,
-			[SubscriptionEvent]
-		> = jest.fn((event) => Promise.resolve(event));
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, { purchaseToken: string }]
-		> = jest.fn((queurl, event) => Promise.resolve({}));
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+
+		const mockStoreFunction = jest.fn((event: SubscriptionEvent) =>
+			Promise.resolve(event),
 		);
+		const mockSqsFunction = jest.fn(
+			(_queueUrl: string, _event: { purchaseToken: string }) =>
+				Promise.resolve(
+					{} as unknown as PromiseResult<
+						SendMessageResult,
+						import('aws-sdk').AWSError
+					>,
+				),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+			Promise.resolve({ freeTrial: true }),
+		);
+
 		const receivedEvent = {
 			version: '1.0',
 			packageName: 'com.guardian.debug',
@@ -282,18 +301,20 @@ describe('The apple pubsub', () => {
 		process.env['Secret'] = 'MYSECRET';
 		process.env['QueueUrl'] = '';
 
-		const mockStoreFunction: jest.Mock<
-			Promise<SubscriptionEvent>,
-			[SubscriptionEvent]
-		> = jest.fn((event) => Promise.resolve(event));
-
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, { receipt: string }]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
-
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ undefined }),
+		const mockStoreFunction = jest.fn((event: SubscriptionEvent) =>
+			Promise.resolve(event),
+		);
+		const mockSqsFunction = jest.fn(
+			(_queueUrl: string, _event: { receipt: string }) =>
+				Promise.resolve(
+					{} as unknown as PromiseResult<
+						SendMessageResult,
+						import('aws-sdk').AWSError
+					>,
+				),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: any) =>
+			Promise.resolve(undefined),
 		);
 
 		const body: StatusUpdateNotification = {
@@ -363,7 +384,7 @@ describe('The apple pubsub', () => {
 			path: '',
 			pathParameters: {},
 			multiValueQueryStringParameters: {},
-			// @ts-expect-error
+			// @ts-expect-error // keeping test fixtures small
 			requestContext: null,
 			resource: '',
 		};

--- a/typescript/tests/soft-opt-ins/acquisition.test.ts
+++ b/typescript/tests/soft-opt-ins/acquisition.test.ts
@@ -1,46 +1,73 @@
 import type { DynamoDBStreamEvent } from 'aws-lambda';
-import { expect } from '@jest/globals';
+import {
+	expect,
+	jest,
+	describe,
+	beforeEach,
+	afterEach,
+	it,
+	test,
+} from '@jest/globals';
 import { Platform } from '../../src/models/platform';
 import { SubscriptionEmpty } from '../../src/models/subscription';
 import { handler } from '../../src/soft-opt-ins/acquisitions';
 import { isPostAcquisition } from '../../src/soft-opt-ins/processSubscription';
+import * as dynamodbMapper from '@aws/dynamodb-data-mapper';
+import * as sqsModule from 'aws-sdk/clients/sqs';
+import fetch from 'node-fetch';
+
+// Typed mock for DynamoDB Mapper
+const mockedDynamoDBMapper = dynamodbMapper as unknown as {
+	DataMapper: new () => {
+		batchPut: jest.Mock;
+		get: jest.Mock;
+		put: jest.Mock;
+		delete: jest.Mock;
+		query: jest.Mock;
+		scan: jest.Mock;
+		update: jest.Mock;
+	};
+	setMockGet: (fn: (arg0: unknown) => unknown) => void;
+};
+
+// Typed mock for SQS
+const mockedSQS = sqsModule as unknown as {
+	default: new () => {
+		sendMessage: jest.Mock;
+	};
+};
 
 jest.mock('@aws/dynamodb-data-mapper', () => {
 	const actualDataMapper = jest.requireActual('@aws/dynamodb-data-mapper');
 
 	const getFn = jest.fn();
 
-	return {
-		...actualDataMapper,
+	return Object.assign({}, actualDataMapper, {
 		DataMapper: jest.fn().mockImplementation(() => ({
 			batchPut: jest.fn(),
 			get: getFn,
-			put: jest.fn().mockResolvedValue(undefined),
+			put: jest.fn().mockImplementation(() => Promise.resolve(undefined)),
 			delete: jest.fn(),
 			query: jest.fn(),
 			scan: jest.fn(),
 			update: jest.fn(),
 		})),
-		setMockGet: (mockImplementation: (arg0: any) => any) => {
+		setMockGet: (mockImplementation: (arg0: unknown) => unknown) => {
 			getFn.mockImplementation(async (params) => {
 				return mockImplementation(params);
 			});
 		},
-	};
+	});
 });
-const setMockGet = require('@aws/dynamodb-data-mapper').setMockGet;
 
 // mock so imports don't use real client which throws an error as credentials are needed
 jest.mock('aws-sdk/clients/dynamodb', () => jest.fn());
 jest.mock('aws-sdk/clients/s3', () => jest.fn());
 jest.mock('aws-sdk/clients/ssm', () => jest.fn());
 
-const fetch = require('node-fetch');
-
-jest.mock('node-fetch');
+jest.mock('node-fetch', () => jest.fn());
 
 jest.mock('../../src/utils/guIdentityApi');
-jest.mock('aws-sdk/clients/ssm', () => jest.fn());
 jest.mock('aws-sdk/clients/cloudwatch', () => jest.fn());
 
 jest.mock('util', () => jest.fn());
@@ -50,19 +77,24 @@ jest.mock('aws-sdk/clients/sqs', () => {
 		sendMessage: jest.fn().mockReturnValue({ promise: jest.fn() }),
 	};
 
-	return jest.fn(() => mockSQS);
+	return {
+		__esModule: true,
+		default: jest.fn(() => mockSQS),
+	};
 });
 
 jest.mock('aws-sdk/clients/sts', () => {
 	const mockSTS = {
 		assumeRole: jest.fn().mockReturnValue({
-			promise: jest.fn().mockResolvedValue({
-				Credentials: {
-					AccessKeyId: 'mockAccessKeyId',
-					SecretAccessKey: 'mockSecretAccessKey',
-					SessionToken: 'mockSessionToken',
-				},
-			}),
+			promise: jest.fn().mockImplementation(() =>
+				Promise.resolve({
+					Credentials: {
+						AccessKeyId: 'mockAccessKeyId',
+						SecretAccessKey: 'mockSecretAccessKey',
+						SessionToken: 'mockSessionToken',
+					},
+				}),
+			),
 		}),
 	};
 
@@ -82,25 +114,21 @@ jest.mock('aws-sdk/lib/core', () => {
 
 describe('isPostAcquisition() function', () => {
 	beforeEach(() => {
-		// Set the current time to a fixed date (2023-03-14)
 		jest.useFakeTimers();
-		jest.setSystemTime(new Date('2023-03-14').getTime()); // or 1678780800000
+		jest.setSystemTime(new Date('2023-03-14').getTime());
 	});
 
 	afterEach(() => {
-		// Clean up the fake timers after each test
 		jest.useRealTimers();
 	});
 
 	test('Return true if acquisition was more than two days ago', () => {
 		const startTimestamp = '2023-03-01 07:24:38 UTC';
-
 		expect(isPostAcquisition(startTimestamp)).toStrictEqual(true);
 	});
 
 	test('Return false if acquisition was less than two days ago', () => {
 		const startTimestamp = '2023-03-13 07:24:38 UTC';
-
 		expect(isPostAcquisition(startTimestamp)).toStrictEqual(false);
 	});
 });
@@ -110,16 +138,13 @@ describe('handler', () => {
 		process.env.DLQUrl = 'https://example.com';
 		jest.clearAllMocks();
 
-		// Set the current time to a fixed date (2023-03-14)
 		jest.useFakeTimers();
-		jest.setSystemTime(new Date('2023-03-14').getTime()); // or 1678780800000
+		jest.setSystemTime(new Date('2023-03-14').getTime());
 	});
 
 	afterEach(() => {
-		// Clean up the fake timers after each test
 		jest.useRealTimers();
-
-		fetch.mockReset();
+		(fetch as unknown as jest.Mock).mockReset();
 	});
 
 	it('should process an acquisition correctly', async () => {
@@ -137,17 +162,15 @@ describe('handler', () => {
 			],
 		};
 
-		// get the mock instances
-		const mockDataMapper =
-			new (require('@aws/dynamodb-data-mapper').DataMapper)();
-		const mockSQS = new (require('aws-sdk/clients/sqs'))();
+		const mockDataMapper = new mockedDynamoDBMapper.DataMapper();
+		const mockSQS = new mockedSQS.default();
 
 		const sub = new SubscriptionEmpty();
 		sub.subscriptionId = '12345';
 		sub.startTimestamp = '2023-03-14 07:24:38 UTC';
 		sub.endTimestamp = '2023-03-14 07:24:38 UTC';
 
-		setMockGet(() => sub);
+		mockedDynamoDBMapper.setMockGet(() => sub);
 
 		await handler(event);
 
@@ -176,7 +199,7 @@ describe('handler', () => {
 		const subscriptionId = '11111';
 		const identityId = '22222';
 		const emailAddress = '97823f89@gmail.com';
-		fetch.mockResolvedValue({
+		(fetch as unknown as jest.Mock).mockResolvedValue({
 			ok: true,
 			json: async () => ({
 				status: 'ok',
@@ -193,7 +216,8 @@ describe('handler', () => {
 					hasPassword: true,
 				},
 			}),
-		});
+		} as never);
+
 		const event: DynamoDBStreamEvent = {
 			Records: [
 				{
@@ -207,16 +231,16 @@ describe('handler', () => {
 				},
 			],
 		};
-		// get the mock instances
-		const mockDataMapper =
-			new (require('@aws/dynamodb-data-mapper').DataMapper)();
-		const mockSQS = new (require('aws-sdk/clients/sqs'))();
+
+		const mockDataMapper = new mockedDynamoDBMapper.DataMapper();
+		const mockSQS = new mockedSQS.default();
+
 		const sub = new SubscriptionEmpty();
 		sub.subscriptionId = subscriptionId;
 		sub.startTimestamp = '2023-03-14 07:24:38 UTC';
 		sub.endTimestamp = '2023-03-14 07:24:38 UTC';
 		sub.platform = Platform.IosFeast;
-		setMockGet(() => sub);
+		mockedDynamoDBMapper.setMockGet(() => sub);
 
 		await handler(event);
 
@@ -225,8 +249,8 @@ describe('handler', () => {
 		expectedQuery.setSubscriptionId(subscriptionId);
 		expect(mockDataMapper.get).toHaveBeenCalledWith(expectedQuery);
 
-		// We expect mockSQS to have been called twice - once for the soft opt in setter and once for the email queue
 		expect(mockSQS.sendMessage).toHaveBeenCalledTimes(2);
+
 		const expectedSOIParams = {
 			QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-CODE`,
 			MessageBody: JSON.stringify({
@@ -237,6 +261,7 @@ describe('handler', () => {
 			}),
 		};
 		expect(mockSQS.sendMessage).toHaveBeenCalledWith(expectedSOIParams);
+
 		const expectedEmailParams = {
 			QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/braze-emails-CODE`,
 			MessageBody: JSON.stringify({
@@ -255,7 +280,7 @@ describe('handler', () => {
 		const subscriptionId = '11111';
 		const identityId = '22222';
 		const emailAddress = '97823f89@gmail.com';
-		fetch.mockResolvedValue({
+		(fetch as unknown as jest.Mock).mockResolvedValue({
 			ok: true,
 			json: async () => ({
 				status: 'ok',
@@ -272,7 +297,8 @@ describe('handler', () => {
 					hasPassword: true,
 				},
 			}),
-		});
+		} as never);
+
 		const event: DynamoDBStreamEvent = {
 			Records: [
 				{
@@ -286,16 +312,16 @@ describe('handler', () => {
 				},
 			],
 		};
-		// get the mock instances
-		const mockDataMapper =
-			new (require('@aws/dynamodb-data-mapper').DataMapper)();
-		const mockSQS = new (require('aws-sdk/clients/sqs'))();
+
+		const mockDataMapper = new mockedDynamoDBMapper.DataMapper();
+		const mockSQS = new mockedSQS.default();
+
 		const sub = new SubscriptionEmpty();
 		sub.subscriptionId = subscriptionId;
 		sub.startTimestamp = '2023-03-14 07:24:38 UTC';
 		sub.endTimestamp = '2023-03-14 07:24:38 UTC';
 		sub.platform = Platform.AndroidFeast;
-		setMockGet(() => sub);
+		mockedDynamoDBMapper.setMockGet(() => sub);
 
 		await handler(event);
 
@@ -304,8 +330,8 @@ describe('handler', () => {
 		expectedQuery.setSubscriptionId(subscriptionId);
 		expect(mockDataMapper.get).toHaveBeenCalledWith(expectedQuery);
 
-		// We expect mockSQS to have been called twice - once for the soft opt in setter and once for the email queue
 		expect(mockSQS.sendMessage).toHaveBeenCalledTimes(2);
+
 		const expectedSOIParams = {
 			QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/soft-opt-in-consent-setter-queue-CODE`,
 			MessageBody: JSON.stringify({
@@ -316,6 +342,7 @@ describe('handler', () => {
 			}),
 		};
 		expect(mockSQS.sendMessage).toHaveBeenCalledWith(expectedSOIParams);
+
 		const expectedEmailParams = {
 			QueueUrl: `https://sqs.eu-west-1.amazonaws.com/mock-aws-account-id/braze-emails-CODE`,
 			MessageBody: JSON.stringify({
@@ -331,7 +358,7 @@ describe('handler', () => {
 	});
 
 	it('should process a post acquisition sign-in correctly', async () => {
-		fetch.mockResolvedValue({
+		(fetch as unknown as jest.Mock).mockResolvedValue({
 			ok: true,
 			json: async () => ({
 				status: 'ok',
@@ -348,8 +375,7 @@ describe('handler', () => {
 					hasPassword: true,
 				},
 			}),
-		});
-
+		} as never);
 		const event: DynamoDBStreamEvent = {
 			Records: [
 				{
@@ -364,17 +390,15 @@ describe('handler', () => {
 			],
 		};
 
-		// get the mock instances
-		const mockDataMapper =
-			new (require('@aws/dynamodb-data-mapper').DataMapper)();
-		const mockSQS = new (require('aws-sdk/clients/sqs'))();
+		const mockDataMapper = new mockedDynamoDBMapper.DataMapper();
+		const mockSQS = new mockedSQS.default();
 
 		const sub = new SubscriptionEmpty();
 		sub.subscriptionId = '12345';
 		sub.startTimestamp = '2023-03-01 07:24:38 UTC';
 		sub.endTimestamp = '2025-03-01 07:24:38 UTC';
 
-		setMockGet(() => sub);
+		mockedDynamoDBMapper.setMockGet(() => sub);
 
 		await handler(event);
 


### PR DESCRIPTION
Previously: https://github.com/guardian/mobile-purchases/pull/2127

Fifth episode of a series aimed at removing all linting errors from the entire codebase. Here we update deleteLink.test.ts. This has moved the number of errors from 143 to 129