### PR TITLE
upgrade io.netty to 4.1.135.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,13 +7,13 @@ import scala.collection.immutable
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" % "scala-xml" % VersionScheme.Always
 
 ThisBuild / dependencyOverrides ++= Seq(
-  "io.netty" % "netty-codec-http2" % "4.1.133.Final",
-  "io.netty" % "netty-codec-http" % "4.1.133.Final",
-  "io.netty" % "netty-codec" % "4.1.133.Final",
-  "io.netty" % "netty-common" % "4.1.133.Final",
-  "io.netty" % "netty-buffer" % "4.1.133.Final",
-  "io.netty" % "netty-transport" % "4.1.133.Final",
-  "io.netty" % "netty-handler" % "4.1.133.Final"
+  "io.netty" % "netty-codec-http2" % "4.1.135.Final",
+  "io.netty" % "netty-codec-http" % "4.1.135.Final",
+  "io.netty" % "netty-codec" % "4.1.135.Final",
+  "io.netty" % "netty-common" % "4.1.135.Final",
+  "io.netty" % "netty-buffer" % "4.1.135.Final",
+  "io.netty" % "netty-transport" % "4.1.135.Final",
+  "io.netty" % "netty-handler" % "4.1.135.Final"
 )
 
 val testAndCompileDependencies: String = "test->test;compile->compile"


### PR DESCRIPTION
Moving io.netty from 4.1.133.Final to 4.1.135.Final, to address the two following vulnerabilities

1. http://github.com/guardian/mobile-purchases/security/dependabot/201
2. https://github.com/guardian/mobile-purchases/security/dependabot/202

