### PR TITLE
repair credentials resolution

### DIFF
--- a/typescript/src/feast/pubsub/apple.ts
+++ b/typescript/src/feast/pubsub/apple.ts
@@ -60,7 +60,7 @@ export function buildHandler(
 
 				return HTTPResponses.OK;
 			} catch (e) {
-				console.error('Internal server error', e);
+				console.error('[505b73ff] internal server error', e);
 				return HTTPResponses.INTERNAL_ERROR;
 			}
 		} else {

--- a/typescript/src/utils/aws.ts
+++ b/typescript/src/utils/aws.ts
@@ -12,41 +12,22 @@ import {
 } from '@aws-sdk/client-sqs';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
-import { fromIni, fromContainerMetadata } from '@aws-sdk/credential-providers';
 import { Region, Stage } from './appIdentity';
 import { getMembershipAccountId } from './guIdentityApi';
 import type { SoftOptInEventProductName } from './softOptIns';
-
-// Create credential provider that always returns credentials - this is a sync function that returns a promise
-const credentialProvider = () => {
-	return (async () => {
-		try {
-			// Try ECS credentials first
-			const ecsCredentials = fromContainerMetadata();
-			const ecsCreds = await ecsCredentials();
-			if (ecsCreds) {
-				return ecsCreds;
-			}
-		} catch {
-			// Fall back to shared ini file
-			const iniCredentials = fromIni({ profile: 'mobile' });
-			return iniCredentials();
-		}
-		throw new Error('Unable to get AWS credentials');
-	})();
-};
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
 
 // Use the credential provider directly - it will be called when needed
 export const aws = new DynamoDBClient({
 	region: Region,
-	credentials: credentialProvider,
+	credentials: defaultProvider(),
 });
 
 export const dynamoMapper = new DataMapper({ client: aws });
 
 export const sqs = new SQSClient({
 	region: Region,
-	credentials: credentialProvider,
+	credentials: defaultProvider(),
 });
 
 let SOISqsClient: SQSClient | undefined;
@@ -145,12 +126,12 @@ async function getSqsClientForComms(): Promise<SQSClient> {
 
 export const s3: S3Client = new S3Client({
 	region: Region,
-	credentials: credentialProvider,
+	credentials: defaultProvider(),
 });
 
 export const ssm: SSMClient = new SSMClient({
 	region: Region,
-	credentials: credentialProvider,
+	credentials: defaultProvider(),
 });
 
 const cloudWatchClient = new CloudWatchClient({ region: Region });


### PR DESCRIPTION
The change we made earlier today https://github.com/guardian/mobile-purchases/pull/2135 , notably the aws sdk upgrade bit, has caused "Could not resolve credentials using profile: [mobile] in configuration/credentials file(s)" in `feast-apple-pubsub.js`. This refactoring should repair it. Here we use the `defaultProvider()`.