### PR TITLE
update lambda role to adapt to new code conventions

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -124,6 +124,13 @@ Resources:
                 - ssm:GetParametersByPath
               Effect: Allow
               Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}/google-oauth-lambda
+        - PolicyName: googleoauth-config2
+          PolicyDocument:
+            Statement:
+              Action:
+                - ssm:GetParameter
+              Effect: Allow
+              Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/mobile-purchases/${Stage}/google-oauth-lambda/google.serviceAccountJson
         - PolicyName: google-access-tokens
           PolicyDocument:
             Statement:
@@ -398,7 +405,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: mobile-purchases-google-oauth2.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}-google-oauth2/${App}-google-oauth2.zip

--- a/mpapi-next-gen/webpack.config.js
+++ b/mpapi-next-gen/webpack.config.js
@@ -1,14 +1,19 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = (env = {}) => ({
-	// Good for debugging Lambda errors
 	devtool: 'inline-cheap-source-map',
 
 	module: {
 		rules: [
 			{
 				test: /\.ts$/,
-				use: 'ts-loader',
+				use: {
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.json',
+					},
+				},
 				exclude: /node_modules/,
 			},
 		],
@@ -16,12 +21,20 @@ module.exports = (env = {}) => ({
 
 	resolve: {
 		extensions: ['.ts', '.js'],
+		extensionAlias: {
+			'.js': ['.ts', '.js'],
+			'.mjs': ['.mts', '.mjs'],
+			'.cjs': ['.cts', '.cjs'],
+		},
+		// Force a single version of the library
+		alias: {
+			'google-auth-library': require.resolve('google-auth-library'),
+		},
 	},
 
 	target: 'node',
 	mode: env.production ? 'production' : 'development',
 
-	// Your Lambda handlers
 	entry: {
 		'mobile-purchases-google-oauth2':
 			'./src/handlers/mobile-purchases-google-oauth2.ts',
@@ -32,10 +45,32 @@ module.exports = (env = {}) => ({
 		filename: '[name].js',
 		libraryTarget: 'commonjs2',
 		clean: true,
+		chunkFilename: '[name].js',
 	},
 
-	// Optimize bundle size (AWS SDK v3 is already modular)
 	optimization: {
+		splitChunks: false,
+		minimize: true,
 		usedExports: true,
+		runtimeChunk: false,
+		// Disable all chunk optimizations
+		removeAvailableModules: true,
+		removeEmptyChunks: true,
+		mergeDuplicateChunks: true,
 	},
+
+	// No externals - bundle everything
+	externals: {},
+
+	node: {
+		__dirname: false,
+		__filename: false,
+	},
+
+	plugins: [
+		// Force a single chunk
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1,
+		}),
+	],
 });


### PR DESCRIPTION
Three updates

1. This is a follow of giving to using the new lambda to retrieve google credentials ( https://github.com/guardian/mobile-purchases/pull/2241 ). Since we are now using a slightly different convention, we need to update the cloudformation

2. We also set the node runtime environment to 22.

3. The code was failing on CODE, while testing, due to problems with the packaging. So we update webpack.