### PR TITLE
country to currency mapping: Costa Rica - Costa Rican Colone

### DIFF
--- a/typescript/src/feast/acquisition-events/google.ts
+++ b/typescript/src/feast/acquisition-events/google.ts
@@ -154,6 +154,7 @@ const countryToCurrencyMap = {
 	PR: 'USD', // Puerto Rico - United States Dollar
 	BO: 'BOB', // Bolivia - Bolivian boliviano
 	KW: 'KWD', // Kuwait - Kuwaiti dinar (KWD)
+	CR: 'CRC', // Costa Rica - Costa Rican Colones (CRC)
 };
 
 const countryToCurrency = (country: string): string => {


### PR DESCRIPTION
Prevent 
Error: [acba643d] (countryToCurrencyMap) country CR is not supported