### PR TITLE
linting src/utils/*

### DIFF
--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -1,9 +1,9 @@
-import { DataMapper, ItemNotFoundException } from '@aws/dynamodb-data-mapper';
+import { DataMapper } from '@aws/dynamodb-data-mapper';
 import CloudWatch from 'aws-sdk/clients/cloudwatch';
 import DynamoDB from 'aws-sdk/clients/dynamodb';
 import S3 from 'aws-sdk/clients/s3';
 import Sqs from 'aws-sdk/clients/sqs';
-import SSM = require('aws-sdk/clients/ssm');
+import SSM from 'aws-sdk/clients/ssm';
 import STS from 'aws-sdk/clients/sts';
 import {
 	CredentialProviderChain,
@@ -135,9 +135,9 @@ export async function putMetric(
 	metricName: string,
 	value = 1.0,
 ): Promise<void> {
-	const metricDatum: AWS.CloudWatch.MetricDatum = {
+	const metricDatum = {
 		MetricName: metricName,
-		Unit: 'Count',
+		Unit: 'Count' as const,
 		Value: value,
 		Dimensions: [
 			{
@@ -147,7 +147,7 @@ export async function putMetric(
 		],
 	};
 
-	const params: AWS.CloudWatch.PutMetricDataInput = {
+	const params = {
 		Namespace: 'soft-opt-ins',
 		MetricData: [metricDatum],
 	};
@@ -157,7 +157,7 @@ export async function putMetric(
 
 export function sendToSqs(
 	queueUrl: string,
-	event: any,
+	event: unknown,
 	delaySeconds?: number,
 ): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
 	return sqs
@@ -192,7 +192,7 @@ export async function sendToSqsSoftOptIns(
 
 export async function sendToSqsComms(
 	queueUrl: string,
-	event: any,
+	event: unknown,
 	delaySeconds?: number,
 ): Promise<PromiseResult<Sqs.SendMessageResult, AWSError>> {
 	const membershipSqs = await getSqsClientForComms();

--- a/typescript/src/utils/guIdentityApi.ts
+++ b/typescript/src/utils/guIdentityApi.ts
@@ -1,22 +1,11 @@
 import type { HttpRequestHeaders } from '../models/apiGatewayHttp';
 import { Stage } from '../utils/appIdentity';
-import { restClient } from './restClient';
 import { getConfigValue } from './ssmConfig';
+import OktaJwtVerifier from '@okta/jwt-verifier';
 
-interface UserId {
-	id: string;
-}
-
-interface IdentityResponse {
-	status: string;
-	user: UserId;
-}
-
-interface OktaJwtVerifierReturn {
-	claims: {
-		scp: [string];
-		legacy_identity_id: string;
-	};
+interface OktaJwtVerifierClaims {
+	scp: [string];
+	legacy_identity_id: string;
 }
 
 interface OktaStageParameters {
@@ -75,43 +64,39 @@ function getOktaStageParameters(stage: string): OktaStageParameters {
 export async function getUserId(
 	headers: HttpRequestHeaders,
 ): Promise<UserIdResolution> {
+	const oktaparams = getOktaStageParameters(Stage);
+
+	const issuer = oktaparams.issuer;
+	const expectedAud = oktaparams.expectedAud;
+	const scope = oktaparams.scope;
+
+	const oktaJwtVerifier = new OktaJwtVerifier({
+		issuer: issuer,
+	});
+
+	const accessTokenString = getAuthToken(headers);
+
 	try {
-		const OktaJwtVerifier = require('@okta/jwt-verifier');
+		return await oktaJwtVerifier
+			.verifyAccessToken(accessTokenString || '', expectedAud)
+			.then((payload) => {
+				const claims = payload.claims as unknown as OktaJwtVerifierClaims;
 
-		const oktaparams = getOktaStageParameters(Stage);
-
-		const issuer = oktaparams.issuer;
-		const expectedAud = oktaparams.expectedAud;
-		const scope = oktaparams.scope;
-
-		const oktaJwtVerifier = new OktaJwtVerifier({
-			issuer: issuer,
-		});
-
-		const accessTokenString = getAuthToken(headers);
-
-		try {
-			return await oktaJwtVerifier
-				.verifyAccessToken(accessTokenString, expectedAud)
-				.then((payload: OktaJwtVerifierReturn) => {
-					if (payload.claims.scp.includes(scope)) {
-						if (payload.claims.legacy_identity_id) {
-							return {
-								status: 'success',
-								userId: payload.claims.legacy_identity_id,
-							};
-						} else {
-							return { status: 'missing-identity-id', userId: null };
-						}
+				if (claims.scp.includes(scope)) {
+					if (claims.legacy_identity_id) {
+						return {
+							status: 'success',
+							userId: claims.legacy_identity_id,
+						};
 					} else {
-						// We have passed authentication but we didn't pass the scope check
-						return { status: 'incorrect-scope', userId: null };
+						return { status: 'missing-identity-id', userId: null };
 					}
-				});
-		} catch (error) {
-			return { status: 'incorrect-token', userId: null };
-		}
+				} else {
+					return { status: 'incorrect-scope', userId: null };
+				}
+			});
 	} catch (error) {
-		throw error;
+		console.log(`error: ${error}`);
+		return { status: 'incorrect-token', userId: null };
 	}
 }

--- a/typescript/src/utils/ssmConfig.ts
+++ b/typescript/src/utils/ssmConfig.ts
@@ -2,7 +2,7 @@ import { App, Stack, Stage } from './appIdentity';
 import { ssm } from './aws';
 import type { Option } from './option';
 
-type Config = Record<string, any>;
+type Config = Record<string, unknown>;
 
 function recursivelyFetchConfig(
 	nextToken?: string,
@@ -50,10 +50,12 @@ function fetchConfig(): Promise<Config> {
 
 export function getConfigValue<A>(key: string, defaultValue?: A): Promise<A> {
 	return fetchConfig().then((conf) => {
-		if (conf[key]) {
-			return conf[key];
+		const value = conf[key];
+		if (value !== undefined && value !== null) {
+			// Assert that the value is of type A
+			return value as A;
 		} else {
-			if (defaultValue) {
+			if (defaultValue !== undefined) {
 				return defaultValue;
 			} else {
 				throw new Error(


### PR DESCRIPTION
Previously: https://github.com/guardian/mobile-purchases/pull/2130

Eigth episode of a series aimed at removing all TypeScript linting errors from the entire codebase. Here we remove linting errors in all the files under src/utils/. This has moved the number of errors from 64 to 54