### PR TITLE
upgrade apple-fetch-offer-details to node22

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -584,7 +584,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: apple-fetch-offer-details.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-apple-fetch-offer-details/apple-fetch-offer-details.zip


### PR DESCRIPTION
Node20 is end of life, here we are upgrading to Node22.