### PR TITLE
more logging for investigation

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -428,7 +428,7 @@ Resources:
       TreatMissingData: notBreaching
       Tags:
         - Key: App
-          Value: mobile-purchases-google-oauth2
+          Value: mobile-purchases-googleoauth2
 
   GooglePubSubLambda:
     Type: AWS::Serverless::Function

--- a/typescript/src/pubsub/google-common.ts
+++ b/typescript/src/pubsub/google-common.ts
@@ -83,23 +83,29 @@ export function parsePayload(
 			JSON.parse(body ?? '').message.data,
 			'base64',
 		);
+		console.log(`[79079615] ${rawNotification}`);
 		const parseResult = DeveloperNotificationSchema.safeParse(
 			JSON.parse(rawNotification.toString()),
 		);
+		console.log(`[f3f7d615] ${JSON.stringify(parseResult)}`);
 		if (!parseResult.success) {
-			return new Error(`HTTP Payload body parse error: ${parseResult.error}`);
+			return new Error(
+				`[5f0bf526] HTTP Payload body parse error: ${parseResult.error}`,
+			);
 		}
-
 		const data = parseResult.data;
+		console.log(`[5e895cb6] ${JSON.stringify(data)}`);
 		if (isSubscriptionNotification(data)) {
+			console.log(`[f3f7d615] returning data`);
 			return data;
 		}
-
 		return new Ignorable(
-			`Notification is not a subscription notification. Notification was: ${JSON.stringify(data)}`,
+			`[12d734c8] notification is not a subscription notification. Notification was: ${JSON.stringify(data)}`,
 		);
 	} catch (e) {
-		console.log('Error during the parsing of the HTTP Payload body: ' + e);
+		console.log(
+			'[5a49e03d] error during the parsing of the HTTP Payload body: ' + e,
+		);
 		return e as Error;
 	}
 }


### PR DESCRIPTION
Previously
- https://github.com/guardian/mobile-purchases/pull/2275

Here we had more logging to understand what exactly is the failing step. 