### PR TITLE
node22 for apple-update-subscriptions

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1141,7 +1141,7 @@ Resources:
       MemorySize: 512
       Role: !GetAtt MobilePurchasesLambdasRole.Arn
       Timeout: 25
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   AppleSubscriptionsEventSource:
     Type: AWS::Lambda::EventSourceMapping


### PR DESCRIPTION
Node 20 is end of life. Here we upgrade to 22. 