### PR TITLE
migrate two export lambdas from legacy to next-gen

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
             mobile-purchases-export-subscription-events-table:
               - tsc-target/export-subscription-events-table.zip
             mobile-purchases-export-subscription-table-v2:
-              - tsc-target/export-subscription-table-v2.zip
+              - mpapi-next-gen/dist/export-subscription-table-v2.zip
             mobile-purchases-export-subscription-tables:
               - tsc-target/export-subscription-tables.zip
             mobile-purchases-google-link-user-subscription:

--- a/mpapi-next-gen/docs/README.md
+++ b/mpapi-next-gen/docs/README.md
@@ -3,4 +3,6 @@ Documentation directory for mpapi-next-gen
 
 ### lambdas
 
+- [mobile-purchases-export-subscription-table-v2.md](mobile-purchases-export-subscription-table-v2.md)
+- [mobile-purchases-export-user-subscription-table-v2.md](mobile-purchases-export-user-subscription-table-v2.md)
 - [mobile-purchases-google-oauth2.md](mobile-purchases-google-oauth2.md)

--- a/mpapi-next-gen/docs/mobile-purchases-export-subscription-table-v2.md
+++ b/mpapi-next-gen/docs/mobile-purchases-export-subscription-table-v2.md
@@ -1,0 +1,8 @@
+
+mobile-purchases-export-user-subscription-table-v2 writes the files
+
+```
+arn:aws:dynamodb:eu-west-1:${account}:table/mobile-purchases-PROD-subscriptions
+```
+
+It uses the exportTableToPointInTime function which is an operation in AWS DynamoDB that exports your table data to an Amazon S3 bucket.

--- a/mpapi-next-gen/docs/mobile-purchases-export-subscription-table-v2.md
+++ b/mpapi-next-gen/docs/mobile-purchases-export-subscription-table-v2.md
@@ -6,3 +6,5 @@ arn:aws:dynamodb:eu-west-1:${account}:table/mobile-purchases-PROD-subscriptions
 ```
 
 It uses the exportTableToPointInTime function which is an operation in AWS DynamoDB that exports your table data to an Amazon S3 bucket.
+
+This lambda and mobile-purchases-export-user-subscription-table-v2 use the same handler. The difference is triggered by environment variable `ClassName`

--- a/mpapi-next-gen/docs/mobile-purchases-export-user-subscription-table-v2.md
+++ b/mpapi-next-gen/docs/mobile-purchases-export-user-subscription-table-v2.md
@@ -1,0 +1,9 @@
+
+mobile-purchases-export-user-subscription-table-v2 writes the two files
+
+```
+arn:aws:dynamodb:eu-west-1:${account}:table/mobile-purchases-PROD-subscriptions
+arn:aws:dynamodb:eu-west-1:${account}:table/mobile-purchases-PROD-user-subscriptions
+```
+
+It uses the exportTableToPointInTime function which is an operation in AWS DynamoDB that exports your table data to an Amazon S3 bucket.

--- a/mpapi-next-gen/docs/mobile-purchases-export-user-subscription-table-v2.md
+++ b/mpapi-next-gen/docs/mobile-purchases-export-user-subscription-table-v2.md
@@ -7,3 +7,5 @@ arn:aws:dynamodb:eu-west-1:${account}:table/mobile-purchases-PROD-user-subscript
 ```
 
 It uses the exportTableToPointInTime function which is an operation in AWS DynamoDB that exports your table data to an Amazon S3 bucket.
+
+This lambda and mobile-purchases-export-subscription-table-v2 use the same handler. The difference is triggered by environment variable `ClassName`

