### PR TITLE
flush stuck messages from historical queues

### DIFF
--- a/mpapi-next-gen/docs/mobile-purchases-export-apple-historical-data.md
+++ b/mpapi-next-gen/docs/mobile-purchases-export-apple-historical-data.md
@@ -2,7 +2,8 @@
 export-historical-data writes the datalake files, of the form
 
 ```
-PROD/date=YYYY-MM-DD/YYYY-MM-DD-<random>.json.gz
+bucket: s3://ophan-raw-mobile-subscription-historical-google/
+path  : PROD/date=YYYY-MM-DD/YYYY-MM-DD-<random>.json.gz
 ```
 
 This uses the same handler as `mobile-purchases-export-google-historical-data-*` (eg: `src/handlers/export-historical-data.ts`). The difference is the SQS queue that it reads data from.

--- a/mpapi-next-gen/src/handlers/exportHistoricalData.ts
+++ b/mpapi-next-gen/src/handlers/exportHistoricalData.ts
@@ -137,7 +137,7 @@ export async function handler(params: {
 		totalMsgCount++;
 		const parsedMessage = JSON.parse(sqsMessage.Body ?? '');
 		const messageDate = parsedMessage.snapshotDate.substring(0, 10);
-		if (messageDate == yesterday) {
+		if (messageDate <= yesterday) {
 			processedMsgCount++;
 			const message = JSON.stringify(parsedMessage) + '\n';
 			zippedStream.write(message);


### PR DESCRIPTION
At the moment

Functions
- mobile-purchases-export-apple-historical-data-PROD
- mobile-purchases-export-google-historical-data-PROD

Are reading from SQS queues
- mobile-purchases-PROD-apple-historical-subscriptions
- mobile-purchases-PROD-google-historical-subscriptions

but only reading messages with `snapshotDate` from the date before today. This was based on the assumption that the code would run successfully at least once a day, but that has not been the case and we have 80,000+ messages stuck in the apple queue. This change should take care of that.

Note: no business impact as Data Design no longer use those files