### PR TITLE
fix remaining linting errors

### DIFF
--- a/build-tc.sh
+++ b/build-tc.sh
@@ -10,6 +10,7 @@ yarn install
 yarn run clean
 
 yarn format:check
+yarn lint:check
 
 yarn run test
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,32 @@
+const typescriptEslint = require('@typescript-eslint/eslint-plugin');
+const typescriptParser = require('@typescript-eslint/parser');
+
+module.exports = [
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescriptEslint,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      // Add your preferred rules here
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,67 +1,67 @@
 {
-  "name": "mobile-purchases",
-  "version": "1.0.0",
-  "description": "IOS receipt validation and purchase persistence",
-  "scripts": {
-    "clean": "rm -r tsc-target",
-    "build": "webpack --env production",
-    "build:dev": "webpack",
-    "test": "jest",
-    "test-lambda": "yarn build:dev && node ./tsc-target/test-launcher.js",
-    "lint:check": "eslint typescript",
-    "lint:fix": "eslint typescript --fix",
-    "format:check": "prettier --check typescript",
-    "format:fix": "prettier --write typescript",
-    "validate": "yarn lint:check && yarn format:check"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/guardian/mobile-purchases.git"
-  },
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/guardian/mobile-purchases/issues"
-  },
-  "homepage": "https://github.com/guardian/mobile-purchases#readme",
-  "private": true,
-  "devDependencies": {
-    "@eslint/eslintrc": "^3.3.5",
-    "@guardian/eslint-config": "^14.0.1",
-    "@guardian/prettier": "^10.0.0",
-    "@types/eslint-scope": "^9.1.0",
-    "@types/jest": "^30.0.0",
-    "@types/node-fetch": "^2.6.2",
-    "@typescript-eslint/eslint-plugin": "^8.58.1",
-    "@typescript-eslint/parser": "^8.58.1",
-    "eslint": "9.8.0",
-    "jest": "^30.3.0",
-    "prettier": "^3.8.1",
-    "ts-jest": "^29.2.5",
-    "ts-loader": "^9.5.7",
-    "ts-node": "^10.4.0",
-    "typescript": "^5.9.3",
-    "webpack": "^5.105.4",
-    "webpack-cli": "^7.0.2"
-  },
-  "dependencies": {
-    "@aws/dynamodb-data-mapper": "^0.7.3",
-    "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
-    "@aws/dynamodb-expressions": "^0.7.3",
-    "@googleapis/androidpublisher": "27.0.0",
-    "@guardian/types": "^9.0.1",
-    "@okta/jwt-verifier": "^4.0.2",
-    "@types/aws-lambda": "8.10.161",
-    "@types/node": "^25.6.0",
-    "aws-sdk": "^2.1693.0",
-    "jsonwebtoken": "^9.0.3",
-    "node-fetch": "2.6.7",
-    "source-map-support": "^0.5.21",
-    "typed-rest-client": "^2.3.0",
-    "zod": "^3.25.73"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
-  "resolutions": {
-    "@types/eslint-scope": "npm:none",
-    "@types/eslint": "npm:none"
-  }
+	"name": "mobile-purchases",
+	"version": "1.0.0",
+	"description": "IOS receipt validation and purchase persistence",
+	"scripts": {
+		"clean": "rm -r tsc-target",
+		"build": "NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --env production",
+		"build:dev": "NODE_OPTIONS=\"--max-old-space-size=8192\" webpack",
+		"test": "jest",
+		"test-lambda": "yarn build:dev && node ./tsc-target/test-launcher.js",
+		"lint:check": "eslint typescript",
+		"lint:fix": "eslint typescript --fix",
+		"format:check": "prettier --check typescript",
+		"format:fix": "prettier --write typescript",
+		"validate": "yarn lint:check && yarn format:check"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/guardian/mobile-purchases.git"
+	},
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/guardian/mobile-purchases/issues"
+	},
+	"homepage": "https://github.com/guardian/mobile-purchases#readme",
+	"private": true,
+	"devDependencies": {
+		"@eslint/eslintrc": "^3.3.5",
+		"@guardian/eslint-config": "^14.0.1",
+		"@guardian/prettier": "^10.0.0",
+		"@types/eslint-scope": "^9.1.0",
+		"@types/jest": "^30.0.0",
+		"@types/node-fetch": "^2.6.2",
+		"@typescript-eslint/eslint-plugin": "^8.58.1",
+		"@typescript-eslint/parser": "^8.58.1",
+		"eslint": "9.8.0",
+		"jest": "^30.3.0",
+		"prettier": "^3.8.1",
+		"ts-jest": "^29.2.5",
+		"ts-loader": "^9.5.7",
+		"ts-node": "^10.4.0",
+		"typescript": "^5.9.3",
+		"webpack": "^5.105.4",
+		"webpack-cli": "^7.0.2"
+	},
+	"dependencies": {
+		"@aws/dynamodb-data-mapper": "^0.7.3",
+		"@aws/dynamodb-data-mapper-annotations": "^0.7.3",
+		"@aws/dynamodb-expressions": "^0.7.3",
+		"@googleapis/androidpublisher": "27.0.0",
+		"@guardian/types": "^9.0.1",
+		"@okta/jwt-verifier": "^4.0.2",
+		"@types/aws-lambda": "8.10.161",
+		"@types/node": "^25.6.0",
+		"aws-sdk": "^2.1693.0",
+		"jsonwebtoken": "^9.0.3",
+		"node-fetch": "2.6.7",
+		"source-map-support": "^0.5.21",
+		"typed-rest-client": "^2.3.0",
+		"zod": "^3.25.73"
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+	"resolutions": {
+		"@types/eslint-scope": "npm:none",
+		"@types/eslint": "npm:none"
+	}
 }

--- a/typescript/src/export/dynamoStream.ts
+++ b/typescript/src/export/dynamoStream.ts
@@ -6,10 +6,12 @@ import type { ScanIterator } from '@aws/dynamodb-data-mapper';
 
 export class DynamoStream<T> extends Readable {
 	iterator: ScanIterator<T>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	transformItem: (t: T) => any;
 
 	constructor(
 		iterator: ScanIterator<T>,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		transformItem?: (t: T) => any,
 		opts?: ReadableOptions,
 	) {
@@ -36,7 +38,7 @@ export class DynamoStream<T> extends Readable {
 		});
 	}
 
-	_read(size: number): void {
+	_read(_size: number): void {
 		this.readNext();
 	}
 


### PR DESCRIPTION
Previously: https://github.com/guardian/mobile-purchases/pull/2133 , https://github.com/guardian/mobile-purchases/pull/2135

Here we fix the last remaining linting errors, but without the upgrade aws sdk upgrade ( https://github.com/guardian/mobile-purchases/pull/2135 ) that broke PROD this morning, this enable us to add `yarn lint:check` to the build.

Interestingly the reason why the was sdk upgrade was done in the previous attempt, was because I wanted to get rid of the `any` in dynamoStream.ts. Here we just add a linting exception, #safer

