### PR TITLE
linting: upate test files

### DIFF
--- a/typescript/tests/feast/pubsub/apple.test.ts
+++ b/typescript/tests/feast/pubsub/apple.test.ts
@@ -5,7 +5,7 @@ import type { APIGatewayProxyEvent } from 'aws-lambda';
 import { buildHandler } from '../../../src/feast/pubsub/apple';
 import { HTTPResponses } from '../../../src/models/apiGatewayHttp';
 import type { AppleSubscriptionReference } from '../../../src/models/subscriptionReference';
-import { expect } from '@jest/globals';
+import { expect, beforeEach, describe, it, jest } from '@jest/globals';
 
 const buildApiGatewayEvent = (): APIGatewayProxyEvent => {
 	const body: StatusUpdateNotification = {
@@ -73,7 +73,7 @@ const buildApiGatewayEvent = (): APIGatewayProxyEvent => {
 		pathParameters: {},
 		queryStringParameters: { secret: 'test_secret' },
 		multiValueQueryStringParameters: {},
-		// @ts-expect-error
+		// @ts-expect-error // keeping test fixtures small
 		requestContext: null,
 		resource: '',
 	};
@@ -86,16 +86,16 @@ beforeEach(() => {
 
 describe('The Feast Apple pubsub', () => {
 	it('Should return HTTP 200 and publish the event to SQS', async () => {
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, AppleSubscriptionReference]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
+		const mockSqsFunction = jest.fn(
+			(_queueurl: string, _event: AppleSubscriptionReference) =>
+				Promise.resolve({} as never),
+		);
 		const input = buildApiGatewayEvent();
 		const expectedSubscriptionReferenceInSqs = { receipt: 'TEST' };
 
-		const noOpLogger = (request: APIGatewayProxyEvent): void => {};
+		const noOpLogger = (_request: APIGatewayProxyEvent): void => {};
 		const noOpStoreEventInDynamo = (
-			event: StatusUpdateNotification,
+			_event: StatusUpdateNotification,
 		): Promise<void> => Promise.resolve();
 		const handler = buildHandler(
 			mockSqsFunction,
@@ -113,16 +113,16 @@ describe('The Feast Apple pubsub', () => {
 	});
 
 	it('Should return HTTP 401 if secret is invalid', async () => {
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, AppleSubscriptionReference]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
+		const mockSqsFunction = jest.fn(
+			(_queueurl: string, _event: AppleSubscriptionReference) =>
+				Promise.resolve({} as never),
+		);
 		const input = buildApiGatewayEvent();
 		input.queryStringParameters = {};
 
-		const noOpLogger = (request: APIGatewayProxyEvent): void => {};
+		const noOpLogger = (_request: APIGatewayProxyEvent): void => {};
 		const noOpStoreEventInDynamo = (
-			event: StatusUpdateNotification,
+			_event: StatusUpdateNotification,
 		): Promise<void> => Promise.resolve();
 		const handler = buildHandler(
 			mockSqsFunction,
@@ -137,13 +137,13 @@ describe('The Feast Apple pubsub', () => {
 
 	it('invokes the method to add the event to the Dynamo table', async () => {
 		const input = buildApiGatewayEvent();
-		const sendMessageToSqs: jest.Mock<
-			Promise<any>,
-			[string, AppleSubscriptionReference]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
-		const noOpLogger = (request: APIGatewayProxyEvent): void => {};
-		const storeEventInDynamoMock = jest.fn((parsedPayload: any) =>
-			Promise.resolve(),
+		const sendMessageToSqs = jest.fn(
+			(_queueurl: string, _event: AppleSubscriptionReference) =>
+				Promise.resolve({} as never),
+		);
+		const noOpLogger = (_request: APIGatewayProxyEvent): void => {};
+		const storeEventInDynamoMock = jest.fn(
+			(_parsedPayload: StatusUpdateNotification) => Promise.resolve(),
 		);
 		const handler = buildHandler(
 			sendMessageToSqs,
@@ -152,11 +152,15 @@ describe('The Feast Apple pubsub', () => {
 		);
 
 		const result = await handler(input);
+		const parsedPayload = parsePayload(input.body);
+
+		// Skip the test if parsePayload returns an error
+		if (parsedPayload instanceof Error) {
+			throw parsedPayload;
+		}
 
 		expect(result).toStrictEqual(HTTPResponses.OK);
 		expect(storeEventInDynamoMock).toHaveBeenCalledTimes(1);
-		expect(storeEventInDynamoMock).toHaveBeenCalledWith(
-			parsePayload(input.body),
-		);
+		expect(storeEventInDynamoMock).toHaveBeenCalledWith(parsedPayload);
 	});
 });

--- a/typescript/tests/feast/pubsub/google.test.ts
+++ b/typescript/tests/feast/pubsub/google.test.ts
@@ -3,7 +3,7 @@ import { buildHandler } from '../../../src/feast/pubsub/google';
 import { HTTPResponses } from '../../../src/models/apiGatewayHttp';
 import { SubscriptionEvent } from '../../../src/models/subscriptionEvent';
 import type { GoogleSubscriptionReference } from '../../../src/models/subscriptionReference';
-import { expect } from '@jest/globals';
+import { expect, beforeEach, jest, describe, it } from '@jest/globals';
 
 const buildApiGatewayEvent = (secret: string): APIGatewayProxyEvent => {
 	const receivedEvent = {
@@ -44,7 +44,7 @@ const buildApiGatewayEvent = (secret: string): APIGatewayProxyEvent => {
 		pathParameters: {},
 		queryStringParameters: { secret: secret },
 		multiValueQueryStringParameters: {},
-		// @ts-expect-error
+		// @ts-expect-error // keeping the test fixtures small
 		requestContext: null,
 		resource: '',
 	};
@@ -60,14 +60,14 @@ describe('The Feast Google pubsub', () => {
 		const correctSecret = 'test_secret';
 		const input = buildApiGatewayEvent(correctSecret);
 
-		const noOpStoreEventInDynamo = (event: SubscriptionEvent): Promise<void> =>
+		const noOpStoreEventInDynamo = (_event: SubscriptionEvent): Promise<void> =>
 			Promise.resolve();
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, GoogleSubscriptionReference]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+		const mockSqsFunction = jest.fn(
+			(_queueurl: string, _event: GoogleSubscriptionReference) =>
+				Promise.resolve({} as never),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: unknown) =>
+			Promise.resolve({ freeTrial: true }),
 		);
 		const handler = buildHandler(
 			mockSqsFunction,
@@ -84,14 +84,37 @@ describe('The Feast Google pubsub', () => {
 		const incorrectSecret = 'incorrect_secret';
 		const input = buildApiGatewayEvent(incorrectSecret);
 
-		const noOpStoreEventInDynamo = (event: SubscriptionEvent): Promise<void> =>
+		const noOpStoreEventInDynamo = (_event: SubscriptionEvent): Promise<void> =>
 			Promise.resolve();
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, GoogleSubscriptionReference]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+		const mockSqsFunction = jest.fn(
+			(_queueurl: string, _event: GoogleSubscriptionReference) =>
+				Promise.resolve({} as never),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: unknown) =>
+			Promise.resolve({ freeTrial: true }),
+		);
+		const handler = buildHandler(
+			mockSqsFunction,
+			noOpStoreEventInDynamo,
+			mockFetchMetadataFunction,
+		);
+
+		const result = await handler(input);
+
+		expect(result).toStrictEqual(HTTPResponses.UNAUTHORISED);
+	});
+	it('Should return HTTP 401 if secret is incorrect', async () => {
+		const incorrectSecret = 'incorrect_secret';
+		const input = buildApiGatewayEvent(incorrectSecret);
+
+		const noOpStoreEventInDynamo = (_event: SubscriptionEvent): Promise<void> =>
+			Promise.resolve();
+		const mockSqsFunction = jest.fn(
+			(_queueurl: string, _event: GoogleSubscriptionReference) =>
+				Promise.resolve({} as never),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: unknown) =>
+			Promise.resolve({ freeTrial: true }),
 		);
 		const handler = buildHandler(
 			mockSqsFunction,
@@ -108,13 +131,15 @@ describe('The Feast Google pubsub', () => {
 		const correctSecret = 'test_secret';
 		const input = buildApiGatewayEvent(correctSecret);
 
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, GoogleSubscriptionReference]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
-		const storeEventInDynamoMock = jest.fn((event: any) => Promise.resolve());
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+		const mockSqsFunction = jest.fn(
+			(_queueurl: string, _event: GoogleSubscriptionReference) =>
+				Promise.resolve({} as never),
+		);
+		const storeEventInDynamoMock = jest.fn((_event: SubscriptionEvent) =>
+			Promise.resolve(),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: unknown) =>
+			Promise.resolve({ freeTrial: true }),
 		);
 		const handler = buildHandler(
 			mockSqsFunction,
@@ -123,6 +148,7 @@ describe('The Feast Google pubsub', () => {
 		);
 
 		const result = await handler(input);
+
 		const expectedSubscriptionEventInDynamo: SubscriptionEvent =
 			new SubscriptionEvent(
 				'PURCHASE_TOKEN', // subscriptionId
@@ -170,14 +196,14 @@ describe('The Feast Google pubsub', () => {
 			subscriptionId: 'uk.co.guardian.feast.access.test',
 		};
 
-		const noOpStoreEventInDynamo = (event: SubscriptionEvent): Promise<void> =>
+		const noOpStoreEventInDynamo = (_event: SubscriptionEvent): Promise<void> =>
 			Promise.resolve();
-		const mockSqsFunction: jest.Mock<
-			Promise<any>,
-			[string, GoogleSubscriptionReference]
-		> = jest.fn((queueurl, event) => Promise.resolve({}));
-		const mockFetchMetadataFunction: jest.Mock<Promise<any>> = jest.fn(
-			(event) => Promise.resolve({ freeTrial: true }),
+		const mockSqsFunction = jest.fn(
+			(_queueurl: string, _event: GoogleSubscriptionReference) =>
+				Promise.resolve({} as never),
+		);
+		const mockFetchMetadataFunction = jest.fn((_event: unknown) =>
+			Promise.resolve({ freeTrial: true }),
 		);
 		const handler = buildHandler(
 			mockSqsFunction,

--- a/typescript/tests/feast/update-subs/apple.test.ts
+++ b/typescript/tests/feast/update-subs/apple.test.ts
@@ -4,11 +4,11 @@ import {
 	withAppAccountToken,
 } from '../../../src/feast/update-subs/apple';
 import { GracefulProcessingError } from '../../../src/models/GracefulProcessingError';
-import { ProcessingError } from '../../../src/models/processingError';
 import { Subscription } from '../../../src/models/subscription';
 import type { AppleSubscriptionReference } from '../../../src/models/subscriptionReference';
 import type { UserSubscription } from '../../../src/models/userSubscription';
 import { buildSqsEvent } from './test-helpers';
+import { expect, jest, beforeEach, describe, it } from '@jest/globals';
 
 describe('The Feast (Apple) subscription updater', () => {
 	it('Should fetch the subscription(s) associated with the reference from Apple, persist them to Dynamo and send to the historical queue', async () => {
@@ -25,7 +25,7 @@ describe('The Feast (Apple) subscription updater', () => {
 			mockStoreUserSubscriptionInDynamo,
 		);
 
-		const result = await handler(event);
+		const _result = await handler(event);
 
 		// The receipts `"TEST_RECEIPT_1"` & `"TEST_RECEIPT_2"` together reference the subscriptions with IDs
 		// `"sub-1"`, `"sub-2"` & `"sub-3"`. Importantly, `"sub-4"` is referenced by the receipt `"TEST_RECEIPT_3"`,
@@ -54,7 +54,7 @@ describe('The Feast (Apple) subscription updater', () => {
 			mockStoreUserSubscriptionInDynamo,
 		);
 
-		const result = await handler(event);
+		const _result = await handler(event);
 
 		expect(mockStoreUserSubscriptionInDynamo.mock.calls.length).toEqual(3);
 
@@ -78,7 +78,7 @@ describe('The Feast (Apple) subscription updater', () => {
 	it('Does not throw an error if the receipt lookup with Apple fails with error code 21007', async () => {
 		const event = buildSqsEvent([{ receipt: 'LOOKUP_FAIL_RECEIPT' }]);
 		const fetchSubFromAppleFailure = (
-			reference: AppleSubscriptionReference,
+			_reference: AppleSubscriptionReference,
 		) => {
 			throw new GracefulProcessingError(`Got status 21007 and we're in PROD`);
 		};
@@ -201,9 +201,7 @@ const stubExchangeExternalIdForIdentityId = (externalId: string) => {
 
 	if (maybeMatchingSub) {
 		return Promise.resolve({
-			identityId: subscriptions.find(
-				(s) => s.subscription.appAccountToken == externalId,
-			)?.identityId!,
+			identityId: maybeMatchingSub.identityId!,
 		});
 	}
 
@@ -212,14 +210,14 @@ const stubExchangeExternalIdForIdentityId = (externalId: string) => {
 	);
 };
 
-const mockStoreSubscriptionInDynamo = jest.fn((subscription: Subscription) =>
+const mockStoreSubscriptionInDynamo = jest.fn((_subscription: Subscription) =>
 	Promise.resolve(),
 );
 
 const mockSendSubscriptionToHistoricalQueue = jest.fn(
-	(subscription: Subscription) => Promise.resolve(),
+	(_subscription: Subscription) => Promise.resolve(),
 );
 
 const mockStoreUserSubscriptionInDynamo = jest.fn(
-	(userSubscription: UserSubscription) => Promise.resolve(),
+	(_userSubscription: UserSubscription) => Promise.resolve(),
 );

--- a/typescript/tests/feast/update-subs/google.test.ts
+++ b/typescript/tests/feast/update-subs/google.test.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect, jest, beforeEach, describe, it } from '@jest/globals';
 import { buildHandler } from '../../../src/feast/update-subs/google';
 import { Subscription } from '../../../src/models/subscription';
 import type { UserSubscription } from '../../../src/models/userSubscription';
@@ -69,7 +69,7 @@ describe('The Feast Android subscription updater', () => {
 		);
 		const identityId = '123456';
 		const mockFetchSubscriptionsFromGoogle = jest.fn(
-			(purchaseToken: string, packageName: string) =>
+			(_purchaseToken: string, _packageName: string) =>
 				Promise.resolve(googleSubscription),
 		);
 		const mockFetchSubscriptionsFromGoogleV1 = jest.fn(() =>
@@ -79,12 +79,12 @@ describe('The Feast Android subscription updater', () => {
 			(subscription: Subscription) => Promise.resolve(subscription),
 		);
 		const mockSendSubscriptionToHistoricalQueue = jest.fn(
-			(subscription: Subscription) => Promise.resolve(),
+			(_subscription: Subscription) => Promise.resolve(),
 		);
-		const mockExchangeUuid = jest.fn((uuid: string) =>
+		const mockExchangeUuid = jest.fn((_uuid: string) =>
 			Promise.resolve({ identityId }),
 		);
-		const mockStoreUserSubInDynamo = jest.fn((userSub: UserSubscription) =>
+		const mockStoreUserSubInDynamo = jest.fn((_userSub: UserSubscription) =>
 			Promise.resolve(undefined),
 		);
 		const handler = buildHandler(
@@ -166,7 +166,7 @@ describe('The Feast Android subscription updater', () => {
 		);
 		const identityId = '123456';
 		const mockFetchSubscriptionsFromGoogle = jest.fn(
-			(purchaseToken: string, packageName: string) =>
+			(_purchaseToken: string, _packageName: string) =>
 				Promise.resolve(googleSubscription),
 		);
 		const mockFetchSubscriptionsFromGoogleV1 = jest.fn(() =>
@@ -176,12 +176,12 @@ describe('The Feast Android subscription updater', () => {
 			(subscription: Subscription) => Promise.resolve(subscription),
 		);
 		const mockSendSubscriptionToHistoricalQueue = jest.fn(
-			(subscription: Subscription) => Promise.resolve(),
+			(_subscription: Subscription) => Promise.resolve(),
 		);
-		const mockExchangeUuid = jest.fn((uuid: string) =>
+		const mockExchangeUuid = jest.fn((_uuid: string) =>
 			Promise.resolve({ identityId }),
 		);
-		const mockStoreUserSubInDynamo = jest.fn((userSub: UserSubscription) =>
+		const mockStoreUserSubInDynamo = jest.fn((_userSub: UserSubscription) =>
 			Promise.resolve(undefined),
 		);
 		const handler = buildHandler(

--- a/typescript/tests/helpers/withEnv.ts
+++ b/typescript/tests/helpers/withEnv.ts
@@ -1,6 +1,6 @@
 export const withEnv = async (
 	env: Record<string, string>,
-	callback: () => any,
+	callback: () => unknown,
 ) => {
 	const oldEnv = process.env;
 	process.env = env;


### PR DESCRIPTION
Previously: https://github.com/guardian/mobile-purchases/pull/2128

Sixth episode of a series aimed at removing all linting errors from the entire codebase. Here we update [pubsub/apple.test.ts, pubsub/google.test.ts, update-subs/apple.test.ts, update-subs/google.test.ts, helpers/withEnv.ts]. This has moved the number of errors from 129 to 67.