### PR TITLE
fix invalid value error in export-google-historical-data

### DIFF
--- a/mpapi-next-gen/src/handlers/exportHistoricalData.ts
+++ b/mpapi-next-gen/src/handlers/exportHistoricalData.ts
@@ -153,10 +153,16 @@ export async function handler(params: {
 
 	zippedStream.end();
 
+	const chunks: Buffer[] = [];
+	for await (const chunk of zippedStream) {
+		chunks.push(chunk);
+	}
+	const buffer = Buffer.concat(chunks);
+
 	const uploadCommand = new PutObjectCommand({
 		Bucket: bucket,
 		Key: filename,
-		Body: zippedStream,
+		Body: buffer,
 		ACL: 'bucket-owner-full-control',
 	});
 	await s3Client.send(uploadCommand);


### PR DESCRIPTION
mobile-purchases-export-google-historical-data-PROD is having the following runtime error:

```
Invalid value \"undefined\" for header \"x-amz-decoded-content-length\"
``` 

Here we collect the stream into a buffer before uploading. 

Running on CODE gives the right output:

```
2026-06-23T13:36:16.257Z 6baa35ea-1e18-4341-8005-f9352aab88ae INFO [b3e0e9c1] filename: code-data/date=2026-06-22/2026-06-22-w8c.json.gz
```

But this might not necessarily signal the end of the problem. I need to try in PROD.