### PR TITLE
Increase memory for ExportAppleHistoricalSubscriptionsLambda

### DIFF
--- a/exports-cloudformation.yaml
+++ b/exports-cloudformation.yaml
@@ -331,7 +331,7 @@ Resources:
           ExportBucket: !Ref AppleSubscriptionHistoryExportBucket
           SqsUrl: !Ref AppleHistoricalSubscriptionsQueue
       Description: Export the historical Apple subscriptions to the data lake
-      MemorySize: 3008
+      MemorySize: 8192
       Timeout: 900
       Events:
         Schedule:


### PR DESCRIPTION
I have noticed this in the logs post node22 upgrade of this lambda ( https://github.com/guardian/mobile-purchases/pull/2167 ). 

"""
REPORT RequestId: 7a90c6bd-c7fe-4c4e-9c33-8817b4e5b245 Duration: 250992.46 ms Billed Duration: 251262 ms Memory Size: 3008 MB Max Memory Used: 3008 MB Init Duration: 269.45 ms Status: error Error Type: Runtime.OutOfMemory
"""

This will help.