--- a/mpapi-next-gen/package.json
+++ b/mpapi-next-gen/package.json
@@ -14,6 +14,7 @@
 		"validate": "yarn lint:check && yarn format:check"
 	},
 	"dependencies": {
+		"@aws-sdk/client-dynamodb": "^3.1073.0",
 		"@aws-sdk/client-s3": "^3.1071.0",
 		"@aws-sdk/client-ssm": "^3.1071.0",
 		"google-auth-library": "^10.7.0"

--- a/mpapi-next-gen/src/handlers/export-subscription-table-v2.ts
+++ b/mpapi-next-gen/src/handlers/export-subscription-table-v2.ts
@@ -1,9 +1,10 @@
 import 'source-map-support/register';
-import { aws } from '../utils/aws';
+import { DynamoDBClient, ExportFormat } from '@aws-sdk/client-dynamodb';
+import { ExportTableToPointInTimeCommand } from '@aws-sdk/client-dynamodb';
 import { plusDays } from '../utils/dates';
 
 function prefix_creator(stage: string): string {
-	const yesterday = plusDays(new Date(), -1).toISOString().substr(0, 10);
+	const yesterday = plusDays(new Date(), -1).toISOString().substring(0, 10);
 	if (stage == 'CODE') {
 		return `v2/code-data/date=${yesterday}`;
 	} else {
@@ -55,17 +56,19 @@ export async function handler(): Promise<string> {
 		S3Bucket: bucket,
 		S3BucketOwner: s3BucketOwner,
 		S3Prefix: prefix_creator(stage),
-		ExportFormat: 'DYNAMODB_JSON',
+		ExportFormat: ExportFormat.DYNAMODB_JSON,
 	};
 
-	return aws
-		.exportTableToPointInTime(params)
-		.promise()
-		.then((result) => {
-			console.log(`[89ba1cd3] exporting subscription data to ${bucket}`);
-			return `[0d1f18ab] dynamo export started, with status: ${result.ExportDescription?.ExportStatus}`;
-		})
-		.catch((_) => {
-			throw new Error('[4f4acf88] Failed to start dynamo export');
-		});
+	// Create DynamoDB client
+	const client = new DynamoDBClient({ region: 'eu-west-1' });
+	const command = new ExportTableToPointInTimeCommand(params);
+
+	try {
+		const result = await client.send(command);
+		console.log(`[89ba1cd3] exporting subscription data to ${bucket}`);
+		return `[0d1f18ab] dynamo export started, with status: ${result.ExportDescription?.ExportStatus}`;
+	} catch (error) {
+		console.error('[58869c86] Failed to start dynamo export:', error);
+		throw new Error('[4f4acf88] Failed to start dynamo export');
+	}
 }

--- a/mpapi-next-gen/src/handlers/export-subscription-table-v2.ts
+++ b/mpapi-next-gen/src/handlers/export-subscription-table-v2.ts
@@ -59,7 +59,6 @@ export async function handler(): Promise<string> {
 		ExportFormat: ExportFormat.DYNAMODB_JSON,
 	};
 
-	// Create DynamoDB client
 	const client = new DynamoDBClient({ region: 'eu-west-1' });
 	const command = new ExportTableToPointInTimeCommand(params);
 

--- a/mpapi-next-gen/src/models/README.md
+++ b/mpapi-next-gen/src/models/README.md
@@ -1,0 +1,1 @@
+If a datatype is used in more than one lambda, then we put it in the models directory, otheriwse it remain in the handler.

--- a/mpapi-next-gen/src/utils/dates.ts
+++ b/mpapi-next-gen/src/utils/dates.ts
@@ -1,0 +1,40 @@
+import type { Option } from './option';
+
+export function optionalMsToDate(ms: Option<string> | undefined): Option<Date> {
+	if (ms) {
+		const parsedDate = new Date(Number.parseInt(ms));
+		if (!isNaN(parsedDate.getDate())) {
+			return parsedDate;
+		} else {
+			return null;
+		}
+	} else {
+		return null;
+	}
+}
+
+export function thirtyMonths(from: Date = new Date()): Date {
+	return plusMonths(from, 30);
+}
+
+export function dateToSecondTimestamp(date: Date): number {
+	return Math.ceil(date.getTime() / 1000);
+}
+
+export function plusMonths(from: Date, count: number): Date {
+	const newDate = new Date(from.getTime());
+	newDate.setUTCMonth(from.getUTCMonth() + count);
+	return newDate;
+}
+
+export function plusDays(from: Date, count: number): Date {
+	const newDate = new Date(from.getTime());
+	newDate.setUTCDate(from.getUTCDate() + count);
+	return newDate;
+}
+
+export function plusHours(from: Date, count: number): Date {
+	const newDate = new Date(from.getTime());
+	newDate.setUTCHours(from.getUTCHours() + count);
+	return newDate;
+}

--- a/mpapi-next-gen/src/utils/dates.ts
+++ b/mpapi-next-gen/src/utils/dates.ts
@@ -1,5 +1,31 @@
 import type { Option } from './option';
 
+export function dateToUnixTimestamp(date: Date): number {
+	return Math.ceil(date.getTime() / 1000);
+}
+
+export function plusHours(from: Date, count: number): Date {
+	const newDate = new Date(from.getTime());
+	newDate.setUTCHours(from.getUTCHours() + count);
+	return newDate;
+}
+
+export function plusDays(from: Date, count: number): Date {
+	const newDate = new Date(from.getTime());
+	newDate.setUTCDate(from.getUTCDate() + count);
+	return newDate;
+}
+
+export function plusMonths(from: Date, count: number): Date {
+	const newDate = new Date(from.getTime());
+	newDate.setUTCMonth(from.getUTCMonth() + count);
+	return newDate;
+}
+
+export function plusThirtyMonths(from: Date): Date {
+	return plusMonths(from, 30);
+}
+
 export function optionalMsToDate(ms: Option<string> | undefined): Option<Date> {
 	if (ms) {
 		const parsedDate = new Date(Number.parseInt(ms));
@@ -11,30 +37,4 @@ export function optionalMsToDate(ms: Option<string> | undefined): Option<Date> {
 	} else {
 		return null;
 	}
-}
-
-export function thirtyMonths(from: Date = new Date()): Date {
-	return plusMonths(from, 30);
-}
-
-export function dateToSecondTimestamp(date: Date): number {
-	return Math.ceil(date.getTime() / 1000);
-}
-
-export function plusMonths(from: Date, count: number): Date {
-	const newDate = new Date(from.getTime());
-	newDate.setUTCMonth(from.getUTCMonth() + count);
-	return newDate;
-}
-
-export function plusDays(from: Date, count: number): Date {
-	const newDate = new Date(from.getTime());
-	newDate.setUTCDate(from.getUTCDate() + count);
-	return newDate;
-}
-
-export function plusHours(from: Date, count: number): Date {
-	const newDate = new Date(from.getTime());
-	newDate.setUTCHours(from.getUTCHours() + count);
-	return newDate;
 }

--- a/mpapi-next-gen/src/utils/option.ts
+++ b/mpapi-next-gen/src/utils/option.ts
@@ -1,0 +1,1 @@
+export type Option<A> = A | null;

--- a/mpapi-next-gen/webpack.config.js
+++ b/mpapi-next-gen/webpack.config.js
@@ -38,6 +38,8 @@ module.exports = (env = {}) => ({
 	entry: {
 		'mobile-purchases-google-oauth2':
 			'./src/handlers/mobile-purchases-google-oauth2.ts',
+		'export-subscription-table-v2':
+			'./src/handlers/export-subscription-table-v2.ts',
 	},
 
 	output: {

--- a/mpapi-next-gen/yarn.lock
+++ b/mpapi-next-gen/yarn.lock
@@ -84,6 +84,24 @@
     "@smithy/types" "^4.14.3"
     tslib "^2.6.2"
 
+"@aws-sdk/client-dynamodb@^3.1073.0":
+  version "3.1073.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1073.0.tgz#2996b5d74f67567666817084996a0411d0dcb26e"
+  integrity sha512-2GUPeI0drcms+LOoSC2DfVLCUWQxjjUm4jN08MrVh40XnIRQZ9PxCjFCqAj6yMRXPAzze925MMXEXBQC7IS6jw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.22"
+    "@aws-sdk/credential-provider-node" "^3.972.57"
+    "@aws-sdk/dynamodb-codec" "^3.973.22"
+    "@aws-sdk/middleware-endpoint-discovery" "^3.972.19"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/fetch-http-handler" "^5.4.6"
+    "@smithy/node-http-handler" "^4.7.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/client-s3@^3.1071.0":
   version "3.1071.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.1071.0.tgz#8b7f223714d567ccd9ca7dfd62d8550809f9b4a8"
@@ -237,6 +255,35 @@
   dependencies:
     "@aws-sdk/core" "^3.974.22"
     "@aws-sdk/nested-clients" "^3.997.22"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/dynamodb-codec@^3.973.22":
+  version "3.973.22"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.22.tgz#b049c3ece497ca2dcf6448d02141632cd91f23b2"
+  integrity sha512-QBs7/nWHsPA0wTEqhU5iPgaDjeZzQHhmwJr6Q0f56rW3Fk8ExJQgXFzEg/l48iDwJVUIMLjPqhw7dNP3cShUxA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.22"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/endpoint-cache@^3.972.8":
+  version "3.972.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.8.tgz#25fdeb6b17bc2cb4eeecb583a32c28a3126d0676"
+  integrity sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==
+  dependencies:
+    mnemonist "0.38.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-endpoint-discovery@^3.972.19":
+  version "3.972.19"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.19.tgz#affa05f6ac297a8eff7eeae5650fd08baf16b5f4"
+  integrity sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==
+  dependencies:
+    "@aws-sdk/endpoint-cache" "^3.972.8"
     "@aws-sdk/types" "^3.973.13"
     "@smithy/core" "^3.24.6"
     "@smithy/types" "^4.14.3"
@@ -3013,6 +3060,13 @@ minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+mnemonist@0.38.3:
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.3.tgz#35ec79c1c1f4357cfda2fe264659c2775ccd7d9d"
+  integrity sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==
+  dependencies:
+    obliterator "^1.6.1"
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -3127,6 +3181,11 @@ object.values@^1.1.6, object.values@^1.2.1:
     call-bound "^1.0.3"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
+
+obliterator@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
 optionator@^0.9.3:
   version "0.9.4"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,6 @@ const getEntries = (env) => {
     "soft-opt-in-acquisitions": "./typescript/src/soft-opt-ins/acquisitions.ts",
     "soft-opt-in-acquisitions-dlq-processor": "./typescript/src/soft-opt-ins/dlq-processor.ts",
     "export-subscription-tables": "./typescript/src/export/exportSubscriptions.ts",
-    "export-subscription-table-v2": "./typescript/src/export/exportSubscriptions-v2.ts",
     "export-subscription-events-table": "./typescript/src/export/exportEvents.ts",
     "export-historical-data": "./typescript/src/export/exportHistoricalData.ts",
     "apple-revalidate-receipts": "./typescript/src/revalidate-receipts/appleRevalidateReceipts.ts",


### PR DESCRIPTION
Project: mpapi-next-gen

Here we move lambdas 

mobile-purchases-export-subscription-table-v2-* and 
mobile-purchases-export-user-subscription-table-v2-*

from legacy to the new next-gen lambdas. 