### PR TITLE
update node for apple-subscription-status

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -554,7 +554,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: apple-subscription-status.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-apple-subscription-status/apple-subscription-status.zip


### PR DESCRIPTION
Node 20 is end of life, this upgrades the runtime for apple-subscription-status to 22