### PR TITLE
Add Bolivia - Bolivian boliviano to country to currency mapping

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -152,6 +152,7 @@ const countryToCurrencyMap = {
 	GH: 'GHS', // Ghana - Ghanaian Cedi
 	JM: 'JMD', // Jamaica - Jamaican dollar
 	PR: 'USD', // Puerto Rico - United States Dollar
+	BO: 'BOB', // Bolivia - Bolivian boliviano
 };
 
 const countryToCurrency = (country: string): string => {


### PR DESCRIPTION
Will prevent "Error: [acba643d] (countryToCurrencyMap) country BO is not supported", causing an alarm